### PR TITLE
Add 'C++11: Syntax and Feature', a C++11 reference book for Japanese

### DIFF
--- a/free-programming-books-ja.md
+++ b/free-programming-books-ja.md
@@ -135,6 +135,7 @@
 * [C++入門](http://www.asahi-net.or.jp/~yf8k-kbys/newcpp0.html)
 * [ロベールのＣ＋＋教室](http://www7b.biglobe.ne.jp/~robe/cpphtml/)
 * [cpprefjp - C++ Reference Site in Japanese](https://sites.google.com/site/cpprefjp/)
+* [C++11の文法と機能(C++11: Syntax and Feature)](https://ezoeryou.github.com/cpp-book/C++11-Syntax-and-Feature.xhtml)
 
 
 ###CoffeeScript


### PR DESCRIPTION
[C++11: Syntax and Feature](https://ezoeryou.github.com/cpp-book/C++11-Syntax-and-Feature.xhtml) is a C++11 reference book based on the latest C++ specification, [ISO/IEC 14882:2011](http://www.iso.org/iso/catalogue_detail.htm?csnumber=50372).  It is written by [Ezoe Ryo](http://cpplover.blogspot.jp/), who is a member of C++ standard committee.  This book is fantastic because the words used in this book is the same ones in C++ specification and readers can look up them in the specification easily.
It is published with GFDL license today.
