### PR TITLE
 Refactor menu link of ZH version md file， and remove multiple ebook link

### DIFF
--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -357,8 +357,8 @@
 ### CoffeeScript
 
 * [CoffeeScript 中文](http://coffee-script.org)
-* [CoffeeScript 编程风格指南](https://github.com/elrrrrrrr/coffeescript-style-guide/blob/master/README-ZH.md)
 * [CoffeeScript 编码风格指南](https://github.com/geekplux/coffeescript-style-guide)
+* [CoffeeScript 编程风格指南](https://github.com/elrrrrrrr/coffeescript-style-guide/blob/master/README-ZH.md)
 
 
 ### Dart

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -63,7 +63,7 @@
   * [Scratch](#scratch)
   * [Shell](#shell)
   * [Swift](#swift)
-  * [VBA](#Excel-vba)
+  * [VBA](#vba-microsoft-visual-basic-applications)
   * [Vim](#vim)
   * [Visual Prolog](#visual-prolog)
   * [WebAssembly](#webassembly)

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -226,7 +226,7 @@
 * [Git 参考手册](http://gitref.justjavac.com)
 * [Github帮助文档](https://github.com/waylau/github-help)
 * [GitHub秘籍](https://snowdream86.gitbooks.io/github-cheat-sheet/content/zh/)
-* [Git教程](http://www.liaoxuefeng.com/wiki/0013739516305929606dd18361248578c67b8067c8c017b000) （本文由 [@廖雪峰](http://weibo.com/liaoxuefeng) 创作，如果觉得本教程对您有帮助，可以去 [iTunes](https://itunes.apple.com/cn/app/git-jiao-cheng/id876420437) 购买）
+* [Git教程](http://www.liaoxuefeng.com/wiki/0013739516305929606dd18361248578c67b8067c8c017b000) （作者：[@廖雪峰](http://weibo.com/liaoxuefeng)）
 * [Got GitHub](https://github.com/gotgit/gotgithub)
 * [GotGitHub](http://www.worldhello.net/gotgithub/index.html)
 * [HgInit (中文版)](https://zh-hginit.readthedocs.io/en/latest/)
@@ -302,7 +302,7 @@
 * [selenium 中文文档](https://github.com/fool2fish/selenium-doc)
 * [开源软件架构](http://www.ituring.com.cn/book/1143)
 * [持续集成（第二版）](http://article.yeeyan.org/view/2251/94882) (译言网)
-* [約耳談軟體(Joel on Software)](https://web.archive.org/web/20170615232349/http://local.joelonsoftware.com/wiki/首頁)
+* [約耳談軟體(Joel on Software)](https://web.archive.org/web/20170615232349/http://local.joelonsoftware.com/wiki/首頁) (繁体中文)
 * [编码规范](https://github.com/ecomfe/spec)
 * [让开发自动化系列专栏](http://www.ibm.com/developerworks/cn/java/j-ap/)
 * [追求代码质量](http://www.ibm.com/developerworks/cn/java/j-cq/)
@@ -320,7 +320,7 @@
 * [Google Android官方培训课程中文版](http://hukai.me/android-training-course-in-chinese/index.html)
 * Google Material Design 正體中文版 ([译本一](https://wcc723.gitbooks.io/google_design_translate/content/style-icons.html) [译本二](https://github.com/1sters/material_design_zh))
 * [Material Design 中文版](http://wiki.jikexueyuan.com/project/material-design/)
-* [Point-of-Android](https://github.com/FX-Max/Point-of-Android) Android 一些重要知识点解析整理
+* [Point-of-Android](https://github.com/FX-Max/Point-of-Android) （Android 一些重要知识点解析整理）
 
 
 ### AWK
@@ -517,7 +517,7 @@
 
 #### D3.js
 
-  * [Learning D3.JS](http://d3.decembercafe.org) (Created by 十二月咖啡馆)
+  * [Learning D3.JS](http://d3.decembercafe.org) (作者：十二月咖啡馆)
   * [官方API文档](https://github.com/mbostock/d3/wiki/API--%E4%B8%AD%E6%96%87%E6%89%8B%E5%86%8C)
   * [张天旭的D3教程](http://blog.csdn.net/zhang__tianxu/article/category/1623437)
   * [楚狂人的D3教程](http://www.cnblogs.com/winleisure/tag/D3.js/)

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -689,6 +689,7 @@
 
 * [简明Excel VBA](https://github.com/Youchien/concise-excel-vba)
 
+
 ### Vim
 
 * [Vim Manual(中文版)](http://man.chinaunix.net/newsoft/vi/doc/help.html)

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -2,9 +2,6 @@
 
 * [语言无关](#语言无关)
   * [IDE](#ide)
-  * [MySQL](#mysql)
-  * [NoSQL](#nosql)
-  * [PostgreSQL](#postgresql)
   * [Web](#web)
   * [WEB服务器](#web服务器)
   * [其它](#其它)
@@ -45,13 +42,27 @@
   * [iOS](#ios)
   * [Java](#java)
   * [JavaScript](#javascript)
+    * [AngularJS](#angularjs)
+    * [Backbone.js](#backbonejs)
+    * [CoffeeScript](#coffeeScript)
+    * [D3.js](#d3js)
+    * [ExtJS](#extjs)
+    * [impress.js](#impressjs)
+    * [jQuery](#jquery)
+    * [Node.js](#nodejs)
+    * [React.js](#reactjs)
+    * [Vue.js](#vuejs)
+    * [Zepto.js](#zeptojs)
   * [LaTeX](#latex)
   * [LISP](#lisp)
   * [Lua](#lua)
   * [Markdown](#markdown)
+  * [MySQL](#mysql)
   * [Node.js](#nodejs)
+  * [NoSQL](#nosql)
   * [Perl](#perl)
   * [PHP](#php)
+  * [PostgreSQL](#postgresql)
   * [Python](#python)
     * [Django](#django)
   * [R](#r)
@@ -76,23 +87,6 @@
 * [IntelliJ IDEA 简体中文专题教程](https://github.com/judasn/IntelliJ-IDEA-Tutorial)
 
 
-### MySQL
-
-* [21分钟MySQL入门教程](http://www.cnblogs.com/mr-wid/archive/2013/05/09/3068229.html)
-* [MySQL索引背后的数据结构及算法原理](http://blog.codinglabs.org/articles/theory-of-mysql-index.html)
-
-
-### NoSQL
-
-* [Disque 使用教程](http://disque.huangz.me)
-* [Redis 命令参考](http://redisdoc.com)
-* [Redis 设计与实现](http://redisbook.com)
-* [The Little MongoDB Book](https://github.com/justinyhuang/the-little-mongodb-book-cn/blob/master/mongodb.md)
-* [The Little Redis Book](https://github.com/JasonLai256/the-little-redis-book/blob/master/cn/redis.md)
-* [带有详细注释的 Redis 2.6 代码](https://github.com/huangz1990/annotated_redis_source)
-* [带有详细注释的 Redis 3.0 代码](https://github.com/huangz1990/redis-3.0-annotated)
-
-
 ### PostgreSQL
 
 * [PostgreSQL 8.2.3 中文文档](http://works.jinbuguo.com/postgresql/menu823/index.html)
@@ -107,6 +101,7 @@
 * [3 Web Designs in 3 Weeks](https://www.gitbook.com/book/juntao/3-web-designs-in-3-weeks/details)
 * [Chrome 开发者工具中文手册](https://github.com/CN-Chrome-DevTools/CN-Chrome-DevTools)
 * [Chrome扩展开发文档](http://open.chrome.360.cn/extension_dev/overview.html)
+* [Chrome扩展及应用开发](http://www.ituring.com.cn/minibook/950)
 * [Growth: 全栈增长工程师指南](https://github.com/phodal/growth-ebook)
 * [Grunt中文文档](http://www.gruntjs.net)
 * [Gulp 入门指南](https://github.com/nimojs/gulp-book)
@@ -485,30 +480,8 @@
 ### Javascript
 
 * [Airbnb JavaScript 规范](https://github.com/adamlu/javascript-style-guide)
-* AngularJS
-  * [AngularJS入门教程](https://github.com/zensh/AngularjsTutorial_cn)
-  * [AngularJS最佳实践和风格指南](https://github.com/mgechev/angularjs-style-guide/blob/master/README-zh-cn.md)
-  * [在Windows环境下用Yeoman构建AngularJS项目](http://www.waylau.com/build-angularjs-app-with-yeoman-in-windows/)
-  * [构建自己的AngularJS](https://github.com/xufei/Make-Your-Own-AngularJS/blob/master/01.md)
-* backbone.js
-  * [backbone.js中文文档](http://www.css88.com/doc/backbone/)
-  * [backbone.js入门教程](http://www.the5fire.com/backbone-js-tutorials-pdf-download.html) (PDF)
-  * [Backbone.js入门教程第二版](https://github.com/the5fire/backbonejs-learning-note)
-* [Chrome扩展及应用开发](http://www.ituring.com.cn/minibook/950)
-* CoffeeScript
-  * [CoffeeScript 编码风格指南](https://github.com/geekplux/coffeescript-style-guide)
-* D3.js
-  * [Learning D3.JS](http://d3.decembercafe.org) (Created by 十二月咖啡馆)
-  * [官方API文档](https://github.com/mbostock/d3/wiki/API--%E4%B8%AD%E6%96%87%E6%89%8B%E5%86%8C)
-  * [张天旭的D3教程](http://blog.csdn.net/zhang__tianxu/article/category/1623437)
-  * [楚狂人的D3教程](http://www.cnblogs.com/winleisure/tag/D3.js/)
 * [ECMAScript 6 入门](http://es6.ruanyifeng.com) (作者：阮一峰)
-* ExtJS
-  * [Ext4.1.0 中文文档](http://extjs-doc-cn.github.io/ext4api/)
 * [Google JavaScript 代码风格指南](http://bq69.com/blog/articles/script/868/google-javascript-style-guide.html)
-* [Google JSON 风格指南](https://github.com/darcyliu/google-styleguide/blob/master/JSONStyleGuide.md)
-* impress.js
-  * [impress.js的中文教程](https://github.com/kokdemo/impress.js-tutorial-in-Chinese)
 * [JavaScript Promise迷你书](http://liubin.github.io/promises-book/)
 * [Javascript 原理](https://web.archive.org/web/20170112164945/http://typeof.net/s/jsmech/)
 * [JavaScript 标准参考教程（alpha）](http://javascript.ruanyifeng.com)
@@ -517,10 +490,58 @@
 * [JavaScript 秘密花园](http://bonsaiden.github.io/JavaScript-Garden/zh/)
 * [JavaScript核心概念及实践](http://icodeit.org/jsccp/) (PDF) (此书已由人民邮电出版社出版发行，但作者依然免费提供PDF版本，希望开发者们去购买，支持作者)
 * [Javascript编程指南](http://pij.robinqu.me) ([源码](https://github.com/RobinQu/Programing-In-Javascript))
-* jQuery
+* [你不知道的Javascript](https://github.com/getify/You-Dont-Know-JS/tree/1ed-zh-CN) (深入JavaScript语言核心机制的系列图书)
+* [命名函数表达式探秘](http://justjavac.com/named-function-expressions-demystified.html)  (注:原文由[为之漫笔](http://www.cn-cuckoo.com) 翻译，原始地址无法打开，所以此处地址为我博客上的备份)
+* [学用 JavaScript 设计模式](http://www.oschina.net/translate/learning-javascript-design-patterns) (开源中国)
+* [深入理解JavaScript系列](http://www.cnblogs.com/TomXu/archive/2011/12/15/2288411.html)
+
+
+#### AngularJS
+
+  * [AngularJS入门教程](https://github.com/zensh/AngularjsTutorial_cn)
+  * [AngularJS最佳实践和风格指南](https://github.com/mgechev/angularjs-style-guide/blob/master/README-zh-cn.md)
+  * [在Windows环境下用Yeoman构建AngularJS项目](http://www.waylau.com/build-angularjs-app-with-yeoman-in-windows/)
+  * [构建自己的AngularJS](https://github.com/xufei/Make-Your-Own-AngularJS/blob/master/01.md)
+
+
+#### Backbone.js
+
+  * [Backbone.js中文文档](http://www.css88.com/doc/backbone/)
+  * [Backbone.js入门教程](http://www.the5fire.com/backbone-js-tutorials-pdf-download.html) (PDF)
+  * [Backbone.js入门教程第二版](https://github.com/the5fire/backbonejs-learning-note)
+
+
+#### CoffeeScript
+
+  * [CoffeeScript 编码风格指南](https://github.com/geekplux/coffeescript-style-guide)
+
+
+#### D3.js
+
+  * [Learning D3.JS](http://d3.decembercafe.org) (Created by 十二月咖啡馆)
+  * [官方API文档](https://github.com/mbostock/d3/wiki/API--%E4%B8%AD%E6%96%87%E6%89%8B%E5%86%8C)
+  * [张天旭的D3教程](http://blog.csdn.net/zhang__tianxu/article/category/1623437)
+  * [楚狂人的D3教程](http://www.cnblogs.com/winleisure/tag/D3.js/)
+
+
+#### ExtJS
+
+  * [Ext4.1.0 中文文档](http://extjs-doc-cn.github.io/ext4api/)
+
+
+#### impress.js
+
+  * [impress.js的中文教程](https://github.com/kokdemo/impress.js-tutorial-in-Chinese)
+
+
+#### jQuery
+
   * [How to write jQuery plugin](http://i5ting.github.io/How-to-write-jQuery-plugin/build/jquery.plugin.html)
   * [简单易懂的JQuery魔法](http://www.nowamagic.net/librarys/books/contents/jquery)
-* Node.js
+
+
+#### Node.js
+
   * [express.js 中文文档](http://expressjs.jser.us)
   * [Express框架](http://javascript.ruanyifeng.com/nodejs/express.html)
   * [koa 中文文档](https://github.com/guo-yu/koa-guide)
@@ -534,21 +555,26 @@
   * [七天学会NodeJS](http://nqdeng.github.io/7-days-nodejs/)
   * [使用 Express + MongoDB 搭建多人博客](https://github.com/nswbmw/N-blog)
   * [JavaScript全栈工程师培训材料](http://nodejs.ctolib.com/docs/sfile/jstraining/engineering.html)
-* React.js
+
+
+#### React.js
+
   * [Learn React & Webpack by building the Hacker News front page](https://github.com/theJian/build-a-hn-front-page)
   * [React-Bits 中文文档](https://github.com/hateonion/react-bits-CN)
   * [React Native 中文文档(含最新Android内容)](http://wiki.jikexueyuan.com/project/react-native/)
   * [React webpack-cookbook](https://github.com/fakefish/react-webpack-cookbook)
   * [React.js 中文文档](https://discountry.github.io/react/)
   * [React.js 入门教程](http://fraserxu.me/intro-to-react/)
-* Vue.js
+
+
+#### Vue.js
+
   * [Vue.js中文文档](https://cn.vuejs.org/v2/guide/)
-* Zepto.js
+
+
+#### Zepto.js
+
   * [Zepto.js 中文文档](http://css88.com/doc/zeptojs_api)
-* [你不知道的Javascript](https://github.com/getify/You-Dont-Know-JS/tree/1ed-zh-CN) (深入JavaScript语言核心机制的系列图书)
-* [命名函数表达式探秘](http://justjavac.com/named-function-expressions-demystified.html)  (注:原文由[为之漫笔](http://www.cn-cuckoo.com) 翻译，原始地址无法打开，所以此处地址为我博客上的备份)
-* [学用 JavaScript 设计模式](http://www.oschina.net/translate/learning-javascript-design-patterns) (开源中国)
-* [深入理解JavaScript系列](http://www.cnblogs.com/TomXu/archive/2011/12/15/2288411.html)
 
 
 ### LaTeX
@@ -577,11 +603,28 @@
 * [献给写作者的 Markdown 新手指南](http://www.jianshu.com/p/q81RER)
 
 
+### MySQL
+
+* [21分钟MySQL入门教程](http://www.cnblogs.com/mr-wid/archive/2013/05/09/3068229.html)
+* [MySQL索引背后的数据结构及算法原理](http://blog.codinglabs.org/articles/theory-of-mysql-index.html)
+
+
 ### Node.js
 
 * [Node 入门](http://www.nodebeginner.org/index-zh-cn.html)
 * [The NodeJS 中文文档](https://www.gitbook.com/book/0532/nodejs/details) （社区翻译）
 * [七天学会NodeJS](http://nqdeng.github.io/7-days-nodejs/) 阿里出品，很好的入门资料
+
+
+### NoSQL
+
+* [Disque 使用教程](http://disque.huangz.me)
+* [Redis 命令参考](http://redisdoc.com)
+* [Redis 设计与实现](http://redisbook.com)
+* [The Little MongoDB Book](https://github.com/justinyhuang/the-little-mongodb-book-cn/blob/master/mongodb.md)
+* [The Little Redis Book](https://github.com/JasonLai256/the-little-redis-book/blob/master/cn/redis.md)
+* [带有详细注释的 Redis 2.6 代码](https://github.com/huangz1990/annotated_redis_source)
+* [带有详细注释的 Redis 3.0 代码](https://github.com/huangz1990/redis-3.0-annotated)
 
 
 ### Perl

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -86,15 +86,6 @@
 * [IntelliJ IDEA 简体中文专题教程](https://github.com/judasn/IntelliJ-IDEA-Tutorial)
 
 
-### PostgreSQL
-
-* [PostgreSQL 8.2.3 中文文档](http://works.jinbuguo.com/postgresql/menu823/index.html)
-* [PostgreSQL 9.3.1 中文文档](http://www.postgres.cn/docs/9.3/index.html)
-* [PostgreSQL 9.4.4 中文文档](http://www.postgres.cn/docs/9.4/index.html)
-* [PostgreSQL 9.5.3 中文文档](http://www.postgres.cn/docs/9.5/index.html)
-* [PostgreSQL 9.6.0 中文文档](http://www.postgres.cn/docs/9.6/index.html)
-
-
 ### Web
 
 * [3 Web Designs in 3 Weeks](https://www.gitbook.com/book/juntao/3-web-designs-in-3-weeks/details)
@@ -639,6 +630,15 @@
 * [Symfony2 实例教程](https://wusuopu.gitbooks.io/symfony2_tutorial/content)
 * [Yii2中文文档](http://www.yiichina.com/doc/guide/2.0)
 * [深入理解 PHP 内核](http://www.php-internals.com/book/)
+
+
+### PostgreSQL
+
+* [PostgreSQL 8.2.3 中文文档](http://works.jinbuguo.com/postgresql/menu823/index.html)
+* [PostgreSQL 9.3.1 中文文档](http://www.postgres.cn/docs/9.3/index.html)
+* [PostgreSQL 9.4.4 中文文档](http://www.postgres.cn/docs/9.4/index.html)
+* [PostgreSQL 9.5.3 中文文档](http://www.postgres.cn/docs/9.5/index.html)
+* [PostgreSQL 9.6.0 中文文档](http://www.postgres.cn/docs/9.6/index.html)
 
 
 ### Python

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -44,7 +44,6 @@
   * [JavaScript](#javascript)
     * [AngularJS](#angularjs)
     * [Backbone.js](#backbonejs)
-    * [CoffeeScript](#coffeeScript)
     * [D3.js](#d3js)
     * [ExtJS](#extjs)
     * [impress.js](#impressjs)
@@ -90,8 +89,8 @@
 
 * [3 Web Designs in 3 Weeks](https://www.gitbook.com/book/juntao/3-web-designs-in-3-weeks/details)
 * [Chrome 开发者工具中文手册](https://github.com/CN-Chrome-DevTools/CN-Chrome-DevTools)
-* [Chrome扩展开发文档](http://open.chrome.360.cn/extension_dev/overview.html)
 * [Chrome扩展及应用开发](http://www.ituring.com.cn/minibook/950)
+* [Chrome扩展开发文档](http://open.chrome.360.cn/extension_dev/overview.html)
 * [Growth: 全栈增长工程师指南](https://github.com/phodal/growth-ebook)
 * [Grunt中文文档](http://www.gruntjs.net)
 * [Gulp 入门指南](https://github.com/nimojs/gulp-book)
@@ -359,6 +358,7 @@
 
 * [CoffeeScript 中文](http://coffee-script.org)
 * [CoffeeScript 编程风格指南](https://github.com/elrrrrrrr/coffeescript-style-guide/blob/master/README-ZH.md)
+* [CoffeeScript 编码风格指南](https://github.com/geekplux/coffeescript-style-guide)
 
 
 ### Dart
@@ -500,11 +500,6 @@
   * [Backbone.js中文文档](http://www.css88.com/doc/backbone/)
   * [Backbone.js入门教程](http://www.the5fire.com/backbone-js-tutorials-pdf-download.html) (PDF)
   * [Backbone.js入门教程第二版](https://github.com/the5fire/backbonejs-learning-note)
-
-
-#### CoffeeScript
-
-  * [CoffeeScript 编码风格指南](https://github.com/geekplux/coffeescript-style-guide)
 
 
 #### D3.js

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -58,7 +58,6 @@
   * [Lua](#lua)
   * [Markdown](#markdown)
   * [MySQL](#mysql)
-  * [Node.js](#nodejs)
   * [NoSQL](#nosql)
   * [Perl](#perl)
   * [PHP](#php)
@@ -551,7 +550,8 @@
   * [Nodejs Wiki Book](https://github.com/nodejs-tw/nodejs-wiki-book) (繁体中文)
   * [nodejs中文文档](https://www.gitbook.com/book/0532/nodejs/details)
   * [Node入门](http://www.nodebeginner.org/index-zh-cn.html)
-  * [七天学会NodeJS](http://nqdeng.github.io/7-days-nodejs/)
+  * [The NodeJS 中文文档](https://www.gitbook.com/book/0532/nodejs/details) （社区翻译）
+  * [七天学会NodeJS](http://nqdeng.github.io/7-days-nodejs/) 阿里出品，很好的入门资料
   * [使用 Express + MongoDB 搭建多人博客](https://github.com/nswbmw/N-blog)
   * [JavaScript全栈工程师培训材料](http://nodejs.ctolib.com/docs/sfile/jstraining/engineering.html)
 
@@ -606,13 +606,6 @@
 
 * [21分钟MySQL入门教程](http://www.cnblogs.com/mr-wid/archive/2013/05/09/3068229.html)
 * [MySQL索引背后的数据结构及算法原理](http://blog.codinglabs.org/articles/theory-of-mysql-index.html)
-
-
-### Node.js
-
-* [Node 入门](http://www.nodebeginner.org/index-zh-cn.html)
-* [The NodeJS 中文文档](https://www.gitbook.com/book/0532/nodejs/details) （社区翻译）
-* [七天学会NodeJS](http://nqdeng.github.io/7-days-nodejs/) 阿里出品，很好的入门资料
 
 
 ### NoSQL

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -63,6 +63,7 @@
   * [Scratch](#scratch)
   * [Shell](#shell)
   * [Swift](#swift)
+  * [VBA](#Excel-vba)
   * [Vim](#vim)
   * [Visual Prolog](#visual-prolog)
   * [WebAssembly](#webassembly)
@@ -683,6 +684,10 @@
 
 * [《The Swift Programming Language》中文版](https://www.gitbook.com/book/numbbbbb/-the-swift-programming-language-/details)
 
+
+### VBA (Microsoft Visual Basic Applications)
+
+* [简明Excel VBA](https://github.com/Youchien/concise-excel-vba)
 
 ### Vim
 

--- a/free-programming-books-zh.md
+++ b/free-programming-books-zh.md
@@ -201,8 +201,7 @@
 
 ### 数据库
 
-* [Redis 设计与实现](http://redisbook.com)
-* [The Little MongoDB Book 中文版](https://github.com/justinyhuang/the-little-mongodb-book-cn)
+<!-- Waiting to add in -->
 
 
 ### 智能系统

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -359,7 +359,7 @@
 * [Practical and Theoretical Aspects of Compiler Construction](http://web.stanford.edu/class/archive/cs/cs143/cs143.1128/) (class lectures and slides)
 
 
-####Computer Science
+#### Computer Science
 
 * [Computer Science I - Draft](https://bitbucket.org/chrisbourke/computersciencei/src) - Dr. Chris Bourke (PDF) (:construction: *in process*)
 * [Computer Science II - Draft](http://cse.unl.edu/~cbourke/ComputerScienceTwo.pdf) - Dr. Chris Bourke (PDF) (:construction: *in process*)
@@ -580,7 +580,7 @@
 * [Bits, Signals, and Packets: An Introduction to Digital Communications and Networks](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-02-introduction-to-eecs-ii-digital-communication-systems-fall-2012/readings/)
 * [Code Connected vol.1](http://hintjens.wdfiles.com/local--files/main%3Afiles/cc1pe.pdf) (PDF) (book on ZeroMQ)
 * [Computer Networking : Principles, Protocols and Practice](http://cnp3book.info.ucl.ac.be/1st/html/index.html) (HTML, ePub, PDF, Kindle)
-* [Computer Networks: A Systems Approach](https://book.systemsapproach.org) - Larry Peterson and Bruce Davie (HTML, epub, mobi, PDF) 
+* [Computer Networks: A Systems Approach](https://book.systemsapproach.org) - Larry Peterson and Bruce Davie (HTML, epub, mobi, PDF)
 * [High-Performance Browser Networking](https://hpbn.co) - Ilya Grigorik
 * [HTTP Succinctly, Syncfusion](https://www.syncfusion.com/resources/techportal/ebooks/http) (PDF, Kindle) (email address *requested*, not required)
 * [HTTP2 Explained](http://daniel.haxx.se/http2/) - Daniel Stenberg

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -784,6 +784,7 @@ Kerridge (PDF) (email address *requested*, not required)
 ### Agda
 
 * [Agda Tutorial](http://people.inf.elte.hu/divip/AgdaTutorial/Index.html)
+* [Programming Language Foundations in Agda](https://plfa.github.io) - Philip Wadler and Wen Kokke
 
 
 ### Alef


### PR DESCRIPTION
## What does this PR do?
Remove Resource(s) | Improve Repo

## For resources
### Description 
Commits on Dec 15, 2018 :


1. Refactor DB and Javascript menu ZH version md file. 
Move 'MySQL, NoSQL, PostgreSQL' under menu: Language Agnostic(语言相关),

2. Delete duplicate book link 

  * D1. `[Redis 设计与实现](http://redisbook.com)`, wiich is the same as menu: NoSQL -> `[Redis 设计与实现](http://redisbook.com)`

  * D2. `[The Little MongoDB Book 中文版](https://github.com/justinyhuang/the-little-mongodb-book-cn)` wiich is the same as menu: NoSQL -> `[The Little MongoDB Book](https://github.com/justinyhuang/the-little-mongodb-book-cn/blob/master/mongodb.md)`

  * D3. Delete a book link of [Google JSON 风格指南], it's a duplicate repo. with [JSON 风格指南], the 2 link is point to the same one page.

  * D4. Delete a duplicate link of `[Node 入门](http://www.nodebeginner.org/index-zh-cn.html)` and `[七天学会NodeJS](http://nqdeng.github.io/7-days-nodejs/)` 

### Why is this valuable (or not)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
