### PR TITLE
Add/verilog courses #2151 

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -347,6 +347,7 @@
 
 * [SystemVerilog - Learn basics of SystemVerilog for Hardware Verification](https://verificationexcellence.teachable.com/p/learn-systemverilog)
 * [SystemVerilog based UVM Methodology - Learn to build UVM based Testbenches in SystemVerilog](https://verificationexcellence.teachable.com/p/learn-ovm-uvm)
+* [SOC Verification Using SystemVerilog](http://verificationexcellence.in/online-courses/soc-verification-using-systemverilog)
 * [Verilog Hardware Description Language - An Introductory Course](http://vol.verilog.com/VOL/main.htm)
 
 

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -345,9 +345,9 @@
 
 ### Verilog / VHDL / SystemVerilog
 
+* [SOC Verification Using SystemVerilog](http://verificationexcellence.in/online-courses/soc-verification-using-systemverilog)
 * [SystemVerilog - Learn basics of SystemVerilog for Hardware Verification](https://verificationexcellence.teachable.com/p/learn-systemverilog)
 * [SystemVerilog based UVM Methodology - Learn to build UVM based Testbenches in SystemVerilog](https://verificationexcellence.teachable.com/p/learn-ovm-uvm)
-* [SOC Verification Using SystemVerilog](http://verificationexcellence.in/online-courses/soc-verification-using-systemverilog)
 * [Verilog Hardware Description Language - An Introductory Course](http://vol.verilog.com/VOL/main.htm)
 
 

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -345,9 +345,9 @@
 
 ### Verilog / VHDL / SystemVerilog
 
-* [Verilog Hardware Description Language - An Introductory Course](http://vol.verilog.com/VOL/main.htm)
 * [SystemVerilog - Learn basics of SystemVerilog for Hardware Verification](https://verificationexcellence.teachable.com/p/learn-systemverilog)
 * [SystemVerilog based UVM Methodology - Learn to build UVM based Testbenches in SystemVerilog](https://verificationexcellence.teachable.com/p/learn-ovm-uvm)
+* [Verilog Hardware Description Language - An Introductory Course](http://vol.verilog.com/VOL/main.htm)
 
 
 ### Web Development

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -40,8 +40,8 @@
 * [Scala](#scala)
 * [Software Engineering](#software-engineering)
 * [Swift](#swift)
-* [SystemVerilog](#systemverilog)
 * [Theory](#theory)
+* [Verilog / VHDL / SystemVerilog](#verilog--vhdl--systemverilog)
 * [Web Development](#web-development)
 
 
@@ -337,16 +337,17 @@
 * [Swiftris - Build an iOS Tetris app from scratch](https://www.bloc.io/swiftris-build-your-first-ios-game-with-swift)
 
 
-### SystemVerilog
-
-* [SystemVerilog - Learn basics of SystemVerilog for Hardware Verification](https://verificationexcellence.teachable.com/p/learn-systemverilog)
-* [SystemVerilog based UVM Methodology - Learn to build UVM based Testbenches in SystemVerilog](https://verificationexcellence.teachable.com/p/learn-ovm-uvm)
-
-
 ### Theory
 
 * [Automata Theory](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+Fall2016/about)
 * [Udacity: Intro to Theoretical Computer Science](https://www.udacity.com/course/intro-to-theoretical-computer-science--cs313)
+
+
+### Verilog / VHDL / SystemVerilog
+
+* [Verilog Hardware Description Language - An Introductory Course](http://vol.verilog.com/VOL/main.htm)
+* [SystemVerilog - Learn basics of SystemVerilog for Hardware Verification](https://verificationexcellence.teachable.com/p/learn-systemverilog)
+* [SystemVerilog based UVM Methodology - Learn to build UVM based Testbenches in SystemVerilog](https://verificationexcellence.teachable.com/p/learn-ovm-uvm)
 
 
 ### Web Development


### PR DESCRIPTION
Renamed `SystemVerilog` section to `Verilog / VHDL / SystemVerilog` because they are 3 different hardware description languages. Grouped them together so that all the Verilog resources can be found in one spot. Added new course as suggested in #2151 