### PR TITLE
Unix for Poets: Using PDF from Stanford

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1660,7 +1660,7 @@ See also [LaTeX](#latex)
 * [Conquering the Command Line](http://www.conqueringthecommandline.com/)
 * [Unix Toolbox](http://cb.vu/unixtoolbox.xhtml) - Colin Barschel
 * [UNIX Tutorial for Beginners](http://www.ee.surrey.ac.uk/Teaching/Unix/) (HTML)
-* [Unix for Poets](https://phaven-prod.s3.amazonaws.com/files/document_part/asset/25053/HYDkIhrS3il3SWCjj-WZ-ScKn2Y/UnixforPoets.pdf) - Kenneth Ward Church (PDF)
+* [Unix for Poets](http://www.stanford.edu/class/cs124/kwc-unix-for-poets.pdf) - Kenneth Ward Church (PDF)
 
 
 ###Vim


### PR DESCRIPTION
The previous link pointed to Amazon S3 web space, as mentioned in:
https://github.com/vhf/free-programming-books/pull/909
that does not seem appropriate.
