### PR TITLE
Fix Algorithms & Data Structures link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -60,7 +60,7 @@
     * [Knockout.js](#knockoutjs)
     * [Node.js](#nodejs)
 * [Language Agnostic](#language-agnostic)
-    * [Algorithms & Datastructures](#algorithms--datastructures)
+    * [Algorithms & Datastructures](#algorithms--data-structures)
     * [Cellular Automata](#cellular-automata)
     * [Compiler Design](#compiler-design)
     * [Database](#database)


### PR DESCRIPTION
The Algorithms & Data Structures anchor link doesn't work. Very small typo. This fixes it.
