### PR TITLE
Fix broken angular-course link

### DIFF
--- a/free-programming-books-ru.md
+++ b/free-programming-books-ru.md
@@ -106,7 +106,7 @@
 
 #### Angular
 
-* [Angular 5. Полное руководство](https://bxnotes.ru/conspect/angular-5-the-complete-guide) - Maximilian Schwarzmüller
+* [Angular 5. Полное руководство](https://bxnotes.ru/conspect/angular-5-the-complete-guide/) - Maximilian Schwarzmüller
 * [Руководство по Angular](https://metanit.com/web/angular2) - Евгений Попов
 
 


### PR DESCRIPTION
missed "/" in the end of link, which gave 404