### PR TITLE
add: kubernetes and docker play grounds

### DIFF
--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -59,7 +59,7 @@
 ### Docker
 
 * [Katakoda](https://www.katacoda.com/courses/docker/playground)
-* [Play with Docker](https://labs.play-with-docker.com/)
+* [Play with Docker](https://labs.play-with-docker.com)
 
 
 ### Elm
@@ -105,7 +105,7 @@
 ### Kubernetes
 
 * [Katakoda](https://www.katacoda.com/courses/kubernetes/playground)
-* [Play with Kubernetes](https://labs.play-with-k8s.com/)
+* [Play with Kubernetes](https://labs.play-with-k8s.com)
 
 
 ### <a name="dotnet"></a>.NET

--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -4,6 +4,7 @@
 * [ClojureScript](#clojurescript)
 * [Crystal](#crystal)
 * [CSS](#css)
+* [Docker](#docker)
 * [Elm](#elm)
 * [Go](#go)
 * [Haskell](#haskell)
@@ -11,6 +12,7 @@
 * [Java](#java)
 * [JavaScript](#javascript)
 * [Kotlin](#kotlin)
+* [Kubernetes](#kubernetes)
 * [.Net](#dotnet)
 * [Node.js](#nodejs)
 * [OCaml](#ocaml)
@@ -53,6 +55,10 @@
 * [Dabblet](http://dabblet.com)
 * [Flexy Boxes](http://the-echoplex.net/flexyboxes/)
 
+### Docker
+
+* [Play with Docker](https://labs.play-with-docker.com/)
+* [Katakoda](https://www.katacoda.com/courses/docker/playground)
 
 ### Elm
 
@@ -92,6 +98,12 @@
 ### Kotlin
 
 * [Kotlin](https://play.kotlinlang.org)
+
+
+### Kubernetes
+
+* [Play with Kubernetes](https://labs.play-with-k8s.com/)
+* [Katakoda](https://www.katacoda.com/courses/kubernetes/playground)
 
 
 ### <a name="dotnet"></a>.NET

--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -55,10 +55,12 @@
 * [Dabblet](http://dabblet.com)
 * [Flexy Boxes](http://the-echoplex.net/flexyboxes/)
 
+
 ### Docker
 
-* [Play with Docker](https://labs.play-with-docker.com/)
 * [Katakoda](https://www.katacoda.com/courses/docker/playground)
+* [Play with Docker](https://labs.play-with-docker.com/)
+
 
 ### Elm
 
@@ -102,8 +104,8 @@
 
 ### Kubernetes
 
-* [Play with Kubernetes](https://labs.play-with-k8s.com/)
 * [Katakoda](https://www.katacoda.com/courses/kubernetes/playground)
+* [Play with Kubernetes](https://labs.play-with-k8s.com/)
 
 
 ### <a name="dotnet"></a>.NET


### PR DESCRIPTION
## What does this PR do?
Add Resource(s)

## For resources
### Description 
Adding the playgrounds for Docker and Kubernetes

### Why is this valuable (or not)
This is a valuable addition to practice Docker and Kubernetes online without installing anything in local

### How do we know it's really free?
These are from Docker and Katakoda, just try hitting the link above.

### For book lists, is it a book?
-na-

### Checklist:
- [x] Not a duplicate
- [ ] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
