### PR TITLE
Add The Art of Prolog

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2050,6 +2050,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Prolog Problems](https://sites.google.com/site/prologsite/prolog-problems) - Werner Hett
 * [Prolog Techniques](http://bookboon.com/en/prolog-techniques-applications-of-prolog-ebook) - Attila Csenki, Bookboon. (email address *requested*, not required)
 * [Prolog Tutorial](http://www.cpp.edu/~jrfisher/www/prolog_tutorial/contents.html)
+* [The Art of Prolog, Second Edition](https://mitpress.mit.edu/books/art-prolog-second-edition) -  Leon S. Sterling, Ehud Y. Shapiro (Open Access)
 * [The First 10 Prolog Programming Contests](https://dtai.cs.kuleuven.be/ppcbook/) - Bart Demoen, Phuong-Lan Nguyen, Tom Schrijvers, Remko Tronçon
 * [Warren's Abstract Machine: A Tutorial Reconstruction](http://wambook.sourceforge.net) - Hassan A¨it-Kaci
 


### PR DESCRIPTION
## What does this PR do?
Add [The Art of Prolog, Second Edition](https://mitpress.mit.edu/books/art-prolog-second-edition).

## For resources
### Description 

### Why is this valuable (or not)
One of the classics from which to learn Prolog.

### How do we know it's really free?
It is one of MIT Press' Open Access Titles.

### For book lists, is it a book?
Yes.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)