### PR TITLE
Updated links to Dive Into HTML5

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -384,7 +384,7 @@
 * [Category wise tutorials - J2EE](http://www.mkyong.com/)
 * [How to Think Like a Computer Scientist](http://greenteapress.com/thinkapjava/)
 * [Introduction to Programming Using Java](http://math.hws.edu/javanotes/) - David J. Eck
-* [Java Application Development on Linux by Carl Albing and Michael Schwarz(PDF)](http://www.phptr.com/content/images/013143697X/downloads/013143697X_book.pdf)
+* [Java Application Development on Linux by Carl Albing and Michael Schwarz (PDF)](http://www.phptr.com/content/images/013143697X/downloads/013143697X_book.pdf)
 * [The Java EE6 Tutorial](http://download.oracle.com/javaee/6/tutorial/doc/javaeetutorial6.pdf) (PDF)
 * [Java Thin-Client Programming](http://www.redbooks.ibm.com/redbooks/SG245118.html)
 * [Learning Java](http://chimera.labs.oreilly.com/books/1234000001805/index.html) - Patrick Niemeyer
@@ -499,7 +499,7 @@
 ###Oberon
 
 * [Programming in Oberon](http://www-old.oberon.ethz.ch/WirthPubl/ProgInOberon.pdf) (PDF)
-* [Object-Oriented Programming in Oberon-2](http://ssw.jku.at/Research/Books/Oberon2.pdf ) (PDF)
+* [Object-Oriented Programming in Oberon-2](http://ssw.jku.at/Research/Books/Oberon2.pdf) (PDF)
 
 
 ###Objective-C


### PR DESCRIPTION
1. Changed the link to the community-maintained web version of the book.

> We work hard to add and update content, links, APIs, and actively maintain this fine resource; refreshing and reflecting the relevant and current state of HTML5, just as Mark Pilgrim did during his tenure
1. Added a link to a PDF version of Dive Into HTML5.

> The eBook has an embedded table of contents, working cross-references, well-placed page breaks and tons of others tiny tweaks and enhancements. 

Both of these resources have been updated and enhanced and build upon the original work by Mark Pilgrim.

It should be said that I did not hotlink to the PDF but instead linked to the page where the PDF can be downloaded.
Mislav Marohnić, the person who prepared the PDF, made a great effort in doing so and he should be recognised for that. I think that the other PDF hotlinks should be substituted with links to the proper pages where the PDFs can be downloaded but I'll leave that up to others.
