### PR TITLE
Updated broken C# link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -874,7 +874,7 @@
 * [C# Yellow Book](http://www.csharpcourse.com) (intro to programming)
 * [Creating Mobile Apps with Xamarin.Forms C#](https://developer.xamarin.com/guides/xamarin-forms/creating-mobile-apps-xamarin-forms/)
 * [Daily Design Patterns](https://www.exceptionnotfound.net/downloads/dailydesignpattern.pdf) (PDF)
-* [Data Structures and Algorithms with Object-Oriented Design Patterns in C#](http://programming.etherealspheres.com/backup/ebooks%20-%20Other%20Programming%20Languages/Data%20Structures%20And%20Algorithms%20With%20Object-Oriented%20Design%20Patterns%20In%20C%20Sharp.pdf)
+* [Data Structures and Algorithms with Object-Oriented Design Patterns in C#](https://web.archive.org/web/20161220072449/http://www.brpreiss.com/books/opus6/) - Bruno Preiss
 * [Dissecting a C# Application](https://damieng.com/blog/2007/11/08/dissecting-a-c-application-inside-sharpdevelop) - Christian Holm, Bernhard Spuida, Mike Kruger
 * [Fundamentals of Computer Programming with C#](http://www.introprogramming.info/english-intro-csharp-book/read-online/) - Svetlin Nakov
 * [Introduction to Rx](http://www.introtorx.com)

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -874,7 +874,7 @@
 * [C# Yellow Book](http://www.csharpcourse.com) (intro to programming)
 * [Creating Mobile Apps with Xamarin.Forms C#](https://developer.xamarin.com/guides/xamarin-forms/creating-mobile-apps-xamarin-forms/)
 * [Daily Design Patterns](https://www.exceptionnotfound.net/downloads/dailydesignpattern.pdf) (PDF)
-* [Data Structures and Algorithms with Object-Oriented Design Patterns in C#](http://www.brpreiss.com/books/opus6/)
+* [Data Structures and Algorithms with Object-Oriented Design Patterns in C#](http://programming.etherealspheres.com/backup/ebooks%20-%20Other%20Programming%20Languages/Data%20Structures%20And%20Algorithms%20With%20Object-Oriented%20Design%20Patterns%20In%20C%20Sharp.pdf)
 * [Dissecting a C# Application](https://damieng.com/blog/2007/11/08/dissecting-a-c-application-inside-sharpdevelop) - Christian Holm, Bernhard Spuida, Mike Kruger
 * [Fundamentals of Computer Programming with C#](http://www.introprogramming.info/english-intro-csharp-book/read-online/) - Svetlin Nakov
 * [Introduction to Rx](http://www.introtorx.com)


### PR DESCRIPTION
The link for "Data Structures and Algorithms with Object-Oriented Design Patterns" under C# was broken. I updated it so it goes to the correct pdf file.