### PR TITLE
O'Reilly Commons doesn't exist anymore

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -245,7 +245,6 @@
 * [Microsoft Technologies 1, including books on Windows Azure, SharePoint, Visual Studio Guide, Windows phone development, ASP.net, Office365, etc. collection by Eric Ligman](https://blogs.msdn.microsoft.com/mssmallbiz/2012/07/27/large-collection-of-free-microsoft-ebooks-for-you-including-sharepoint-visual-studio-windows-phone-windows-8-office-365-office-2010-sql-server-2012-azure-and-more/)
 * [Microsoft Technologies 2, including books on Windows Azure, SharePoint, Visual Studio Guide, Windows phone development, ASP.net, etc. collection by Eric Ligman](https://blogs.msdn.microsoft.com/mssmallbiz/2012/07/30/another-large-collection-of-free-microsoft-ebooks-and-resource-kits-for-you-including-sharepoint-2013-office-2013-office-365-duet-2-0-azure-cloud-windows-phone-lync-dynamics-crm-and-more/)
 * [Microsoft Technologies 3, including books on Windows Azure, SharePoint, Visual Studio Guide, Windows phone development, ASP.net, etc. collection by Eric Ligman](https://blogs.msdn.microsoft.com/mssmallbiz/2017/07/11/largest-free-microsoft-ebook-giveaway-im-giving-away-millions-of-free-microsoft-ebooks-again-including-windows-10-office-365-office-2016-power-bi-azure-windows-8-1-office-2013-sharepo/)
-* [O'Reilly's Commons](http://commons.oreilly.com/wiki/index.php/O%27Reilly_Commons)
 * [O'Reilly's Open Books Project](http://www.oreilly.com/openbook/)
 * [Papers we love](https://github.com/papers-we-love/papers-we-love)
 * [Programming](https://en.wikibooks.org/wiki/Category%3aComputer_programming) - Wikibooks


### PR DESCRIPTION
## What does this PR do?
Remove Resource(s)

## For resources
### Description 
Removed the link to O'Reilly Commons because it doesn't exist anymore.

### Why is this valuable (or not)
It doesn't make sense to link to a resource that doesn't exist anymore and routes the user to an unrelated page (https://www.oreilly.com/ideas)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
