### PR TITLE
Scratch foreign language guides

### DIFF
--- a/free-programming-books-de.md
+++ b/free-programming-books-de.md
@@ -23,6 +23,7 @@
   * [Django](#django)
 * [Ruby on Rails](#ruby-on-rails)
 * [Scilab](#scilab)
+* [Scratch](#scratch)
 * [UML](#uml)
 * [Unix](#unix)
 * [Visual Basic](#visual-basic)
@@ -174,6 +175,11 @@
 ### Scilab
 
 * [Einführung in Scilab/Xcos 5.4](http://www.buech-gifhorn.de/scilab/Einfuehrung.pdf) (PDF)
+
+
+### Scratch
+
+* [Kreative Informatik mit Scratch](http://eis.ph-noe.ac.at/kreativeinformatik/)
 
 
 ### UML

--- a/free-programming-books-es.md
+++ b/free-programming-books-es.md
@@ -41,6 +41,7 @@
 * [Ruby](#ruby)
   * [Ruby on Rails](#ruby-on-rails)
 * [Scala](#scala)
+* [Scratch](#scratch)
 * [SQL](#sql)
 * [SVG](#svg)
 
@@ -331,6 +332,11 @@
 
 * [Manual de Scala para programadores Java](http://www.scala-lang.org/docu/files/ScalaTutorial-es_ES.pdf) (PDF)
 * [Scala con Ejemplos](https://github.com/ErunamoJAZZ/ScalaByExample-es) *(:construction: En proceso)*
+
+
+### Scratch
+
+* [Informática Creativa](https://github.com/programamos/GuiaScratch) (PDF)
 
 
 ### SQL

--- a/free-programming-books-fr.md
+++ b/free-programming-books-fr.md
@@ -37,6 +37,7 @@
 * [Ruby](#ruby)
 * [Sage](#sage)
 * [Scilab](#scilab)
+* [Scratch](#scratch)
 * [SPIP](#spip)
 * [SQL](#sql)
 * [Systèmes d'exploitation](#systemes-d-exploitation)
@@ -260,6 +261,11 @@
 ### Scilab
 
 * [Introduction à Scilab](http://forge.scilab.org/index.php/p/docintrotoscilab/downloads/) - Michaël Baudin, Artem Glebov, Jérome Briot
+
+
+### Scratch
+
+* [Informatique Créative](https://pixees.fr/programmation-creative-en-scratch/)
 
 
 ### SPIP

--- a/free-programming-books-ko.md
+++ b/free-programming-books-ko.md
@@ -18,6 +18,7 @@
   * [Flask](#flask)
 * [R](#r)
 * [Ruby](#ruby)
+* [Scratch](#scratch)
 * [Swift](#swift)
 
 
@@ -123,6 +124,11 @@
 ### Ruby
 
 * [루비 스타일 가이드](https://github.com/dalzony/ruby-style-guide/blob/master/README-koKR.md)
+
+
+### Scratch
+
+* [창의컴퓨팅(Creative Computing) 가이드북](http://digital.kyobobook.co.kr/digital/ebook/ebookDetail.ink?barcode=480150000247P)
 
 
 ### Swift

--- a/free-programming-books-nl.md
+++ b/free-programming-books-nl.md
@@ -1,8 +1,14 @@
 ### Index
 
 * [Python](#python)
+* [Scratch](#scratch)
 
 
 ### Python
 
 * [De Programmeursleerling: Leren coderen met Python 3](http://www.spronck.net/pythonbook/dutchindex.xhtml) - Pieter Spronck (PDF) (3.x)
+
+
+### Scratch
+
+* [Creatief Computergebruik Handleiding](http://www.digi-lab.org/scratch/CreatiefComputingHandleidingNL.pdf) [Creatief Computeren Werkboek](http://www.digi-lab.org/scratch/CreatiefComputingWerkboek.pdf)

--- a/free-programming-books-nl.md
+++ b/free-programming-books-nl.md
@@ -11,4 +11,4 @@
 
 ### Scratch
 
-* [Creatief Computergebruik Handleiding](http://www.digi-lab.org/scratch/CreatiefComputingHandleidingNL.pdf) [Creatief Computeren Werkboek](http://www.digi-lab.org/scratch/CreatiefComputingWerkboek.pdf)
+* [Creatief Computergebruik](http://scratched.gse.harvard.edu/resources/creatief-computergebruik)

--- a/free-programming-books-ro.md
+++ b/free-programming-books-ro.md
@@ -4,6 +4,7 @@
 * [HTML](#hmtl)
 * [MySQL](#mysql)
 * [PHP](#php)
+* [Scratch](#scratch)
 
 
 ### Ajax
@@ -24,3 +25,8 @@
 ### PHP
 
 * [PHP](http://php.punctsivirgula.ro)
+
+
+### Scratch
+
+* [Informatica Creativa - Manualul Profesorului](http://digitaliada.ro/Informatica-Creativa-Harvard-Graduate-School-of-Education-a1545736596708594) [Informatica Creativa - Caietul Cursantului](http://digitaliada.ro/materiale-concurs/documente/194-Caietul%20Cursantului_Informatica%20Creativa.pdf)

--- a/free-programming-books-ro.md
+++ b/free-programming-books-ro.md
@@ -29,4 +29,4 @@
 
 ### Scratch
 
-* [Informatica Creativa - Manualul Profesorului](http://digitaliada.ro/Informatica-Creativa-Harvard-Graduate-School-of-Education-a1545736596708594) [Informatica Creativa - Caietul Cursantului](http://digitaliada.ro/materiale-concurs/documente/194-Caietul%20Cursantului_Informatica%20Creativa.pdf)
+* [Informatica Creativa](http://scratched.gse.harvard.edu/resources/informatica-creativa-0)

--- a/free-programming-books-ru.md
+++ b/free-programming-books-ru.md
@@ -482,7 +482,7 @@
 
 ### Scratch
 
-* [Креативное программирование](https://www.dropbox.com/s/qsthpk5r6gqmi6u/CreativeComputing_RUS_june2016.pdf?dl=0)
+* [Креативное программирование](https://www.dropbox.com/s/qsthpk5r6gqmi6u/CreativeComputing_RUS_june2016.pdf?dl=0) (PDF)
 
 
 ### Smalltalk

--- a/free-programming-books-ru.md
+++ b/free-programming-books-ru.md
@@ -59,6 +59,7 @@
 * [Rust](#rust)
 * [Scala](#scala)
 * [Scilab](#scilab)
+* [Scratch](#scratch)
 * [Smalltalk](#smalltalk)
 * [SQL](#sql)
   * [PostgreSQL](#postgresql)
@@ -477,6 +478,11 @@
 
 * [Введение в Scilab](http://forge.scilab.org/index.php/p/docintrotoscilab/downloads)
 * [Программирование в Scilab](http://forge.scilab.org/index.php/p/docprogscilab/downloads)
+
+
+### Scratch
+
+* [Креативное программирование](https://www.dropbox.com/s/qsthpk5r6gqmi6u/CreativeComputing_RUS_june2016.pdf?dl=0)
 
 
 ### Smalltalk

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -665,7 +665,7 @@
 
 ### Scratch
 
-* [创意计算课程指南](http://cccgchinese.strikingly.com/)
+* [创意计算课程指南](http://cccgchinese.strikingly.com)
 
 
 ### Shell

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -60,6 +60,7 @@
   * [Rust](#rust)
   * [Scala](#scala)
   * [Scheme](#scheme)
+  * [Scratch](#scratch)
   * [Shell](#shell)
   * [Swift](#swift)
   * [Vim](#vim)
@@ -660,6 +661,11 @@
 ### Scheme
 
 * [Scheme 入门教程](http://deathking.github.io/yast-cn/) (《Yet Another Scheme Tutorial》中文版)
+
+
+### Scratch
+
+* [创意计算课程指南](http://cccgchinese.strikingly.com/)
 
 
 ### Shell

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2349,6 +2349,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### Scratch
 
+* [An Introductory Computing Curriculum Using Scratch](http://scratched.gse.harvard.edu/guide/download.html)
 * [Computer Science Concepts in Scratch](https://stwww1.weizmann.ac.il/scratch/scratch_en/)
 
 


### PR DESCRIPTION
## What does this PR do?
Add Resource(s) | Remove Resource(s) | Add info | Improve Repo

As requested, this PR adds Harvard's Graduate School of Education guide to scratch in all the foreign language translations located at http://scratched.gse.harvard.edu/guide/download.html


## For resources
### Description 
Harvard GSE guide to Creative Computing with Scratch in translation

### Why is this valuable (or not)
150 page guide for K-12 students to explore scratch in many languages

### How do we know it's really free?
CC-BY-SA

### For book lists, is it a book?
Fo sho

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)

For some reason my old commit from Aug 1 (#2937) adding the english version is still popping up under this PR. Hope it doesn't break the PR. Let me know if it does.
