### PR TITLE
Added StackBlitz under Angular in free-programming-playgrounds page

### DIFF
--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -28,6 +28,8 @@
 ### Angular
 
 * [Plunker](http://plnkr.co)
+* [StackBlitz](https://stackblitz.com/)
+
 
 
 ### ClojureScript

--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -31,7 +31,6 @@
 * [StackBlitz](https://stackblitz.com/)
 
 
-
 ### ClojureScript
 
 * [Web REPL](http://clojurescript.net)


### PR DESCRIPTION
## What does this PR do?
Add Resource(s) 

### Why is this valuable (or not)

StackBlitz is a free online code editor for Angular. This is not included in the existing link.



