### PR TITLE
update: broken Farsi links HELP REQUESTED #3265

### DIFF
--- a/free-programming-books-fa_IR.md
+++ b/free-programming-books-fa_IR.md
@@ -1,6 +1,5 @@
 ### فهرست
 
-* [C#](#c-sharp)
 * [CSS](#css)
 * [Javascript](#javascript)
 * [LaTeX](#latex)
@@ -12,11 +11,6 @@
 * [گنو/لینوکس](#%DA%AF%D9%86%D9%88%D9%84%DB%8C%D9%86%D9%88%DA%A9%D8%B3)
   * [اوبونتو](#%D8%A7%D9%88%D8%A8%D9%88%D9%86%D8%AA%D9%88)
 * [مهندسی نرم‌افزار](#%D9%85%D9%87%D9%86%D8%AF%D8%B3%DB%8C-%D9%86%D8%B1%D9%85%E2%80%8C%D8%A7%D9%81%D8%B2%D8%A7%D8%B1)
-
-
-### C Sharp
-
-* [توسعه چابک در C#](http://agiledevelopment.ir/ebook/)
 
 
 ### CSS
@@ -38,7 +32,7 @@
 
 #### Symfony
 
-* [سیمفونی ۵: سریع‌ترین مسیر](https://symfony.com/doc/5.0/the-fast-track/fa/index.html)
+* [سیمفونی ۵: سریع‌ترین مسیر](https://symfony.com/doc/current/the-fast-track/fa/index.html)
 
 
 ### Python


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Remove Resource(s) Improve Repo(update resource)

http://agiledevelopment.ir/ebook/
- that domain is currently available for purchase
- I removed this link from this md and the c sharp category because it was the only book in the category

http://docs.occc.ir/books/Main%20Book-20110110_2.pdf
- i was able to access the pdf, it took a very long time however.

http://linuxreview.ir/archbook/ArchBook-2012-1.pdf
- this link is no longer in this md (and i couldn't find it on the site)

https://symfony.com/doc/5.0/the-fast-track/fa/index.html
- this link was moved on the site so i updated it


## For resources
### Description 

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
is a duplicate of a previous request that i couldn't get travis CI to work so i just made another one
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
