### PR TITLE
Erlang in Anger

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -822,6 +822,7 @@
 * [Erlang Handbook](https://github.com/esl/erlang-handbook/raw/master/output/ErlangHandbook.pdf) (PDF)
 * [Études for Erlang](http://chimera.labs.oreilly.com/books/1234000000726/index.html) - J. David Eisenberg
 * [Learn You Some Erlang For Great Good](http://learnyousomeerlang.com/) - Frederic Trottier-Hebert
+* [Stuff Goes Bad: Erlang in Anger](https://s3.amazonaws.com/erlang-in-anger/text.v1.0.0.pdf) - Fred Herbert (PDF)
 
 
 ### F Sharp


### PR DESCRIPTION
_Stuff Goes Bad: Erlang in Anger_ by Fred Hébert and Heroku is licensed under a Creative Commons BY-NC-SA 4.0 International License. [HN Buzz](https://news.ycombinator.com/item?id=8330501).
