### PR TITLE
Differential Equations link fixed

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -461,7 +461,7 @@
 * [Computational and Inferential Thinking. The Foundations of Data Science](https://www.inferentialthinking.com)
 * [Computational Geometry](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/)
 * [Concepts & Applications of Inferential Statistics](http://vassarstats.net/textbook/)
-* [Differential Equations](http://tutorial.math.lamar.edu/download.aspx) - Paul Dawkins (PDF, use form to download)
+* [Differential Equations](http://tutorial.math.lamar.edu/Classes/DE/DE.aspx) - Paul Dawkins (PDF, use download menu to download)
 * [Elementary Differential Equations](http://ramanujan.math.trinity.edu/wtrench/texts/TRENCH_DIFF_EQNS_I.PDF) - William F. Trench (PDF)
 * [Essentials of Metaheuristics](http://cs.gmu.edu/~sean/book/metaheuristics/) - Sean Luke
 * [Graph Theory](http://compalg.inf.elte.hu/~tony/Oktatas/TDK/FINAL/)


### PR DESCRIPTION
## What does this PR do?
Improve Repo

## For resources
### Description 
The original download link doesn't work anymore and the best way to download the PDF is to go to the new link and click the download link in the download menu. There IS a direct download link provided by the site (http://tutorial.math.lamar.edu/GetFile.aspx?file=B,1,N) but interestingly enough, it leads to a page that claims it's been moved and that the new link is exactly the same. 

I figured that this solution is the least confusing for the users.

### Why is this valuable (or not)

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
