### PR TITLE
Add "Go El Kitabı" to Turkish list

### DIFF
--- a/free-programming-books-tr.md
+++ b/free-programming-books-tr.md
@@ -68,8 +68,8 @@
 
 ### Go
 
+* [Go El Kitabı](https://github.com/umutphp/the-little-go-book) - [Umut Işık](https://github.com/umutphp) tarafından çevirildi. PDF ve ePub halleri [Release](https://github.com/umutphp/the-little-go-book/releases) sayfasından indirilebilir.
 * [Go Turu](https://go-tour-turkish.appspot.com/welcome/1)
-* [Go El Kitabı](https://github.com/umutphp/the-little-go-book) - [Umut Işık](https://github.com/umutphp)
 
 
 ### Html

--- a/free-programming-books-tr.md
+++ b/free-programming-books-tr.md
@@ -68,7 +68,7 @@
 
 ### Go
 
-* [Go El Kitabı](https://github.com/umutphp/the-little-go-book) - [Umut Işık](https://github.com/umutphp) tarafından çevirildi. PDF ve ePub halleri [Release](https://github.com/umutphp/the-little-go-book/releases) sayfasından indirilebilir.
+* [Go El Kitabı](https://github.com/umutphp/the-little-go-book) - Karl Seguin, Umut Işık tarafından çevirildi
 * [Go Turu](https://go-tour-turkish.appspot.com/welcome/1)
 
 

--- a/free-programming-books-tr.md
+++ b/free-programming-books-tr.md
@@ -69,6 +69,7 @@
 ### Go
 
 * [Go Turu](https://go-tour-turkish.appspot.com/welcome/1)
+* [Go El Kitabı](https://github.com/umutphp/the-little-go-book) - [Umut Işık](https://github.com/umutphp)
 
 
 ### Html


### PR DESCRIPTION
## What does this PR do?
Add Resource

## For resources
### Description 
It is the Turkish translation of [The Go Little Book](https://github.com/karlseguin/the-little-go-book) by [Karl Seguin](https://github.com/karlseguin).

### Why is this valuable (or not)
It is a very handy book for starting to learn Go.

### How do we know it's really free?
It is licensed under [Attribution-NonCommercial-ShareAlike 4.0 International](http://creativecommons.org/licenses/by-nc-sa/4.0/).

### For book lists, is it a book?
Yes

### Checklist:
- [ + ] Not a duplicate
- [ + ] Included author(s) if appropriate
- [ + ] Lists are in alphabetical order
- [ + ] Needed indications added (PDF, access notes, under construction)
