### PR TITLE
Add link to PDF and Kindle for Android Succinctly

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -600,7 +600,7 @@
 * [Google Android Developer Training](https://developer.android.com/training/index.html)
 * [Styling Android](http://www.stylingandroid.com/)
 * [TechnoTalkative Android](http://www.technotalkative.com/android/)
-* [Android Programming Succinctly, Syncfusion](https://www.syncfusion.com/resources/techportal/ebooks/android) (PDF, Kindle) *(Just fill the fields with any values)*
+* [Android Programming Succinctly, Syncfusion](https://www.syncfusion.com/resources/techportal/ebooks/android) ([PDF](https://www.syncfusion.com/content/downloads/ebook/Android_Programming_Succinctly.pdf), [Kindle](https://www.syncfusion.com/content/downloads/ebook/Android_Programming_Succinctly.mobi)) *(Just fill the fields with any values)*
 
 
 ###APL


### PR DESCRIPTION
Added direct link to PDF and Kindle formats at syncfusion.com;
No login required.
