### PR TITLE
Update Rust By Example link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2318,7 +2318,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### Rust
 
-* [Rust by Example](http://rustbyexample.com)
+* [Rust by Example](https://doc.rust-lang.org/stable/rust-by-example/)
 * [Rust for Rubyists](http://www.rustforrubyists.com/book/index.html)
 * [The Rust Programming Language](http://doc.rust-lang.org/book/)
 * [The Rustonomicon](https://doc.rust-lang.org/nomicon/)


### PR DESCRIPTION
## What does this PR do?

Update the link for *Rust By Example* since the URL has moved.
