### PR TITLE
Link to Programming in Lua

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1537,7 +1537,7 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 ### Lua
 
 * [Lua 5.1 Reference Manual](http://www.lua.org/manual/5.1/)
-* [Programming Gems](http://www.lua.org/gems/)
+* [Programming in Lua (first edition)](https://www.lua.org/pil/contents.html)
 * [Wikibook](https://en.wikibooks.org/wiki/Lua_Programming)
 
 


### PR DESCRIPTION
the Lua Programming Gems book is not freely available (apart from the second chapter and notes for some other chapters), and is not a general guide to the language; the first edition of Programming in Lua, however, *is* freely available, and *is* a guide for learning the language in general.