### PR TITLE
Added OpenSCAD User Manual

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -48,6 +48,7 @@
 * [Oberon](#oberon)
 * [Objective-C](#objective-c)
 * [OCaml](#ocaml)
+* [OpenSCAD](#openscad)
 * [Oracle Server](#oracle-server)
 * [Oracle PL/SQL](#oracle-plsql)
 * [Parrot / Perl 6](#parrot--perl-6)
@@ -575,6 +576,11 @@
 * [Developing Applications With Objective Caml](http://caml.inria.fr/pub/docs/oreilly-book/)
 * [Real World OCaml](https://realworldocaml.org/beta3/en/html/)
 * [Think OCaml](http://web.archive.org/web/20120307164444/http://www.thinkocaml.com/)
+
+
+###OpenSCAD
+
+* [OpenSCAD User Manual](http://en.wikibooks.org/wiki/OpenSCAD_User_Manual)
 
 
 ###Oracle Server


### PR DESCRIPTION
Added a section for OpenSCAD and a link to the online User Manual that describes the software and the 3D modelling language it uses.
