### PR TITLE
Correcting french typo

### DIFF
--- a/free-programming-books-fr.md
+++ b/free-programming-books-fr.md
@@ -63,7 +63,7 @@
 
 #### Logiciels libres
 
-* [Histoires et cultures du libres](http://framabook.org/histoiresetculturesdulibre/)
+* [Histoires et cultures du Libre](http://framabook.org/histoiresetculturesdulibre/)
 * [Option libre. Du bon usage des licences libres](http://framabook.org/optionlibre-dubonusagedeslicenceslibres/) - Jean Benjamin
 * [Produire du logiciel libre](http://framabook.org/produire-du-logiciel-libre-2/) - Karl Fogel
 * [Richard Stallman et la révolution du logiciel libre](http://framabook.org/richard-stallman-et-la-revolution-du-logiciel-libre-2/) - R.M. Stallman, S. Williams et C. Masutti


### PR DESCRIPTION
## What does this PR do?
Improve Repo -> correcting a typo in the french ebooks file

From: Histoires et cultures du **libres**
To: Histoires et cultures du **Libre**

According to the link in the file: https://framabook.org/histoiresetculturesdulibre/

![image](https://user-images.githubusercontent.com/24396771/86517951-7d1bc880-be2d-11ea-8ef4-3453e9a587f7.png)

Currently on the ebook page:

![image](https://user-images.githubusercontent.com/24396771/86517986-b05e5780-be2d-11ea-8d35-6d9701241f9c.png)
