### PR TITLE
Updated the missing APL books

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -841,8 +841,8 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### APL
 
-* [A Practical Introduction to APL1 & APL2](http://aplwiki.com/BooksAndPublications#A_Practical_Introduction_to_APL1_.26_APL2)
-* [A Practical Introduction to APL3 & APL4](http://aplwiki.com/BooksAndPublications#A_Practical_Introduction_to_APL3_.26_APL4)
+* [A Practical Introduction to APL1 & APL2](http://robertson.uk.net/) - Graeme Donald Robertson (PDF)
+* [A Practical Introduction to APL3 & APL4](http://robertson.uk.net/) - Graeme Donald Robertson (PDF)
 * [Mastering Dyalog APL](http://www.dyalog.com/mastering-dyalog-apl.htm) (PDF)
 
 

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -841,8 +841,8 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### APL
 
-* [A Practical Introduction to APL1 & APL2](http://robertson.uk.net/) - Graeme Donald Robertson (PDF)
-* [A Practical Introduction to APL3 & APL4](http://robertson.uk.net/) - Graeme Donald Robertson (PDF)
+* [A Practical Introduction to APL1 & APL2](http://robertson.uk.net) - Graeme Donald Robertson (PDF)
+* [A Practical Introduction to APL3 & APL4](http://robertson.uk.net) - Graeme Donald Robertson (PDF)
 * [Mastering Dyalog APL](http://www.dyalog.com/mastering-dyalog-apl.htm) (PDF)
 
 


### PR DESCRIPTION
## What does this PR do?
Improve Repo

## For resources
### Description 
Fixes the issue #3479, the two APL books missing from APLWiki are still hosted on author's personal website.

### Why is this valuable (or not)

### How do we know it's really free?
It's the authors personal website

### For book lists, is it a book?

### Checklist:
- [X] Not a duplicate
- [X] Included author(s) if appropriate
- [X] Lists are in alphabetical order
- [X] Needed indications added (PDF, access notes, under construction)
