### PR TITLE
fix: ng-newsletter angular tutorial link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1549,7 +1549,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 #### Angular.js
 
-* [Angular for the jQuery developer](http://www.ng-newsletter.com/posts/angular-for-the-jquery-developer.html)
+* [Angular for the jQuery developer](http://www.ng-newsletter.com.s3-website-us-east-1.amazonaws.com/posts/angular-for-the-jquery-developer.html)
 * [Angular.js Guide](https://docs.angularjs.org/guide/)
 * [Angular.js Material Designing](https://material.angularjs.org/latest/)
 * [Angular.js Tutorial](https://docs.angularjs.org/tutorial)


### PR DESCRIPTION
## What does this PR do?
Fix broken resource, addresses #3400 

## For resources
### Description 
Current ng-newsletter link results in a 500 page. Found an alternate link, but I suspect it is temporary until the newsletter fixes their 500, so we may not want to update the link.

### Why is this valuable (or not)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
