### PR TITLE
Added Upgraded to Rails 4 github repo.

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -873,6 +873,7 @@ See also [TeX](#tex)
 * [Objects on Rails](http://objectsonrails.com)
 * [Ruby on Rails Guides](http://guides.rubyonrails.org)
 * [A community-driven Rails style guide](https://github.com/bbatsov/rails-style-guide)
+* [Upgrading to Rails 4](https://github.com/alindeman/upgradingtorails4)
 
 
 ###Rust


### PR DESCRIPTION
Well, this is kind of weird. The book's site is [here](http://www.upgradingtorails4.com) and it is sold through the site. But the source code has been open sourced here on GitHub and users can checkout the repo and build the book themselves. 

Thought I'd send in a PR anyway :)
