### PR TITLE
Adds Algebraic Topology by Allen Hatcher

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -499,6 +499,7 @@
 * [Advanced Algebra](http://www.math.stonybrook.edu/~aknapp/download/a2-alg-inside.pdf) - Anthony W. Knapp (PDF)
 * [Algebra: An Elementary Text-Book, Part I (1904)](http://djm.cc/library/Algebra_Elementary_Text-Book_Part_I_Chrystal_edited.pdf) - G. Chrystal (PDF)
 * [Algebra: An Elementary Text-Book, Part II (1900)](http://djm.cc/library/Algebra_Elementary_Text-Book_Part_II_Chrystal_edited02.pdf) - G. Chrystal (PDF)
+* [Algebraic Topology](https://pi.math.cornell.edu/~hatcher/AT/ATpage.html) - Allen Hatcher (PDF)
 * [An Introduction to the Theory of Numbers](http://www.trillia.com/moser-number.html) - Leo Moser (PDF)
 * [Analytic Geometry (1922)](http://djm.cc/library/Analytic_Geometry_Siceloff_Wentworth_Smith_edited.pdf) - Lewis Parker Siceloff, George Wentworth, David Eugene Smith (PDF)
 * [Basic Algebra](http://www.math.stonybrook.edu/~aknapp/download/b2-alg-inside.pdf) - Anthony W. Knapp (PDF)


### PR DESCRIPTION
## What does this PR do?
Add Resource(s)

## For resources
### Description 

This adds the book Algebraic Topology by Allen Hatcher. <https://pi.math.cornell.edu/~hatcher/AT/ATpage.html>. Note that I linked to the home page for the book; this lets people access the errata, get the print version (which is not free, but is cheap), or download individual chapters. We could instead directly [link to the PDF](https://pi.math.cornell.edu/~hatcher/AT/AT.pdf), if that is preferred.

### Why is this valuable (or not)

This is a great text that was used for my Algebraic Topology course in uni. I don't see any other books on this topic in the list, so, although it is rather abstract, it may still be useful. Also, the author is diligent about making corrections even to this day.

### How do we know it's really free?

The page I linked to contains the quote from the author:

> By special arrangement with the publisher, an online version will continue to be available for free download here, subject to the terms in the copyright notice.

[The copyright notice](https://pi.math.cornell.edu/~hatcher/AT/ATcopyright.html) simply says

> Single paper or electronic copies for noncommercial personal use may be made without explicit permission from the author or publisher. All other rights reserved.

### For book lists, is it a book?

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
