### PR TITLE
Added an Archive.org link for a missing book

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -304,7 +304,7 @@
 * [CS Unplugged: Computer Science without a computer](http://csunplugged.org/books/)
 * [Data Structures](http://www.cse.iitd.ernet.in/~suban/cs130/index.html) - Prof. Subhashis Banerjee, IIT Delhi
 * [Data Structures (Into Java) - Paul N. Hilfinger](http://www-inst.eecs.berkeley.edu/~cs61b/fa14/book2/data-structures.pdf) (PDF)
-* [Data Structures and Algorithms: Annotated Reference with Examples](http://lib.mdp.ac.id/ebook/Karya%20Umum/Dsa.pdf) - G. Barnett and L. Del Tongo (PDF)
+* [Data Structures and Algorithms: Annotated Reference with Examples](https://web.archive.org/web/20170715160229/http://dotnetslackers.com/Community/files/folders/data-structures-and-algorithms/entry30283.aspx) - G. Barnett and L. Del Tongo
 * [Data Structures Succinctly Part 1, Syncfusion](https://www.syncfusion.com/resources/techportal/ebooks/datastructurespart1) (PDF, Kindle) (email address *requested*, not required)
 * [Data Structures Succinctly Part 2, Syncfusion](https://www.syncfusion.com/resources/techportal/ebooks/datastructurespart2) (PDF, Kindle) (email address *requested*, not required)
 * [Elementary Algorithms](https://github.com/liuxinyu95/AlgoXY) - Larry LIU Xinyu


### PR DESCRIPTION
## What does this PR do?
Improve Repo

## For resources
### Description 
The previous link for _Data Structures and Algorithms: Annotated Reference with Examples_ doesn't work anymore so I updated it to point to the original page on archive.org. The book PDF has also been scraped by archive.org so the download link works.

I was able to find another direct link to the PDF on the same domain as the previous link (mdp.ac.id) but that seems to be a very random source (Indonesian school or education portal, can't tell for sure) not related to the original book at all. Since one of the first pages in the book mentions that it's exclusively published on dotnetslackers.com, I think it's fair game to keep the original site as the download page.

### Why is this valuable (or not)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
