### PR TITLE
Normalize udacity listings

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -135,7 +135,7 @@
 
 ### Cuda
 
-* [Intro to Parallel Programming Using CUDA to Harness the Power of GPUs](https://www.udacity.com/course/intro-to-parallel-programming--cs344)
+* [Intro to Parallel Programming Using CUDA to Harness the Power of GPUs](https://www.udacity.com/course/intro-to-parallel-programming--cs344) (Udacity)
 
 
 ### Data Science
@@ -161,7 +161,7 @@
 * [Practical Deep Learning For Coders taught](http://www.fast.ai) - Jeremy Howard
 * [Self-Paced Courses for Deep Learning](https://developer.nvidia.com/deep-learning-courses)
 * [Unsupervised Feature Learning and Deep Learning](http://deeplearning.stanford.edu/tutorial)
-* [What is Deep Learning](https://www.udacity.com/course/deep-learning--ud730)
+* [What is Deep Learning](https://www.udacity.com/course/deep-learning--ud730) (Udacity)
 
 
 ### Git
@@ -222,7 +222,7 @@
 * [Object-Oriented programming with Java, part II](https://moocfi.github.io/courses/2013/programming-part-2/)
 * [Princeton Algorithms, Part 1](https://www.coursera.org/course/algs4partI)
 * [Princeton Algorithms, Part 2](https://www.coursera.org/course/algs4partII)
-* [Problem Solving With Java](https://www.udacity.com/course/intro-to-java-programming--cs046)
+* [Problem Solving With Java](https://www.udacity.com/course/intro-to-java-programming--cs046) (Udacity)
 * [Spring 5 Core - An Ultimate Guide](https://www.udemy.com/learn-spring-5-core-from-scratch/) - Somnath Musib (Udemy)
 
 
@@ -431,7 +431,7 @@
 ### Theory
 
 * [Automata Theory](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+Fall2016/about)
-* [Udacity: Intro to Theoretical Computer Science](https://www.udacity.com/course/intro-to-theoretical-computer-science--cs313)
+* [Intro to Theoretical Computer Science](https://www.udacity.com/course/intro-to-theoretical-computer-science--cs313) (Udacity)
 
 
 ### TypeScript


### PR DESCRIPTION


## What does this PR do?
Some of our Udacity listings added '(Udacity)' as and access note. This PR makes the practice uniform. We can consider other platforms case by case. In general, I feel that when the platform offers additional services that make it matter what platform a course is on, the addition of an access note is useful.

Comments welcome on appropriateness of  the access notes. Will leave this PR open for comment for a week.

### Checklist:
- [ x] Not a duplicate
- [x ] Included author(s) if appropriate
- [x ] Lists are in alphabetical order
- [x ] Needed indications added (PDF, access notes, under construction)

