### PR TITLE
Update URL for "Welcome to Java for Python Programmers"

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1464,7 +1464,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [The Java EE7 Tutorial](https://docs.oracle.com/javaee/7/JEETT.pdf) - Eric Jendrock, et al (PDF)
 * [The Java Tutorials](https://docs.oracle.com/javase/tutorial/index.html)
 * [Think Java: How to Think Like a Computer Scientist](http://greenteapress.com/thinkapjava/) - Allen B. Downey and Chris Mayfield
-* [Welcome to Java for Python Programmers](https://interactivepython.org/runestone/static/java4python/index.html) - Brad Miller
+* [Welcome to Java for Python Programmers](https://runestone.academy/runestone/books/published/java4python/index.html) - Brad Miller
 * [Welcome to the Java Workshop (2006)](http://javaworkshop.sourceforge.net) - Trevor Miller
 
 


### PR DESCRIPTION
## What does this PR do?
Provides an up to date URL for the "Welcome to Java for Python Programmers" by Brad Miller. When loading the book recently, the former URL generated a certificate warning based on a mis-matched domain. I was able to construct a new URL based on the domain of the cert and path in the original URL.

## For resources
### Description
Nothing exciting, just updating the link to an already listed work.

### Why is this valuable (or not)
When users see security warnings, particularly when they say things like "Attackers might be trying to steal your information from interactivepython.org (for example, passwords, messages, or credit cards)." they likely wonder if the site is safe to continue. It's better to provide up to date, secure links to resources so that users can be confident in the content being safe.

### How do we know it's really free?
It was already listed, this is just an update.

### For book lists, is it a book?
Yep, already listed.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
