### PR TITLE
Removed duplicate link to Dashing d3.js.

### DIFF
--- a/javascript-frameworks-resources.md
+++ b/javascript-frameworks-resources.md
@@ -35,8 +35,7 @@
 
 ## D3.js
 * [D3 Tips and Tricks](https://leanpub.com/D3-Tips-and-Tricks)
-* [D3.js Tutorial](https://www.dashingd3js.com/table-of-contents)
-* [Dashing D3.js](https://www.dashingd3js.com/table-of-contents)
+* [Dashing D3.js Tutorial](https://www.dashingd3js.com/table-of-contents)
 * [Interactive Data Visualization for the Web](http://chimera.labs.oreilly.com/books/1230000000345/index.html)
 * [Interactive Data Visualization with D3](http://alignedleft.com/tutorials/d3)
 


### PR DESCRIPTION
There was a duplicate link to http://dashingd3js.com/table-of-contents, but it was named slightly differently, so I dropped one and combined the names appropriately. Thanks!
