### PR TITLE
The link returns a 404 page

### DIFF
--- a/free-programming-books-nl.md
+++ b/free-programming-books-nl.md
@@ -10,9 +10,6 @@
 
 #### Symfony
 
-* [Symfony 5: Snel van start](https://symfony.com/doc/current/the-fast-track/nl/index.html)
-
-
 ### Python
 
 * [De Programmeursleerling: Leren coderen met Python 3](http://www.spronck.net/pythonbook/dutchindex.xhtml) - Pieter Spronck (PDF) (3.x)


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource(s) | Remove Resource(s) | Add info | Improve Repo
I had to remove a link to a symfony page that's returning a 404 error 

## For resources
### Description 

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
- [X] Not a duplicate
- [X] Included author(s) if appropriate
- [X] Lists are in alphabetical order
- [X] Needed indications added (PDF, access notes, under construction)
