### PR TITLE
Algorithms - Berkeley link doesn't require signup

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -165,7 +165,7 @@
 
 ####Algorithms & Datastructures
 * [Algorithms and Data-Structures](http://www.ethoberon.ethz.ch/WirthPubl/AD.pdf) (PDF)
-* [Algorithms](http://highered.mcgraw-hill.com/sites/0073523402/) (draft)
+* [Algorithms](http://www.cs.berkeley.edu/~vazirani/algorithms/) - Dasgupta, Papadimitriou, Vazirani (PDFs)
 * [Algorithms Course Materials](http://compgeom.cs.uiuc.edu/~jeffe/teaching/algorithms/) - Jeff Erickson
 * [Algorithms, 4th Edition](http://algs4.cs.princeton.edu/home/) - Robert Sedgewick and Kevin Wayne
 * [Binary Trees](http://cslibrary.stanford.edu/110/BinaryTrees.pdf) (PDF)


### PR DESCRIPTION
Not sure what is registration card required by Mcgraw-Hill to signup, so I figured I'd provide another link that doesn't require any action.
