### PR TITLE
Fixes for Go list

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -797,11 +797,11 @@
 
 
 ###Go
-* [The Go Tutorial](http://golang.org/doc/go_tutorial.html)
+* [An Introduction to Programming in Go](http://www.golang-book.com/)
 * [Go by Example](https://gobyexample.com/)
 * [Learning Go](http://archive.miek.nl/projects/learninggo/index.html)
-* [An Introduction to Programming in Go](http://www.golang-book.com/)
 * [Network programming with Go](http://jan.newmarch.name/go/)
+* [The Go Tutorial](http://golang.org/doc/go_tutorial.html)
 
 
 ###Gradle


### PR DESCRIPTION
Miek Gieben revamped his website and switched it to use Pelican (see his [update](http://miek.nl/)); so now the the book URL has changed.

I also noticed the Go list was not alphabetized so made a fix for that as well.
