### PR TITLE
#3600 Removed roadtoreact and roadtographql

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -255,11 +255,6 @@
 * [Shaping up with Angular.js](https://www.codeschool.com/courses/shaping-up-with-angular-js)
 
 
-#### GraphQL
-
-* [The Road to GraphQL The Bare Essential Package](https://roadtoreact.com/course-details?courseId=THE_ROAD_TO_GRAPHQL)
-
-
 #### jQuery
 
 * [Bento jQuery Track](https://bento.io/topic/jquery) (Bento)
@@ -268,7 +263,6 @@
 #### React
 
 * [Start Using React to Build Web Applications](https://egghead.io/courses/react-fundamentals)
-* [The Road to learn React.js The Bare Essentials Packaage](https://roadtoreact.com/course-details?courseId=THE_ROAD_TO_LEARN_REACT)
 
 
 #### Redux

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -22,7 +22,6 @@
 * [Java](#java)
 * [JavaScript](#javascript)
   * [Angular.js](#angularjs)
-  * [GraphQL](#graphql)
   * [jQuery](#jquery)
   * [React](#react)
   * [Redux](#redux)


### PR DESCRIPTION
## What does this PR do?
Remove Resource(s)

## For resources
### Description 
https://github.com/EbookFoundation/free-programming-books/issues/3600

Removed the [Road to React](https://www.roadtoreact.com/) link as I've manually checked the website, and it is indeed no longer free.  
There was another resource called Road to GraphQL which was also on the same website, but this was moved to [Road to GraphQL](https://www.roadtographql.com/) and also no longer freely available either.

### Why is this valuable (or not)
N/A

### How do we know it's really free?
N/A

### For book lists, is it a book?
N/A

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
