### PR TITLE
Removed Swedish MATLAB PDF due to link rot

### DIFF
--- a/free-programming-books-se.md
+++ b/free-programming-books-se.md
@@ -2,7 +2,6 @@
 
 * [C](#c)
 * [C++](#c-1)
-* [MATLAB](#matlab)
 * [PHP](#php)
 
 
@@ -14,11 +13,6 @@
 ### C++
 
 * [Programmera spel i C++ för nybörjare](https://sv.wikibooks.org/wiki/Programmera_spel_i_C%2B%2B_f%C3%B6r_nyb%C3%B6rjare) - Wikibooks
-
-
-### MATLAB
-
-* [Introduktion till MATLAB](https://www.liber.se/plus/E470523401.pdf) (PDF)
 
 
 ### PHP


### PR DESCRIPTION
## What does this PR do?
 Remove Resource

## For resources
### Description 
Link Rot: The Swedish MATLAB PDF resource was unreachable and the server was indicating that the content no longer existed.
