### PR TITLE
Changed a 404 link to Archive.org

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2665,5 +2665,5 @@ Kerridge (PDF) (email address *requested*, not required)
 ### xBase (dBase / Clipper / Harbour)
 
 * [Application Development with Harbour](https://en.wikibooks.org/wiki/Application_Development_with_Harbour) - Wikibooks
-* [CA-Clipper 5.2 Norton Guide](http://www.ousob.com/ng/clguide/)
+* [CA-Clipper 5.2 Norton Guide](https://web.archive.org/web/20190516192814/http://www.ousob.com/ng/clguide/)
 * [Clipper Tutorial: a Guide to Open Source Clipper(s)](https://en.wikibooks.org/wiki/Clipper_Tutorial%3A_a_Guide_to_Open_Source_Clipper(s)) - Wikibooks


### PR DESCRIPTION
## What does this PR do?
Improve Repo

## For resources
### Description 
CA-Clipper 5.2 Norton Guide is not available anymore since last May, according to Archive.org and the nameserver changes made at the time. I changed the link to point to the latest archived page which seems to have quite good coverage.

### Why is this valuable (or not)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
