### PR TITLE
removed google plus link seeing as google plus has been shut down for…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Please read [CONTRIBUTING](/CONTRIBUTING.md). If you're new to GitHub, [welcome]
 
 + [Share on Twitter](http://twitter.com/intent/tweet?text=https://github.com/EbookFoundation/free-programming-books%0AFree%20Programming%20Books)
 + [Share on Facebook](https://www.facebook.com/share.php?u=https%3A%2F%2Fgithub.com%2FEbookFoundation%2Ffree-programming-books&p[images][0]=&p[title]=Free%20Programming%20Books&p[summary]=)
-+ [Share on Google Plus](https://plus.google.com/share?url=https://github.com/EbookFoundation/free-programming-books)
 + [Share on LinkedIn](http://www.linkedin.com/shareArticle?mini=true&url=https://github.com/EbookFoundation/free-programming-books&title=Free%20Programming%20Books&summary=&source=)
 + [Share on Telegram](https://t.me/share/url?url=https://github.com/EbookFoundation/free-programming-books)
 


### PR DESCRIPTION


## What does this PR do?
Remove Resource

## For resources
### Description 
remove google plus share link

### Why is this valuable (or not)
seeing as google plus has been shut down for sometime, I think its time to remove the share this repository link for it.

### How do we know it's really free?
not applicable

### For book lists, is it a book?
no

### Checklist:
- [x] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
