### PR TITLE
Re-added Category Theory for Computing Science with updated link.

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -524,6 +524,7 @@
 ####Theoretical Computer Science
 * [An Introduction to the Theory of Computation](http://www.cse.ohio-state.edu/~gurari/theory-bk/theory-bk.html)
 * [Building Blocks for Theoretical Computer Science](http://www.cs.uiuc.edu/~mfleck/building-blocks/index.html) - Margaret M. Fleck
+* [Category Theory for Computing Science](http://www.tac.mta.ca/tac/reprints/articles/22/tr22.pdf) (PDF)
 * [Homotopy Type Theory: Univalent Foundations of Mathematics](http://homotopytypetheory.org/book/) (PDF)
 * [Introduction to Computing](http://www.computingbook.org/)
 * [Introduction to Theory of Computation](http://cg.scs.carleton.ca/~michiel/TheoryOfComputation/) (PDF) - Anil Maheshwari and Michiel Smid


### PR DESCRIPTION
Previous link was dead and was deleted as part of https://github.com/vhf/free-programming-books/commit/b55bf481a1b36e6d8aff8d153101723be49b8de7
