### PR TITLE
remove the link for the C++ lessons of Guillaume Belz 

### DIFF
--- a/free-programming-books-fr.md
+++ b/free-programming-books-fr.md
@@ -104,7 +104,6 @@
 
 ### C / C++
 
-* [C++ moderne](http://guillaume.belz.free.fr/doku.php?id=programmez_avec_le_langage_c) - Guillaume Belz
 * [Cours de C/C++](http://casteyde.christian.free.fr/cpp/cours/online/book1.html) - Christian Casteyde
 * [Le C en 20 heures](http://framabook.org/le-c-en-20-heures-2/) - Eric Berthomier et Daniel Schang
 * [Le langage C](https://zestedesavoir.com/tutoriels/755/le-langage-c-1/) - Informaticienzero, Taure, Paraze et Lucas-84


### PR DESCRIPTION
The author said it's outdated
![image](https://user-images.githubusercontent.com/45242856/95717889-ed788800-0c6d-11eb-9bab-f783a76cd829.png)
