### PR TITLE
Add Python 3 eBook Resource

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2279,6 +2279,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Hadoop with Python](https://www.oreilly.com/learning/hadoop-with-python) -  Zachary Radtka, Donald Miner
 * [Hands-On Natural Language Processing with Python](https://www.packtpub.com/free-ebooks/hands-natural-language-processing-python) - Rajesh Arumugam, Rajalingappaa Shanmugamani (Packt account *required*)
 * [Hitchhiker's Guide to Python!](http://docs.python-guide.org/en/latest/) (2.6)
+* [How to Code in Python 3](https://assets.digitalocean.com/books/python/how-to-code-in-python.pdf) - Lisa Tagliaferri (PDF)
 * [How to Make Mistakes in Python](http://www.oreilly.com/programming/free/files/how-to-make-mistakes-in-python.pdf) - Mike Pirnat (PDF) (1st edition)
 * [How to Think Like a Computer Scientist: Learning with Python, Interactive Edition](http://interactivepython.org/courselib/static/thinkcspy/index.html) (3.2)
   * [How to Think Like a Computer Scientist: Learning with Python](http://www.greenteapress.com/thinkpython/thinkCSpy/) - Allen B. Downey, Jeff Elkner and Chris Meyers (2.4)


### PR DESCRIPTION
Python 3 book from DigitalOcean.

## Hacktoberfest notes:

- due to the volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open-source contribution, make sure it's not your last!

## What does this PR do?
Added a Python 3 book resource

## For resources
### Description 
A free Python 3 e-book from DigitalOcean.
### Why is this valuable (or not)?
Provides another Python resource for beginners.
### How do we know it's really free?
There was a link from DigitalOcean to access the eBook.
### For book lists, is it a book? For course lists, is it a course? etc.
It is a book.
### Checklist:
- [X] Not a duplicate
- [X] Included author(s) if appropriate
- [X] Lists are in alphabetical order
- [X] Needed indications added (PDF, access notes, under construction)
