### PR TITLE
Fixed broken link for The OpenCL Programming Book

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -646,7 +646,7 @@
 * [Is Parallel Programming Hard, And, If So, What Can You Do About It?](https://www.kernel.org/pub/linux/kernel/people/paulmck/perfbook/perfbook.html) - Paul E. McKenney
 * [Programming on Parallel Machines; GPU, Multicore, Clusters and More](http://heather.cs.ucdavis.edu/parprocbook) - Norm Matloff
 Kerridge (PDF) (email address *requested*, not required)
-* [The OpenCL Programming Book](https://us.fixstars.com/opencl/book/OpenCLProgrammingBook/contents/)
+* [The OpenCL Programming Book](https://us.fixstars.com/products/opencl/book/OpenCLProgrammingBook/contents/)
 * [Using Concurrency and Parallelism Effectively – I](http://bookboon.com/en/using-concurrency-and-parallelism-effectively-i-ebook) - Jon Kerridge (PDF) (email address *requested*, not required)
 * [Using Concurrency and Parallelism Effectively – II](http://bookboon.com/en/using-concurrency-and-parallelism-effectively-ii-ebook) - Jon
 


### PR DESCRIPTION
## What does this PR do?
Updates Resource

## For resources
The OpenCL Programming Book

### Why is this valuable (or not)
This pull request fixes a broken link for the book The OpenCL Programming Book as noted in issue #3244

### How do we know it's really free?
The book has a free html version which the link points to and I imagine also previously pointed to.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
