### PR TITLE
Remove one of duplicated Git Magic

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -490,7 +490,6 @@
 
 ###Git
 * [Pro Git](http://git-scm.com/book)
-* [Gitmagic](http://www-cs-students.stanford.edu/~blynn/gitmagic/index.html)
 * [Git From The Bottom Up](http://ftp.newartisans.com/pub/git.from.bottom.up.pdf) (PDF)
 * [Git internals](https://github.com/pluralsight/git-internals-pdf/raw/master/drafts/peepcode-git.pdf) (PDF)
 * [Git Magic](http://www-cs-students.stanford.edu/~blynn/gitmagic/)


### PR DESCRIPTION
There were two Git Magic: at line 493 and 496. I removed the first since the second has more correct name.
