### PR TITLE
Fixed anchor to PicoLisp

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -108,7 +108,7 @@
 * [PC-BSD](#pc-bsd)
 * [Perl](#perl)
 * [PHP](#php)
-* [PicoLisp](#PicoLisp)
+* [PicoLisp](#picolisp)
 * [PostgreSQL](#postgresql)
 * [PowerShell](#powershell)
 * [Processing](#processing)


### PR DESCRIPTION
Converted anchor to the section for PicoLisp to lowercase, link was broken before.
