### PR TITLE
Two O'Reillys books removed

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -385,7 +385,6 @@
 
 #### Database
 
-* [Big Data Now: Current Perspectives from O'Reilly Radar](http://shop.oreilly.com/product/0636920022640.do)
 * [Database Explorations](http://www.dcs.warwick.ac.uk/~hugh/TTM/Database-Explorations-revision-2.pdf) (PDF)
 * [Database Fundamentals](http://public.dhe.ibm.com/software/dw/db2/express-c/wiki/Database_fundamentals.pdf) (PDF)
 * [Databases, Types, and The Relational Model: The Third Manifesto](http://www.dcs.warwick.ac.uk/~hugh/TTM/DTATRM.pdf) (PDF)
@@ -393,7 +392,6 @@
 * [Readings in Database Systems, 5th Ed.](http://www.redbook.io)
 * [Temporal Database Management](http://people.cs.aau.dk/~csj/Thesis/) - Christian S. Jensen
 * [The Theory of Relational Databases](http://web.cecs.pdx.edu/~maier/TheoryBook/TRD.html)
-* [What is Database Design, Anyway?](http://www.oreilly.com/data/free/what-is-database-design-anyway.csp)
 
 
 #### Datamining


### PR DESCRIPTION
## What does this PR do?
Remove Resource(s)

## For resources
### Description 
Sadly, O'Reilly seems to put some of the previously free books behind a paywall (Safari). Two DB books got this treatment and should be removed since they're not legally available for free anymore.

### Why is this valuable (or not)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
