### PR TITLE
remove broken macruby link

### DIFF
--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -852,7 +852,6 @@ See also [TeX](#tex)
 ###Ruby
 * [The Bastards Book of Ruby](http://ruby.bastardsbook.com/)
 * [Learn Ruby the hard way](http://ruby.learncodethehardway.org/book/)
-* [MacRuby: The Definitive Guide](http://macruby.labs.oreilly.com/)
 * [Mr. Neighborly's Humble Little Ruby Book](http://www.humblelittlerubybook.com/)
 * [Programming Ruby](http://www.ruby-doc.org/docs/ProgrammingRuby/)
 * [Why's (Poignant) Guide to Ruby](http://mislav.uniqpath.com/poignant-guide/) ([mirror](http://www.scribd.com/doc/2236084/Whys-Poignant-Guide-to-Ruby))

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1082,7 +1082,6 @@ See also [TeX](#tex)
 ###Ruby
 * [The Bastards Book of Ruby](http://ruby.bastardsbook.com/)
 * [Learn Ruby the hard way](http://ruby.learncodethehardway.org/book/)
-* [MacRuby: The Definitive Guide](http://macruby.labs.oreilly.com/)
 * [Mr. Neighborly's Humble Little Ruby Book](http://www.humblelittlerubybook.com/)
 * [Programming Ruby](http://www.ruby-doc.org/docs/ProgrammingRuby/)
 * [Why's (Poignant) Guide to Ruby](http://mislav.uniqpath.com/poignant-guide/) ([mirror](http://www.scribd.com/doc/2236084/Whys-Poignant-Guide-to-Ruby))


### PR DESCRIPTION
The MacRuby book is no longer hosted where it used to be, and as far as I can tell is no longer available for free online.

I'm unsure what the convention is for dead links here, but this change simply removes the link.
