### PR TITLE
remove link with error, ruby-ptbr

### DIFF
--- a/free-programming-books-pt_BR.md
+++ b/free-programming-books-pt_BR.md
@@ -1,4 +1,4 @@
-### Índice
+﻿### Índice
 
 * [Android](#android)
 * [C](#c)
@@ -256,7 +256,6 @@
 ### Ruby
 
 * [Aprenda a Programar](http://www.jmonteiro.com/aprendaaprogramar/)
-* [Conhecendo Ruby](http://howtocode.com.br/ebooks/ruby)
 * [Conhecendo Ruby - Eustaquio Rangel](https://leanpub.com/conhecendo-ruby/read)
 * [O (comovente) guia de Ruby do Why](http://why.carlosbrando.com)
 * [Ruby on Rails - Desenv. Ágil para Web com Ruby on Rails](http://www.caelum.com.br/apostila-ruby-on-rails/) - Caelum


### PR DESCRIPTION
## What does this PR do?
Remove link with error:
* [Conhecendo Ruby](http://howtocode.com.br/ebooks/ruby)
books ptBR

## For resources
### Description 

### Why is this valuable (or not)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
