### PR TITLE
Updated Ruby User's Guide link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2336,7 +2336,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Ruby Koans](http://www.rubykoans.com)
 * [Ruby Learning](http://rubylearning.com)
 * [Ruby Programming](http://www.linuxtopia.org/online_books/programming_books/ruby_tutorial/)
-* [Ruby User's Guide](http://www.rubyist.net/~slagell/ruby/)
+* [Ruby User's Guide](https://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/index.html)
 * [Ruby Web Dev: The Other Way](https://leanpub.com/rwdtow/read) - Yevhen Kuzminov
 * [Rubyfu](https://rubyfu.net)
 * [The Bastards Book of Ruby](http://ruby.bastardsbook.com)


### PR DESCRIPTION
## What does this PR do?
Improve Repo

Ruby User's Guide was pointing to a "Page not found" location (as described in issue #3448 ) but ruby-doc.org hosts almost 1:1 version of that same document so I updated the link to point there.