### PR TITLE
Update free-programming-books-fr.md

### DIFF
--- a/free-programming-books-fr.md
+++ b/free-programming-books-fr.md
@@ -200,7 +200,7 @@
 ### Meteor
 
 * [Apprendre Meteor](https://mquandalle.gitbooks.io/apprendre-meteor/content/) - Maxime Quandalle
-* [Discover Meteor](http://fr.discovermeteor.com) - Tom Coleman et Sacha Greif
+* [Discover Meteor (Un lien Wayback Machine)](https://web.archive.org/web/20180207124731/http://fr.discovermeteor.com/) - Tom Coleman et Sacha Greif
 
 
 ### Perl

--- a/free-programming-books-fr.md
+++ b/free-programming-books-fr.md
@@ -200,7 +200,6 @@
 ### Meteor
 
 * [Apprendre Meteor](https://mquandalle.gitbooks.io/apprendre-meteor/content/) - Maxime Quandalle
-* [Discover Meteor (Un lien Wayback Machine)](https://web.archive.org/web/20180207124731/http://fr.discovermeteor.com/) - Tom Coleman et Sacha Greif
 
 
 ### Perl


### PR DESCRIPTION
Changed Meteor link to a Wayback Machine link.

## What does this PR do?
Improve Repo

## For resources
### Description 
Fixed issue #3276 . The link now works now. Also there is a small message in French that indicates it is a Wayback Machine link.
### Why is this valuable (or not)
It fixes the dead link.
### How do we know it's really free?
Because it's the same link, but through Wayback Machine, as it is currently in maintenance.
### For book lists, is it a book?

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
