### PR TITLE
fix version of phoenix link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1226,7 +1226,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 #### Phoenix
 
-* [Phoenix v1.3.0 Guide](https://hexdocs.pm/phoenix/overview.html) (HTML)
+* [Phoenix Framework Guide](https://hexdocs.pm/phoenix/overview.html) (HTML)
 * [Versioned APIs with Phoenix](https://elviovicosa.com/freebies/versioned-apis-with-phoenix-by-elvio-vicosa.pdf) - Elvio Vicosa (PDF)
 
 


### PR DESCRIPTION
## What does this PR do?
Improve Repo

## For resources
### Description 

The link to phoenix guide has wrong version for current point of time. Any version specified here would get stale with time. I am proposing that we remove version mention on the link since the link is to the latest guide whatever that is with time.

### Why is this valuable (or not)

It does not provide inaccurate information to the end users.

### How do we know it's really free?

### For book lists, is it a book?

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
