### PR TITLE
Added Learn to Code HTML & CSS of Shay Howe

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1307,9 +1307,9 @@ Kerridge (PDF) (email address *requested*, not required)
 * [HTML5 Graphing and Data Visualization Cookbook](https://www.packtpub.com/packt/free-ebook/html5-data-visualization-cookbook) - Ben Fhala, Packt. (email address *requested*, not required)
 * [HTML5 Notes for Professionals](http://books.goalkicker.com/HTML5Book/) - Compiled from StackOverflow documentation (3.x)
 * [HTML5 Shoot 'em Up in an Afternoon](https://leanpub.com/html5shootemupinanafternoon/read) - Bryan Bibat
-* [Learn to Code HTML & CSS](https://learn.shayhowe.com/) - Shay Howe (Paid amazon version available)
 * [Learn CSS Layout](http://learnlayout.com)
 * [Learn CSS Layout the pedantic way](http://book.mixu.net/css/)
+* [Learn to Code HTML & CSS](https://learn.shayhowe.com) - Shay Howe (Paid amazon version available)
 * [MaintainableCSS](http://maintainablecss.com)
 * [Pro HTML5 Programming]( http://apress.jensimmons.com/v5/pro-html5-programming/ch0.html)
 * [Scalable and Modular Architecture for CSS](https://smacss.com) - Jonathan Snook

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1309,7 +1309,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [HTML5 Shoot 'em Up in an Afternoon](https://leanpub.com/html5shootemupinanafternoon/read) - Bryan Bibat
 * [Learn CSS Layout](http://learnlayout.com)
 * [Learn CSS Layout the pedantic way](http://book.mixu.net/css/)
-* [Learn to Code HTML & CSS](https://learn.shayhowe.com) - Shay Howe (Paid amazon version available)
+* [Learn to Code HTML & CSS](https://learn.shayhowe.com) - Shay Howe
 * [MaintainableCSS](http://maintainablecss.com)
 * [Pro HTML5 Programming]( http://apress.jensimmons.com/v5/pro-html5-programming/ch0.html)
 * [Scalable and Modular Architecture for CSS](https://smacss.com) - Jonathan Snook

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1307,6 +1307,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [HTML5 Graphing and Data Visualization Cookbook](https://www.packtpub.com/packt/free-ebook/html5-data-visualization-cookbook) - Ben Fhala, Packt. (email address *requested*, not required)
 * [HTML5 Notes for Professionals](http://books.goalkicker.com/HTML5Book/) - Compiled from StackOverflow documentation (3.x)
 * [HTML5 Shoot 'em Up in an Afternoon](https://leanpub.com/html5shootemupinanafternoon/read) - Bryan Bibat
+* [Learn to Code HTML & CSS](https://learn.shayhowe.com/) - Shay Howe (Paid amazon version available)
 * [Learn CSS Layout](http://learnlayout.com)
 * [Learn CSS Layout the pedantic way](http://book.mixu.net/css/)
 * [MaintainableCSS](http://maintainablecss.com)


### PR DESCRIPTION
## Added CSS Book
I recently add the Shay Howe's book about HTML&CSS. The book is available for free but you can also purchase a paid version whether paper or kindle on amazon.com  
* [Learn to Code HTML & CSS](https://learn.shayhowe.com/) 

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
