### PR TITLE
Replace Dive into HTML5 link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1269,7 +1269,7 @@ Kerridge (PDF) (Just fill the fields with any values)
 * [An advanced guide to HTML&CSS](http://learn.shayhowe.com/advanced-html-css/)
 * [Canvassing](http://learnjs.io/canvassing/read)
 * [Code Guide: Standards for developing flexible, durable, and sustainable HTML and CSS](http://mdo.github.io/code-guide/) - Mark Otto
-* [Dive Into HTML5](http://diveintohtml5.info) - Mark Pilgrim ([PDF](http://mislav.net/2011/10/dive-into-html5/))
+* [Dive Into HTML5](http://diveinto.html5doctor.com/) - Mark Pilgrim ([PDF](http://mislav.net/2011/10/dive-into-html5/))
 * [GA Dash](https://dash.generalassemb.ly)
 * [Google's HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.xml)
 * [How to Code in HTML5 and CSS3](http://howtocodeinhtml.com)

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1269,7 +1269,7 @@ Kerridge (PDF) (Just fill the fields with any values)
 * [An advanced guide to HTML&CSS](http://learn.shayhowe.com/advanced-html-css/)
 * [Canvassing](http://learnjs.io/canvassing/read)
 * [Code Guide: Standards for developing flexible, durable, and sustainable HTML and CSS](http://mdo.github.io/code-guide/) - Mark Otto
-* [Dive Into HTML5](http://diveinto.html5doctor.com/) - Mark Pilgrim ([PDF](http://mislav.net/2011/10/dive-into-html5/))
+* [Dive Into HTML5](http://diveinto.html5doctor.com) - Mark Pilgrim ([PDF](http://mislav.net/2011/10/dive-into-html5/))
 * [GA Dash](https://dash.generalassemb.ly)
 * [Google's HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.xml)
 * [How to Code in HTML5 and CSS3](http://howtocodeinhtml.com)


### PR DESCRIPTION
The old link (http://diveintohtml5.info/) returns Access Denied.