### PR TITLE
Adding Harvard GSE Scratch Book

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2349,6 +2349,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### Scratch
 
+* [An Introductory Computing Curriculum Using Scratch](http://scratched.gse.harvard.edu/guide/download.html)
 * [Computer Science Concepts in Scratch](https://stwww1.weizmann.ac.il/scratch/scratch_en/)
 
 


### PR DESCRIPTION
## What does this PR do?
Adds Harvard's Graduate School of Education Creative Curriculum Guide to Scratch

## For resources
### Description 
Scratch Tutorials PDF

### Why is this valuable (or not)
Great Scratch Guide for Students and Teachers

### How do we know it's really free?
CC-BY-SA

### For book lists, is it a book?

### Checklist:
