### PR TITLE
Add IDL guide.

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -415,6 +415,7 @@
 ###IDL
 
 * [Getting Started with IDL](http://www.astro.virginia.edu/class/oconnell/astr511/IDLresources/getting-started-IDL-v7.0.pdf)
+* [Guide to Using IDL for Astronomers](http://www.astro.virginia.edu/class/oconnell/astr511/IDLresources/IDLguide.html)
 
 
 ###Java


### PR DESCRIPTION
IDL is language used on astronomy, but it is now being replaced by Python. I
have added here the Getting Started with IDL.
