### PR TITLE
Added a Java book

### DIFF
--- a/free-programming-books-de.md
+++ b/free-programming-books-de.md
@@ -120,6 +120,7 @@
 * [EJB 3 für Umsteiger: Neuerungen und Änderungen gegenüber dem EJB-2.x-Standard](http://bsd.de/e3fu/umfrage.html) - Heiko W. Rupp
 * [Java 7 Mehr als eine Insel](http://openbook.rheinwerk-verlag.de/java7/)
 * [Java ist auch eine Insel](http://openbook.rheinwerk-verlag.de/javainsel/)
+* [Java SE 8 Standard-Bibliothek](http://openbook.rheinwerk-verlag.de/java8/) - Christian Ullenboom
 * [Programmieren Java: Aufbau](http://www.highscore.de/java/aufbau/)
 * [Programmieren Java: Einführung](http://www.highscore.de/java/einfuehrung/)
 * [Testgetriebene Entwicklung mit JUnit & FIT](http://www.frankwestphal.de/ftp/Westphal_Testgetriebene_Entwicklung.pdf) - Frank Westphal (PDF)


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource(s)

## For resources
### Description 
Added a book named Java SE 8 Standard-Bibliothek
### Why is this valuable (or not)?
A new resource not already listed
### How do we know it's really free?
According to the publisher site, the book is free to read online and also free to print for private use.
### For book lists, is it a book? For course lists, is it a course? etc.
It is a book
### Checklist:
- [X] Not a duplicate
- [X] Included author(s) if appropriate
- [X] Lists are in alphabetical order
- [X] Needed indications added (PDF, access notes, under construction)
