### PR TITLE
Added Machine Learning, Neural and Statistical Classification book to Machine Learning Section

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -308,6 +308,7 @@
 * [Reinforcement Learning: An Introduction](http://webdocs.cs.ualberta.ca/~sutton/book/ebook/the-book.html)
 * [A First Encounter with Machine Learning](https://www.ics.uci.edu/~welling/teaching/ICS273Afall11/IntroMLBook.pdf) (PDF)
 * [Learning Deep Architectures for AI](http://www.iro.umontreal.ca/~bengioy/papers/ftml_book.pdf) (PDF)
+* [Machine Learning, Neural and Statistical Classification](http://www1.maths.leeds.ac.uk/~charles/statlog/whole.pdf) (PDF) or [online version](http://www1.maths.leeds.ac.uk/~charles/statlog/) - This book is based on the EC (ESPRIT) project StatLog.
 
 ####Mathematics
 * [Think Bayes: Bayesian Statistics Made Simple](http://www.greenteapress.com/thinkbayes/) - Allen B. Downey


### PR DESCRIPTION
Added 'Machine Learning, Neural and Statistical Classification' book to Machine Learning Section. This book is based on the EC (ESPRIT) project StatLog, free and has both PDF version and webpage version.
