### PR TITLE
Remove duplicate entry

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -767,7 +767,6 @@
 * [Learn Haskell Fast and Hard](http://yannesposito.com/Scratch/en/blog/Haskell-the-Hard-Way)
 * [Haskell web Programming](http://yannesposito.com/Scratch/fr/blog/Yesod-tutorial-for-newbies/) (Yesod tutorial)
 * [The Haskell Road to Logic, Math and Programming](http://fldit-www.cs.uni-dortmund.de/~peter/PS07/HR.pdf) (PDF)
-* [Haskell :: Functional programming with types](http://upload.wikimedia.org/wikipedia/commons/2/26/Haskell.pdf)
 
 
 ###HTML / CSS


### PR DESCRIPTION
The removed line corresponds with the Haskell Wikibook link which is already present. (The wikibook link is usually more updated than the removed pdf version. Also you can download pdf version of this book from the wikibook link.)
