### PR TITLE
add beam wisdoms under erlang

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1247,6 +1247,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### Erlang
 
+* [BEAM Wisdoms](http://beam-wisdoms.clau.se/en/latest/) (HTML)
 * [Concurrent Programming in ERLANG](http://www.erlang.org/download/erlang-book-part1.pdf) (PDF)
 * [Erlang Handbook](https://github.com/esl/erlang-handbook/raw/master/output/ErlangHandbook.pdf) (PDF)
 * [Erlang Programming](https://en.wikibooks.org/wiki/Erlang_Programming) - Wikibooks (HTML)

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1255,6 +1255,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Learn You Some Erlang For Great Good](http://learnyousomeerlang.com) - Frederic Trottier-Hebert
 * [Making reliable distributed systems in the presence of software errors](http://www.erlang.org/download/armstrong_thesis_2003.pdf) - Joe Armstrong (PDF)
 * [Stuff Goes Bad: Erlang in Anger](https://www.erlang-in-anger.com) - Fred Herbert (PDF)
+* [The BEAM Book](https://blog.stenmans.org/theBeamBook) (HTML)
 
 
 ### ESP8266


### PR DESCRIPTION
## What does this PR do?
Add Resource(s)

## For resources
### Description 

This adds two really nice erlang resources that provide very good information on erlang runtime.

### Why is this valuable (or not)

Very information and in-depth beam books.

### How do we know it's really free?

Freely available open-source projects including source on github

### For book lists, is it a book?

### Checklist:
- [x] Not a duplicate
- [ ] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
