### PR TITLE
Added Google Codelabs and Roadmaps in Android Devlopement

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -908,6 +908,9 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Styling Android](https://blog.stylingandroid.com)
 * [The Busy Coder's Guide to Android Development](https://commonsware.com/Android/4-2-free) (PDF - older versions)
 * [Tutorial Point Android Tutorial](http://www.tutorialspoint.com/android/android_tutorial.pdf) (PDF)
+* [Android Fundamental Codelabs](https://codelabs.developers.google.com/android-training)
+* [Android Advance Development Codelabs](https://codelabs.developers.google.com/advanced-android-training)
+* [Android Developer Roadmap](https://github.com/MindorksOpenSource/android-developer-roadmap)
 
 
 ### APL
@@ -1296,6 +1299,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Flutter Succinctly, Syncfusion](https://www.syncfusion.com/ebooks/flutter-succinctly) (PDF, Kindle) (email address *requested*, not required)
 * [Flutter Tutorial](https://www.tutorialspoint.com/flutter/flutter_tutorial.pdf) (PDF)
 * [Flutter Tutorials Handbook](https://kodestat.gitbook.io/flutter)
+* [Flutter App Development Codelabs](https://codelabs.developers.google.com/flutterlive)
 
 
 ### Force.com


### PR DESCRIPTION
Appended Fundamental Android Development Codelabs, Advanced Android Development Codelab, and Flutter Code Lab. Codelabs are quick handy tools these days to learn coding by doing.

## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource(s) | Remove Resource(s) | Add info | Improve Repo

## For resources
### Description 

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
