### PR TITLE
adding DeepMind x UCL Reinforcement Learning cource

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -374,6 +374,7 @@
 * [Elements of AI](https://www.elementsofai.com)
 * [Embedded Software Safety](https://www.youtube.com/playlist?list=PLAQopGWlIcyaqDBW1zSKx7lHfVcOmWSWt) (P. Koopman)
 * [FindLectures.com](https://www.findlectures.com/?class1=Technology) - Index of conference talks by language / topic
+* [Introduction to Reinforcement Learning with David Silver](https://deepmind.com/learning-resources/-introduction-reinforcement-learning-david-silver) - David Silver
 * [LouvainX Paradigms of Computer Programming – Abstraction and Concurrency](https://www.edx.org/course/paradigms-computer-programming-louvainx-louv1-2x-1#!)
 * [LouvainX Paradigms of Computer Programming – Fundamentals](https://www.edx.org/course/paradigms-computer-programming-louvainx-louv1-1x-1)
 * [MIT 6.S099: Artificial General Intelligence](https://agi.mit.edu)


### PR DESCRIPTION
### What does this PR do?
Add Resource(s)

## For resources
### Description 
DeepMind x University College London's - Introduction to Reinforcement Learning Course.
The website links to YouTube videos of the course lectures, course lecture notes as PDFs and contains the examinations and assessments from the course.

### Why is this valuable (or not)?
The course is very detailed and applicable. It teaches the algorithmic basics of RL without requiring tools or programming knowledge.

### How do we know it's really free?
I've taken the course! It's free. You don't need to enroll or sign up. All resources are available free. 😄 

### For book lists, is it a book? For course lists, is it a course? etc.
It's a course 👍 

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
