### PR TITLE
Isabelle/HOL - fix anchor link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -55,7 +55,7 @@
 * [Icon](#icon)
 * [IDL](#idl)
 * [iOS](#ios)
-* [Isabelle/HOL](#isabelle--hol)
+* [Isabelle/HOL](#isabellehol)
 * [J](#j)
 * [Java](#java)
     * [Spring](#spring)


### PR DESCRIPTION
Anchor link for Isabelle/HOL was not working when viewing the Github parsed file.
