### PR TITLE
Replaced broken Automata Theory English Stanford course link

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -436,7 +436,7 @@
 
 ### Theory
 
-* [Automata Theory](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+Fall2016/about)
+* [Automata Theory](https://online.stanford.edu/courses/soe-ycsautomata-automata-theory)
 * [Intro to Theoretical Computer Science](https://www.udacity.com/course/intro-to-theoretical-computer-science--cs313) (Udacity)
 
 


### PR DESCRIPTION
## What does this PR do?
Improve Repo

Fixed broken link to the Stanford online English course "Automata Theory".

Previously used link was redirected to the Lagunita Learning Platform info page instead of a course page. The course is still present on a different link that can be found from there via courses list, it's also still free.