### PR TITLE
Improve Typescript on free-programming-books-ja.md

### DIFF
--- a/free-programming-books-ja.md
+++ b/free-programming-books-ja.md
@@ -642,6 +642,7 @@
 
 ### TypeScript
 
+* [TypeScript Deep Dive 日本語版](https://typescript-jp.gitbook.io/deep-dive/) - yohamta, basarat
 * [TypeScript クイックガイド](http://phyzkit.net/typescript/) - @KDKTN
 
 

--- a/free-programming-books-ja.md
+++ b/free-programming-books-ja.md
@@ -643,6 +643,7 @@
 ### TypeScript
 
 * [TypeScript Deep Dive 日本語版](https://typescript-jp.gitbook.io/deep-dive/) - yohamta, basarat
+* [TypeScriptの為のクリーンコード](https://msakamaki.github.io/clean-code-typescript/) - labs42io, 酒巻 瑞穂(翻訳)
 
 
 ### VBA

--- a/free-programming-books-ja.md
+++ b/free-programming-books-ja.md
@@ -642,7 +642,7 @@
 
 ### TypeScript
 
-* [TypeScript Deep Dive 日本語版](https://typescript-jp.gitbook.io/deep-dive/) - yohamta, basarat
+* [TypeScript Deep Dive 日本語版](https://typescript-jp.gitbook.io/deep-dive/) - basarat, yohamta(翻訳)
 * [TypeScriptの為のクリーンコード](https://msakamaki.github.io/clean-code-typescript/) - labs42io, 酒巻 瑞穂(翻訳)
 
 

--- a/free-programming-books-ja.md
+++ b/free-programming-books-ja.md
@@ -643,7 +643,6 @@
 ### TypeScript
 
 * [TypeScript Deep Dive 日本語版](https://typescript-jp.gitbook.io/deep-dive/) - yohamta, basarat
-* [TypeScript クイックガイド](http://phyzkit.net/typescript/) - @KDKTN
 
 
 ### VBA


### PR DESCRIPTION
## What does this PR do?
Add Resources | Remove Resource

## For resources
### Description 

- Add TypeScript Deep Dive Japanese version
  - https://github.com/yohamta/typescript-book-jp/
- Add clean-code-typescript Japanese version
   - https://github.com/MSakamaki/clean-code-typescript
- Remove TypeScript quick guide
  - Because the contents were deleted

### Why is this valuable (or not)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
