### PR TITLE
Add Tiny Python 3.6 Notebook by Matt Harrison

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2131,6 +2131,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [The Python GTK+ 3 Tutorial](http://python-gtk-3-tutorial.readthedocs.org/en/latest/)
 * [The Standard Python Library](http://effbot.org/librarybook/) - Fredrik Lundh
 * [Think Complexity](http://greenteapress.com/complexity/) - Allen B. Downey (2nd Edition) (PDF, HTML)
+* [Tiny Python 3.6 Notebook](https://github.com/mattharrison/Tiny-Python-3.6-Notebook) - Matt Harrison (3.6)
 * [Web2py: Complete Reference Manual, 6th Edition (pre-release)](http://web2py.com/book) (2.5 - 2.x)
 
 


### PR DESCRIPTION
Free in the github repo, and also available as a hard copy for purchase.

## What does this PR do?
Add Resource(s)

## For resources
### Description 
[Tiny Python 3.6 Notebook](https://github.com/mattharrison/Tiny-Python-3.6-Notebook) - This book covers the syntax in Python up to version 3.6.

### Why is this valuable (or not)
Concise source of reference for Python.

### How do we know it's really free?
It's available in the github repo and is licensed under the Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)

### For book lists, is it a book?
Yes

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
