### PR TITLE
Added React Podcast

### DIFF
--- a/free-podcasts-screencasts-en.md
+++ b/free-podcasts-screencasts-en.md
@@ -138,7 +138,7 @@
 * [FiveJS](https://fivejs.codeschool.com) (podcast)
 * [Free Quality Javascript video tutorials and screencasts](http://www.screencasts.org/topics/javascript) (screencast)
 * [Front End Happy Hour](http://frontendhappyhour.com) (podcast)
-* [Frontend First](https://frontendfirst.fm) - By Sam Selikoff and Ryan Toronto (podcast)
+* [Frontend First](https://frontendfirst.fm) - Sam Selikoff and Ryan Toronto (podcast)
 * [Frontend Five](https://frontendfive.codeschool.com) (podcast)
 * [JavaScript Air](https://javascriptair.com) (podcast)
 * [JavaScript Jabber](https://devchat.tv/js-jabber) (podcast)
@@ -179,7 +179,7 @@
 
 * [React Native Podcast](https://devchat.tv/react-native-radio) (podcast)
 * [React Podcast](https://reactpodcast.simplecast.fm) (podcast)
-* [React Round Up](https://devchat.tv/podcasts/react-round-up) - By DevChat.tv (podcast)
+* [React Round Up](https://devchat.tv/podcasts/react-round-up) - DevChat.tv (podcast)
 * [ReactCasts](https://www.youtube.com/c/reactcasts) (screencast)
 
 

--- a/free-podcasts-screencasts-en.md
+++ b/free-podcasts-screencasts-en.md
@@ -138,7 +138,7 @@
 * [FiveJS](https://fivejs.codeschool.com) (podcast)
 * [Free Quality Javascript video tutorials and screencasts](http://www.screencasts.org/topics/javascript) (screencast)
 * [Front End Happy Hour](http://frontendhappyhour.com) (podcast)
-* [Frontend First](https://frontendfirst.fm) (Podcast by Sam Selikoff and Ryan Toronto)
+* [Frontend First](https://frontendfirst.fm) - By Sam Selikoff and Ryan Toronto (podcast)
 * [Frontend Five](https://frontendfive.codeschool.com) (podcast)
 * [JavaScript Air](https://javascriptair.com) (podcast)
 * [JavaScript Jabber](https://devchat.tv/js-jabber) (podcast)
@@ -179,6 +179,7 @@
 
 * [React Native Podcast](https://devchat.tv/react-native-radio) (podcast)
 * [React Podcast](https://reactpodcast.simplecast.fm) (podcast)
+* [React Round Up](https://devchat.tv/podcasts/react-round-up) - By DevChat.tv (podcast)
 * [ReactCasts](https://www.youtube.com/c/reactcasts) (screencast)
 
 


### PR DESCRIPTION
Updated React Round Up Podcast by DevChat.tv

## What does this PR do?
Added React Round Up Podcast

## For resources
### Description 
Added React Round Up Podcast by Devchat.tv. 
### Why is this valuable (or not)?
Dedicated for React by React Community members and not specific hosts. React Experts and React Open-source enthusiasts gives talk on even minor trade-offs which is very valuable for one who is interested in learning React in-depth.
### How do we know it's really free?
It is totally free. We can listen to it on their respective websites, listen on Spotify and Apple Podcasts app.
### For book lists, is it a book? For course lists, is it a course? etc.
Not a Book or Course.
### Checklist:
- [x] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
