### PR TITLE
Removed a link from Ruby resource

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1546,7 +1546,6 @@ See also [TeX](#tex)
 ### Ruby
 * [A community-driven Ruby style guide](https://github.com/bbatsov/ruby-style-guide)
 * [CodeCademy Ruby](http://www.codecademy.com/tracks/ruby)
-* [How To Think Like a Computer Scientist: Learning With Ruby](http://mysite.verizon.net/hpassel/thinkruby/)
 * [Just Enough Ruby to Get By](http://dmtri.com/posts/65)
 * [Learn Ruby the hard way](http://ruby.learncodethehardway.org/book/)
 * [Learn to Program, by Chris Pine](http://pine.fm/LearnToProgram/)


### PR DESCRIPTION
Removed a link of Ruby resource http://mysite.verizon.net/hpassel/thinkruby/ as many of links in the resource return Not Found status
e.g. http://mysite.verizon.net/hpassel/thinkruby/book/ch03exer.html, http://mysite.verizon.net/hpassel/thinkruby/book/ch05exer.html
