### PR TITLE
Removed the bash book from online course section.

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -77,7 +77,6 @@
 
 ### Bash / Shell
 
-* [Bash tutorial](http://gdrcorelec.ups-tlse.fr/files/bash.pdf) (PDF)
 * [Bento Shell Track](https://bento.io/topic/shell) (Bento)
 
 


### PR DESCRIPTION
I have attempted to remove the bash book from the online course section again . There were some problems with the linter. Please someone review ! Thanks :)