### PR TITLE
Removed a book from the online courses list

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -77,7 +77,7 @@
 
 ### Bash / Shell
 
-* [Bash tutorial](http://gdrcorelec.ups-tlse.fr/files/bash.pdf) (PDF)
+
 * [Bento Shell Track](https://bento.io/topic/shell) (Bento)
 
 


### PR DESCRIPTION
Removed a book which i feel violates the following guideline : 
A course is a learning material which is not a book and where there is no interactive tool embedded in the site.

The book is : 
* [Bash tutorial](http://gdrcorelec.ups-tlse.fr/files/bash.pdf) (PDF)