### PR TITLE
Remove bad link from free-programming-interactive-tutorials-en.md

### DIFF
--- a/free-programming-interactive-tutorials-en.md
+++ b/free-programming-interactive-tutorials-en.md
@@ -201,7 +201,6 @@
 ### Ruby
 
 * [CodeCademy Ruby](https://www.codecademy.com/learn/ruby)
-* [Codeschool Ruby paths](https://www.codeschool.com/paths/ruby)
 * [Ruby Koans](http://www.rubykoans.com)
 * [The Odin Project](http://www.theodinproject.com)
 * [Try Ruby](http://tryruby.org)


### PR DESCRIPTION
## What does this PR do?
Removed a link to a url that redirects to a paid site. [Codeschool was acquired by Pluralsight](https://www.pluralsight.com/blog/news/code-school-acquisition) and the resources are no longer in existence.
