### PR TITLE
Update the link to the Aprende a Programar con Ruby.

### DIFF
--- a/free-programming-books-es.md
+++ b/free-programming-books-es.md
@@ -220,7 +220,7 @@
 
 
 ###Ruby
-* [Guía para aprender a programar con Ruby. Adaptación al español del libro "Learn to Program" de Chris Pine](https://github.com/rubyperu/aprende.a.programar)
+* [Guía para aprender a programar con Ruby. Adaptación al español del libro "Learn to Program" de Chris Pine](https://github.com/rubysur/aprende.a.programar)
 * [Ruby en 20 minutos](https://www.ruby-lang.org/es/documentation/quickstart/)
 
 


### PR DESCRIPTION
The link is outdated because the GitHub organization maintaining the book
changed their name. The link currently works because of a redirect, but it
would better to replace it with the current link.
