### PR TITLE
update dead link to Emacs manual with new link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -252,7 +252,7 @@
 
 ###Emacs
 
-* [GNU Emacs Manual, 16th Edition, v. 22](http://shop.fsf.org/product/gnu-emacs-manual-16th-edition/)
+* [GNU Emacs Manual, 17th Edition, v. 24.2](http://shop.fsf.org/product/Emacs_Manual_24/)
 * [An Introduction to Programming in Emacs Lisp, 3rd Edition](https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html)
 
 


### PR DESCRIPTION
Link to emacs manual is dead. Here is the new link.
