### PR TITLE
Added italian book - Immersione in Python 3

### DIFF
--- a/free-programming-books-it.md
+++ b/free-programming-books-it.md
@@ -212,9 +212,9 @@
 
 * [Il manuale di riferimento di Python](http://docs.python.it/html/ref/)
 * [Il tutorial di Python](http://docs.python.it/html/tut/)
+* [Immersione in Python 3](http://gpiancastelli.altervista.org/dip3-it/) - Mark Pilgrim, _traduzione di: Giulio Piancastelli_ (HTML) [(PDF)](http://gpiancastelli.altervista.org/dip3-it/d/diveintopython3-it-pdf-latest.zip)
 * [La libreria di riferimento di Python](http://docs.python.it/html/lib/)
 * [Pensare da Informatico, Versione Python](http://www.python.it/doc/Howtothink/Howtothink-html-it/index.htm)
-* [Immersione in Python 3](http://gpiancastelli.altervista.org/dip3-it/) - Mark Pilgrim, _traduzione di: Giulio Piancastelli_ (HTML) [(PDF)](http://gpiancastelli.altervista.org/dip3-it/d/diveintopython3-it-pdf-latest.zip)
 
 
 #### Django

--- a/free-programming-books-it.md
+++ b/free-programming-books-it.md
@@ -214,6 +214,7 @@
 * [Il tutorial di Python](http://docs.python.it/html/tut/)
 * [La libreria di riferimento di Python](http://docs.python.it/html/lib/)
 * [Pensare da Informatico, Versione Python](http://www.python.it/doc/Howtothink/Howtothink-html-it/index.htm)
+* [Immersione in Python 3](http://gpiancastelli.altervista.org/dip3-it/) - Mark Pilgrim, _traduzione di: Giulio Piancastelli_ (HTML) [(PDF)](http://gpiancastelli.altervista.org/dip3-it/d/diveintopython3-it-pdf-latest.zip)
 
 
 #### Django


### PR DESCRIPTION
## What does this PR do?
Added "Immersione in Python 3" to the list of free italian books on python

### Why is this valuable
This is a accurate translation and revision of the book  'Dive into python' by Mark Pilgrim made by Giulio Piancastelli and analyzes the differences between python 2 and python 3. Python 2 is still widely used today and this resource can be useful for Italian only speakers who wants to make the transition to python 3.

### How do we know it's really free?
On the official site the license can be clearly found on the bottom stated as CC BY-SA 3.0, also this book translation is listed on the official italian python site as a resource.

### Links
I used the official site link for the HTML version. The PDF version links to the generic 'latest' version so any future revision should be included without the need of URL updating.

### Checklist:
- [X] Not a duplicate
- [X] Included author(s) if appropriate
- [X] Lists are in alphabetical order
- [X] Needed indications added (PDF, access notes, under construction)
