### PR TITLE
Enable emoji on GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-minimal
+plugins:
+  - jemoji


### PR DESCRIPTION
## What does this PR do?
This will enable emoji to be printed on the website. Currently only the keyword are printed.
Example:
:books: instead of `:books:`

This is related to #2479
More information about this topic can be found here:
https://help.github.com/articles/emoji-on-github-pages/


### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate -> not needed
- [x] Lists are in alphabetical order -> not needed
- [x] Needed indications added (PDF, access notes, under construction)-> not needed


## Live-Example:
A working example can be seen on my fork:
https://blackgen.github.io/free-programming-books/

Compare this to:
https://ebookfoundation.github.io/free-programming-books/