### PR TITLE
Added Comprehensive Python Cheatsheet to the Python section

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2206,6 +2206,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Code Like a Pythonista: Idiomatic Python](https://web.archive.org/web/20180411011411/http://python.net/~goodger/projects/pycon/2007/idiomatic/handout.html) - David Goodger
 * [CodeCademy Python](https://www.codecademy.com/learn/python)
 * [Composing Programs](http://composingprograms.com) (3.x)
+* [Comprehensive Python Cheatsheet](https://gto76.github.io/python-cheatsheet) - Jure Šorn (HTML) (3.7)
 * [Cracking Codes with Python](http://inventwithpython.com/cracking/) - Al Sweigart
 * [Data Structures and Algorithms in Python](https://web.archive.org/web/20161016153130/http://www.brpreiss.com/books/opus7/html/book.html) - B. R. Preiss (PDF)
 * [Dive into Python 3](https://diveintopython3.problemsolving.io) - Mark Pilgrim (3.0)


### PR DESCRIPTION
## What does this PR do?
Add Resource

## For resources
### Description 
**[Comprehensive Python Cheatsheet](https://gto76.github.io/python-cheatsheet)** is a Python language reference that strives to be comprehensive while being as concise as possible. 

### Why is this valuable (or not)
* Its conciseness enables it to also probe into deeper topics like coroutines, metaprogramming, and also some fun ones like audio and games while being just 50 pages long.
* Brian Kernighan thinks it's a "very helpful cheat sheet, quite long": https://www.cs.princeton.edu/courses/archive/spring19/cos333/python.help

### How do we know it's really free?
The HTML is really free: https://gto76.github.io/python-cheatsheet
but the PDF isn't: https://transactions.sendowl.com/products/78175486/4422834F/view

### For book lists, is it a book?
Although it has a "cheatsheet" in the title, being 50 pages long probably makes it more a book.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
