### PR TITLE
added C Programming Language book PDF source

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -940,7 +940,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Programming in C](http://ee.hawaii.edu/~tep/EE160/Book/PDF/) - Bharat Kinariwala & Tep Dobry
 * [The C book](http://publications.gbdirect.co.uk/c_book/)
 * [The Craft of Text Editing or A Cookbook for an Emacs](http://www.finseth.com/craft/) - Craig A. Finseth
-* [The Current C Programming Language Standard – ISO/IEC 9899:202x (C2x)](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2310.pdf) - Open Standards Org -www.open-std.org
+* [The Current C Programming Language Standard – ISO/IEC 9899:202x (C2x)](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2310.pdf) - Open Standards Org - www.open-std.org (PDF)
 * [The GNU C Programming Tutorial](http://www.crasseux.com/books/ctut.pdf) (PDF)
 * [The little book about OS development](http://littleosbook.github.io) - Erik Helin, Adam Renberg
 * [The New C Standard - An Economic and Cultural commentary (2009)](http://www.knosof.co.uk/cbook/cbook.html) - Derek M. Jones (PDF)

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -940,6 +940,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Programming in C](http://ee.hawaii.edu/~tep/EE160/Book/PDF/) - Bharat Kinariwala & Tep Dobry
 * [The C book](http://publications.gbdirect.co.uk/c_book/)
 * [The Craft of Text Editing or A Cookbook for an Emacs](http://www.finseth.com/craft/) - Craig A. Finseth
+* [The Current C Programming Language Standard – ISO/IEC 9899:202x (C2x)](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2310.pdf) - Open Standards Org -www.open-std.org
 * [The GNU C Programming Tutorial](http://www.crasseux.com/books/ctut.pdf) (PDF)
 * [The little book about OS development](http://littleosbook.github.io) - Erik Helin, Adam Renberg
 * [The New C Standard - An Economic and Cultural commentary (2009)](http://www.knosof.co.uk/cbook/cbook.html) - Derek M. Jones (PDF)


### PR DESCRIPTION
with reference to issues [**3189**](https://github.com/EbookFoundation/free-programming-books/issues/3189)
Added C Programming current standard PDF source.

## What does this PR do?
Add Free and Reliable PDF Resource(s)
## For resources
PDF Resource Current C Programming Language Standard
### Description 
The Book review and propose upcoming C programming standard indicated as **ISO/IEC 9899:202x**
### Why is this valuable (or not)
for Professionals to get familiarity with new standard that that are being adopted and proposed since 2017 to 202x.
### How do we know it's really free?
The book is kinda internet draft, that are usually free/opensource and are welcomed to improve and propose changes.
### For book lists, is it a book?
Its a book in PDF version.
### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
