### PR TITLE
Update a Java book URL - #2990

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1455,7 +1455,6 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Neural Network Development with Java](https://www.packtpub.com/packt/free-ebook/neural-networks-java) - Alan M. F. Souza and Fabio M. Soares (email address *requested*, not required)
 * [Object-Oriented Programming in JavaTM Textbook](http://computing.southern.edu/halterman/OOPJ/) - Rick Halterman (PDF per Chapter)
 * [Object Oriented Programming using Java](https://bookboon.com/en/object-oriented-programming-using-java-ebook) - Simon Kendal (PDF) , Bookboon. (email address *requested*, not required)
-* [Object-Oriented vs. Functional Programming](https://pepa.holla.cz/wp-content/uploads/2016/10/object-oriented-vs-functional-programming.pdf) - Richard Warburton (PDF) (email address *requested*, not required)
 * [OOP - Learn Object Oriented Thinking & Programming](http://pub.bruckner.cz/titles/oop) - Rudolf Pecinovsky (PDF)
 * [Open Data Structures (in Java)](http://opendatastructures.org/ods-java.pdf) - Pat Morin (PDF)
 * [Processing XML with Java (A Guide to SAX, DOM, JDOM, JAXP, and TrAX) (2002)](http://www.cafeconleche.org/books/xmljava/) - Elliotte Rusty Harold

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1455,7 +1455,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Neural Network Development with Java](https://www.packtpub.com/packt/free-ebook/neural-networks-java) - Alan M. F. Souza and Fabio M. Soares (email address *requested*, not required)
 * [Object-Oriented Programming in JavaTM Textbook](http://computing.southern.edu/halterman/OOPJ/) - Rick Halterman (PDF per Chapter)
 * [Object Oriented Programming using Java](https://bookboon.com/en/object-oriented-programming-using-java-ebook) - Simon Kendal (PDF) , Bookboon. (email address *requested*, not required)
-* [Object-Oriented vs. Functional Programming](http://www.oreilly.com/programming/free/object-oriented-vs-functional-programming.csp) - Richard Warburton (email address *requested*, not required)
+* [Object-Oriented vs. Functional Programming](https://pepa.holla.cz/wp-content/uploads/2016/10/object-oriented-vs-functional-programming.pdf) - Richard Warburton (PDF) (email address *requested*, not required)
 * [OOP - Learn Object Oriented Thinking & Programming](http://pub.bruckner.cz/titles/oop) - Rudolf Pecinovsky (PDF)
 * [Open Data Structures (in Java)](http://opendatastructures.org/ods-java.pdf) - Pat Morin (PDF)
 * [Processing XML with Java (A Guide to SAX, DOM, JDOM, JAXP, and TrAX) (2002)](http://www.cafeconleche.org/books/xmljava/) - Elliotte Rusty Harold


### PR DESCRIPTION
Changes:
- The book 'Object-Oriented vs. Functional Programming' has a .csp link
- Also a sign-up is required to read the book since it's hosted at oreilly.com
- The contributing guide is against a hosting service and required sign-up.
- That is why this PR is created.

## What does this PR do?
Update Resource(s)

## For resources
### Description 

### Why is this valuable (or not)
The .csp link is replaced with .pdf link.
Also sign-up is avoided to read .csp page.

### How do we know it's really free?
The pdf is downloaded free and verified for correct content.

### For book lists, is it a book?
Yes

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [x ] Needed indications added (PDF, access notes, under construction)
