### PR TITLE
Update free-programming-books-ja.md / add JavaScript Primer

### DIFF
--- a/free-programming-books-ja.md
+++ b/free-programming-books-ja.md
@@ -370,6 +370,7 @@
 * [Google JavaScript スタイルガイド](https://w.atwiki.jp/aias-jsstyleguide2/) - Aaron Whyte, Bob Jervis, Dan Pupius, Erik Arvidsson, Fritz Schneider, Robby Walker, aiaswood(翻訳)
 * [JavaScript Garden](http://bonsaiden.github.io/JavaScript-Garden/ja/) - Ivo Wetzel, HIRAKI Satoru(翻訳)
 * [JavaScript Plugin Architecture](https://azu.gitbooks.io/javascript-plugin-architecture/content/) - azu
+* [JavaScript Primer](https://jsprimer.net) - azu, Suguru Inatomi
 * [JavaScript Promiseの本](https://azu.github.io/promises-book/) - azu
 * [JavaScript style guide](https://developer.mozilla.org/ja/docs/JavaScript_style_guide) - MDN
 * [JavaScript 基礎文法最速マスター](http://gifnksm.hatenablog.jp/entry/20100131/1264934942) - id:gifnksm


### PR DESCRIPTION
## What does this PR do?
Add Resource

## For resources
"JavaScript Primer" is fundamental textbook of JavaScript in Japanese.

### Why is this valuable (or not)
Fundamental textbook of modern JavaScript based on ECMAScript 2015 or later.  
Not only grammer, explains cause of error and how to debug also.

### How do we know it's really free?
The content of this book is hosted on GitHub.  
https://github.com/asciidwango/js-primer

* The text content released under the CC BY-NC 4.0
* Source Code released under the MIT License.

### For book lists, is it a book?
Yes.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)