### PR TITLE
Add The Craft of Programming for #2999

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -774,6 +774,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Structure and Interpretation of Computer Programs](https://mitpress.mit.edu/sicp/)
 * [Structure and Interpretation of Computer Programs](http://sarabander.github.io/sicp/html/index.xhtml)
 * [The Black Art of Programming](http://self.gutenberg.org/wplbn0002828847-the-black-art-of-programming-by-mcilroy-mark.aspx?) - Mark McIlroy
+* [The Craft of Programming](https://kilthub.cmu.edu/articles/The_Craft_of_Programming/6610514) - John C. Reynolds
 * [Think Complexity](http://www.greenteapress.com/compmod/) - Allen B. Downey
 
 


### PR DESCRIPTION
## What does this PR do?
Add Resource - The Craft of Programming

## For resources
### Description 
From https://www.cs.cmu.edu/~jcr/craftprog.html:
This is a textbook on programming with emphasis on specification and proof of programs. It is now out of print, and all rights have reverted to the author, who has decided to make it publicly available.

### Why is this valuable (or not)
It's a CS textbook hosted on CMU's site and the description provided seems like it would be a valuable resource. also requested by #2999

### How do we know it's really free?
Rights provided in description at https://www.cs.cmu.edu/~jcr/craftprog.html

### For book lists, is it a book?
Yes

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
