### PR TITLE
Fix the Real World OCaml link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1999,7 +1999,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 * [Developing Applications With Objective Caml](http://caml.inria.fr/pub/docs/oreilly-book/)
 * [Functional Programming in OCaml](https://www.cs.cornell.edu/courses/cs3110/2019sp/textbook/) - Michael R. Clarkson
-* [Real World OCaml](https://realworldocaml.org/v1/en/html/)
+* [Real World OCaml](https://dev.realworldocaml.org/toc.html)
 * [Think OCaml](http://greenteapress.com/thinkocaml/index.html) - Allen B. Downey and Nicholas Monje
 * [Unix System Programming in OCaml](http://ocaml.github.io/ocamlunix/) [Github Repo](https://github.com/ocaml/ocamlunix/)
 * [Using, Understanding, and Unraveling The OCaml Language: From Practice to Theory and vice versa](http://pauillac.inria.fr/~remy/cours/appsem/) - Didier Rémy


### PR DESCRIPTION
## What does this PR do?
Improve Repo

### Description 
The current Real World OCaml link returns the 301 Moved Permanently status. The book, however, seems to still be available online. This PR replaces the older obsolete link with the new working one.
