### PR TITLE
Add link to HTML5 For Web Designers

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -598,6 +598,7 @@
 * [HTML Dog Tutorials](http://www.htmldog.com/)
 * [HTML5 Canvas](http://chimera.labs.oreilly.com/books/1234000001654/index.html) - Steve Fulton & Jeff Fulton
 * [HTML5 for Publishers](http://chimera.labs.oreilly.com/books/1234000000770/index.html) - Sanders Kleinfeld
+* [HTML5 For Web Designers](http://html5forwebdesigners.com/) - Jeremy Keith
 * [Learn CSS Layout](http://learnlayout.com/)
 
 


### PR DESCRIPTION
Just adding another HTML5 book that's online in its entirety: http://html5forwebdesigners.com/
