### PR TITLE
Added Category Theory for Programmers

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -697,6 +697,7 @@
 
 * [Building Blocks for Theoretical Computer Science](http://mfleck.cs.illinois.edu/building-blocks/index.html) - Margaret M. Fleck
 * [Category Theory for Computing Science](http://www.tac.mta.ca/tac/reprints/articles/22/tr22.pdf) (PDF)
+* [Category Theory for Programmers](https://github.com/hmemcpy/milewski-ctfp-pdf) - Bartosz Milewski (PDF)
 * [Homotopy Type Theory: Univalent Foundations of Mathematics](http://homotopytypetheory.org/book/) (PDF)
 * [Introduction to Computer Science](http://www.cse.iitd.ernet.in/~suban/CSL102/) - Prof. Subhashis Banerjee, IIT Delhi
 * [Introduction to Computing](http://www.computingbook.org)


### PR DESCRIPTION
Unofficial PDF version of "Category Theory for Programmers" by Bartosz Milewski, converted from his blogpost series. Blog content licensed as CC BY 4.0 International as seen at https://bartoszmilewski.com/about/