### PR TITLE
Add Introducción a Rails to the list of spanish books.

### DIFF
--- a/free-programming-books-es.md
+++ b/free-programming-books-es.md
@@ -226,6 +226,7 @@
 
 ####Ruby on Rails
 * [El maldito libro de los Descarrilados](http://yottabi.com/mld.pdf) (PDF)
+* [Introducción a Rails](http://rubysur.org/introduccion.a.rails/)
 
 
 ###R


### PR DESCRIPTION
This book is a spanish translation of the official guide "Getting Started
with Rails."
