### PR TITLE
Added "Pick/Basic: A Programmer's Guide - Jonathan E. Sisk", under Basic...

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1489,7 +1489,7 @@ See also [TeX](#tex)
 * [Web2py: Complete Reference Manual, 6th Edition (pre-release)](http://web2py.com/book) (2.5 - 2.x)
 * [Welcome to Problem Solving with Algorithms and Data Structures](http://interactivepython.org/runestone/static/pythonds/index.html) - Brad Miller and David Ranum
 * [Wikibooks: Python Programming](http://en.wikibooks.org/wiki/Python_Programming) (2.7)
-* [CodeAcademy Python](http://www.codecademy.com/tracks/python)
+* [CodeCademy Python](http://www.codecademy.com/tracks/python)
 * [Python for Informatics](http://www.pythonlearn.com/book_007.pdf)
 * [Composing Programs](http://composingprograms.com/) (3.x)
 


### PR DESCRIPTION
....

Fixed "CodeCademy Python" spelling to "CodeAcademy Python", under Python.
