### PR TITLE
added Go Tour by golang.org

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -156,8 +156,8 @@
 
 ### Go
 
+* [A Tour Of Go](https://tour.golang.org/welcome/1)
 * [Go Tutorial](http://www.tutorialspoint.com/go/index.htm)
-* [Go Tour](https://tour.golang.org/welcome/1)
 
 
 ### Haskell

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -157,6 +157,7 @@
 ### Go
 
 * [Go Tutorial](http://www.tutorialspoint.com/go/index.htm)
+* [Go Tour](https://tour.golang.org/welcome/1)
 
 
 ### Haskell


### PR DESCRIPTION

Added "A Tour of Go" by Golang.org for Go free-courses.
