### PR TITLE
Update free-programming-playgrounds.md

### DIFF
--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -141,6 +141,7 @@
 * [CodeSandbox.io](https://codesandbox.io)
 * [StackBlitz](https://stackblitz.com/fork/react)
 
+
 ### Ruby
 
 * [Codepad](http://codepad.org)

--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -9,6 +9,7 @@
 * [Go](#go)
 * [Haskell](#haskell)
 * [Ionic](#ionic)
+* [Java](#java)
 * [JavaScript](#javascript)
 * [Kotlin](#kotlin)
 * [.Net](#dotnet)
@@ -76,11 +77,14 @@
 
 * [StackBlitz](https://stackblitz.com/fork/ionic)
 
+### Java
+
+* [repl.it](https://repl.it) (_including a separate Java/Swing_)
 
 ### JavaScript
 
 * [CodePen](https://codepen.io)
-* [CodeSandbox.io](https://codesandbox.io) (_React_)
+* [CodeSandbox.io](https://codesandbox.io)
 * [JSBin](http://jsbin.com)
 * [JSFiddle](http://jsfiddle.net)
 * [Plunker](http://plnkr.co)
@@ -132,8 +136,8 @@
 
 ### React
 
+* [CodeSandbox.io](https://codesandbox.io)
 * [StackBlitz](https://stackblitz.com/fork/react)
-
 
 ### Ruby
 

--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -77,9 +77,11 @@
 
 * [StackBlitz](https://stackblitz.com/fork/ionic)
 
+
 ### Java
 
 * [repl.it](https://repl.it) (_including a separate Java/Swing_)
+
 
 ### JavaScript
 
@@ -181,3 +183,4 @@
 
 * [Playground](https://www.typescriptlang.org/play/index.html)
 * [StackBlitz](https://stackblitz.com/fork/typescript)
+


### PR DESCRIPTION
Added codesandbox.io under React (and removed the react reference from its listing on JavaScript).
Added a Java section and linked to repl.it
repl.it actually has sandboxes for most of the languages listed here, and maybe some others, but I didn't add them all in. The Swing support for Java is new, and has some bugs. They didn't respond to my report, so I think they are spread a little thin.

## What does this PR do?
Add Resource(s) [repl.it], Improve Repo [copied codesandbox.io to #react]

## For resources
### Description 

### Why is this valuable (or not)

### How do we know it's really free?
I have used both codesandbox and repl.it

### For book lists, is it a book?

### Checklist:
- [x ] Not a duplicate
- [x ] Included author(s) if appropriate
- [x ] Lists are in alphabetical order
- [x ] Needed indications added (PDF, access notes, under construction)
