### PR TITLE
Added Snap! Reference Manual

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -196,7 +196,7 @@
 * [Sed](#sed)
 * [Self](#self)
 * [Smalltalk](#smalltalk)
-* [Snap&#33;](#snap&#33;)
+* [Snap&#33;](#snap)
 * [Spark](#spark)
 * [SQL (implementation agnostic)](#sql-implementation-agnostic)
 * [SQL Server](#sql-server)

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -196,7 +196,7 @@
 * [Sed](#sed)
 * [Self](#self)
 * [Smalltalk](#smalltalk)
-* [Snap&#33;](#snap)
+* [Snap](#snap)
 * [Spark](#spark)
 * [SQL (implementation agnostic)](#sql-implementation-agnostic)
 * [SQL Server](#sql-server)
@@ -2479,7 +2479,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Stef's Free Online Smalltalk Books](http://stephane.ducasse.free.fr/FreeBooks.html) (meta-list)
 
 
-### Snap&#33;
+### Snap
 
 * [Snap! Reference Manual](https://snap.berkeley.edu/snapsource/help/SnapManual.pdf) - B. Harvey, J. Mönig (PDF)
 

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -196,6 +196,7 @@
 * [Sed](#sed)
 * [Self](#self)
 * [Smalltalk](#smalltalk)
+* [Snap&#33;](#snap&#33;)
 * [Spark](#spark)
 * [SQL (implementation agnostic)](#sql-implementation-agnostic)
 * [SQL Server](#sql-server)
@@ -2476,6 +2477,11 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Pharo by Example](http://books.pharo.org/pharo-by-example/) (Smalltalk Implementation and IDE)
 * [Squeak By Example](http://www.squeakbyexample.org) (Smalltalk Implementation and IDE)
 * [Stef's Free Online Smalltalk Books](http://stephane.ducasse.free.fr/FreeBooks.html) (meta-list)
+
+
+### Snap&#33;
+
+* [Snap! Reference Manual](https://snap.berkeley.edu/snapsource/help/SnapManual.pdf) - B. Harvey, J. Mönig (PDF)
 
 
 ### Spark


### PR DESCRIPTION
## What does this PR do?
Add Resource(s)

## For resources
### Description 
Added reference manual for programming language Snap!

### Why is this valuable (or not)
There were no Snap! books in the repo previously.

### How do we know it's really free?
It's available directly on the Snap! official website. Snap! has the license GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007

### For book lists, is it a book?
Yes

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
