### PR TITLE
Update free-programming-playgrounds.md

### DIFF
--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -15,6 +15,7 @@
 * [JavaScript](#javascript)
 * [Kotlin](#kotlin)
 * [Kubernetes](#kubernetes)
+* [Misc](#misc)
 * [.Net](#dotnet)
 * [Node.js](#nodejs)
 * [OCaml](#ocaml)
@@ -119,6 +120,10 @@
 * [Katakoda](https://www.katacoda.com/courses/kubernetes/playground)
 * [Play with Kubernetes](https://labs.play-with-k8s.com)
 
+
+### Misc
+
+* [Repl.it](https://repl.it/)
 
 ### <a name="dotnet"></a>.NET
 


### PR DESCRIPTION
Added Miscellaneous section and a playground link. Misc should contain playgrounds/interpreters that host a variety of languages, not purely one.

## What does this PR do?
Add Resource(s)

## For resources
Python

### Description 
Adds a new Misc sections along with a playground for that section.

### Why is this valuable (or not)
It aids in finding quality playgrounds/interpreters that don't support only one language, but multiple.

### How do we know it's really free?
It is free, however they offer subscriptions for trivial related benefits. Used for it's basic intended purpose, you can create online code repositories for free without an account.

### For book lists, is it a book?
No, it's a playground

### Checklist:
- [ ] Not a duplicate
There is a heading that uses repl.it for Java specifically, however repl.it has a broader array of languages other than Java. I'll leave it up to the maintainer to decide whether or not this should be pushed for non-specific language playgrounds.
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
