### PR TITLE
Cellular automata books list has moved

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -331,7 +331,7 @@
 #### Cellular Automata
 
 * [A New Kind of Science](https://www.wolframscience.com/nksonline/toc.html) - Stephen Wolfram
-* [Cellular Automata Books](http://uncomp.uwe.ac.uk/genaro/Cellular_Automata_Repository/Books.html)
+* [Cellular Automata Books](http://www.comunidad.escom.ipn.mx/genaro/Cellular_Automata_Repository/Books.html)
 
 
 #### Cloud Computing


### PR DESCRIPTION
## What does this PR do?
Improve Repo

## For resources
### Description 
The original link to the cellular automata books list leads to a _not found_ page. Going to the root page (https://uncomp.uwe.ac.uk/genaro) shows that the site has moved. The same exact list (and the rest of the site it seems) can be found at the new location.

### Why is this valuable (or not)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
