### PR TITLE
add JSBooks to meta-lists

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -123,6 +123,7 @@
 * [TechBooksForFree.com](http://www.techbooksforfree.com/)
 * [Theassayer.org](http://theassayer.org/)
 * [Wikibooks: Programming](http://en.wikibooks.org/wiki/Category%3aComputer_programming)
+* [JSBooks - directory of free javascript ebooks](https://github.com/revolunet/JSbooks)
 
 
 ###Graphics Programming


### PR DESCRIPTION
Found a collection of free JS ebooks - the meta-lists section seemed the most approprate place to put this.
