### PR TITLE
Retirando link do Padrões JS

### DIFF
--- a/free-programming-books-pt_BR.md
+++ b/free-programming-books-pt_BR.md
@@ -44,7 +44,6 @@
 
 
 ###JavaScript
-* [Aprendendo Padrões de Projeto JavaScript PT-BR](https://leanpub.com/aprendendo-padroes-de-projeto-javascript)
 * [Eloquent Javascript PT-BR](https://leanpub.com/eloquentejavascript)
 * [Fundamentos de jQuery](http://herberthamaral.com/posts/2013-02-25-sobre-o-jquery-fundamentals.html)
 * [Guia Rápido de Desenvolvimento para Firefox OS: Criando apps com HTML5 para o Firefox OS](https://leanpub.com/guiarapidofirefoxos)


### PR DESCRIPTION
Licença gera dupla interpretação, sendo assim, após tradução do JavaScript Eloquente irei contatar o autor para obter uma permissão/ou não, para tal.
