### PR TITLE
Updated Link from Pro Git to new book version

### DIFF
--- a/free-programming-books-de.md
+++ b/free-programming-books-de.md
@@ -90,7 +90,8 @@
 
 * [Das Git-Buch](http://gitbu.ch) [PDF, EPUB]
 * [Git Magic](http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/de/)
-* [Pro Git](http://git-scm.com/book/de/current)
+* [Pro Git 2009](http://git-scm.com/book/de/v1)
+* [Pro Git - neue Version](http://git-scm.com/book/de/current) (:construction: *in process*)
 
 
 ### Groovy

--- a/free-programming-books-de.md
+++ b/free-programming-books-de.md
@@ -90,7 +90,7 @@
 
 * [Das Git-Buch](http://gitbu.ch) [PDF, EPUB]
 * [Git Magic](http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/de/)
-* [Pro Git](http://git-scm.com/book/de/v1)
+* [Pro Git](http://git-scm.com/book/de/current)
 
 
 ### Groovy

--- a/free-programming-books-de.md
+++ b/free-programming-books-de.md
@@ -90,8 +90,8 @@
 
 * [Das Git-Buch](http://gitbu.ch) [PDF, EPUB]
 * [Git Magic](http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/de/)
-* [Pro Git 2009](http://git-scm.com/book/de/v1)
-* [Pro Git - neue Version](http://git-scm.com/book/de/current) (:construction: *in process*)
+* [Pro Git (2009)](http://git-scm.com/book/de/v1)
+* [Pro Git (neue Version)](http://git-scm.com/book/de/current) (:construction: *in process*)
 
 
 ### Groovy


### PR DESCRIPTION
This PR is a copy from [#3152](https://github.com/EbookFoundation/free-programming-books/pull/3152). I deleted my fork after pull so the update didn't integrate into my previous PR. @bluetata 

## What does this PR do?
For the german book "Pro Git" is a new version available. Updated the link for it.

## For resources
### Description 

### Why is this valuable (or not)

### How do we know it's really free?
License notes are on the first page available.

### For book lists, is it a book?


### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
