### PR TITLE
Add Computer Networking: Principles, Protocols and Practice (CNP3)

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -202,6 +202,8 @@
 * [ZeroMQ Guide](http://zguide.zeromq.org/page:all)
 * [Network Security Tools](http://commons.oreilly.com/wiki/index.php/Network_Security_Tools)
 * [HTTP Succinctly, Syncfusion](http://www.syncfusion.com/resources/techportal/ebooks/http) (PDF, Kindle) *(Just fill the fields with any values)*
+* [Computer Networking: Principles, Protocols and Practice (CNP3)](http://inl.info.ucl.ac.be/CNP3) (PDF, EPUB, MOBI + [sources](https://github.com/obonaventure/cnp3/tree/master/book)) - O. Bonaventure
+* [Computer Networking: Principles, Protocols and Practice, 2nd edition (CNP3bis)](http://cnp3bis.info.ucl.ac.be/) (PDF, EPUB + [sources](https://github.com/obonaventure/cnp3/tree/master/book-2nd)) - O. Bonaventure (in progress)
 
 
 ####Compiler Design
@@ -412,7 +414,6 @@
 * [The Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide)
 * [Data Sorcery with Clojure](http://data-sorcery.org/contents/)
 * [Modern cljs](https://github.com/magomimmo/modern-cljs)
-* [Clojure Koans](http://clojurekoans.com/)
 
 
 ###CoffeeScript
@@ -652,7 +653,6 @@ See also [TeX](#tex)
 * [Practical Common Lisp](http://www.gigamonkeys.com/book/)
 * [Successful Lisp: How to Understand and Use Common Lisp](http://psg.com/~dlamkins/sl/) - David Lamkins
 * [Sketchy LISP](http://www.bcl.hamilton.ie/~nmh/t3x.org/zzz/) - Nils Holm
-* [Lisp Koans](https://github.com/google/lisp-koans)
 
 
 ###Lua
@@ -703,7 +703,6 @@ See also [TeX](#tex)
 * [The Little Redis Book](http://openmymind.net/2012/1/23/The-Little-Redis-Book/)
 * [The Little Riak Book](http://littleriakbook.com/)
 * [Graph Databases](http://graphdatabases.com/)
-* [MongoDB Koans](https://github.com/chicagoruby/MongoDB_Koans)
 
 
 ###Oberon
@@ -833,12 +832,10 @@ See also [TeX](#tex)
 * [Python Scientific Lecture Notes](http://scipy-lectures.github.io/)
 * [Snake Wrangling For Kids](http://www.briggs.net.nz/snake-wrangling-for-kids.html)
 * [The Art and Craft of Programming](http://beastie.cs.ua.edu/cs150/book/index.html)
-* [The Programming Historian](http://niche-canada.org/files/programming-historian-1.pdf) - William J. Turkel, Adam Crymble and Alan MacEachern
 * [Think Python](http://www.greenteapress.com/thinkpython/) - Allen B. Downey
 * [Problem Solving with Algorithms and Data Structures](http://interactivepython.org/courselib/static/pythonds/index.html)
 * [Python Module of the Week](http://pymotw.com/2/)
 * [Wikibooks: Python Programming](http://en.wikibooks.org/wiki/Python_Programming)
-* [Python Koans](https://github.com/gregmalcolm/python_koans)
 
 ####Django
 * [Djen of Django](http://agiliq.com/books/djenofdjango/)
@@ -886,7 +883,6 @@ See also [TeX](#tex)
 * [Ruby Essentials](http://www.techotopia.com/index.php/Ruby_Essentials)
 * [Ruby Learning](http://rubylearning.com/)
 * [Try Ruby](http://tryruby.org/)
-* [Ruby Koans](http://www.rubykoans.com/)
 
 
 ###Ruby on Rails


### PR DESCRIPTION
The first edition receives the 'Open-textbook' award in 2012 (Saylor foundation - USA)
The second one is currently rewriting (and should be released at the end of 2013)
