### PR TITLE
add link Python para Competições de Programação in courses pt_BR

### DIFF
--- a/free-courses-pt_BR.md
+++ b/free-courses-pt_BR.md
@@ -198,6 +198,7 @@
 * [Introdução à linguagem Python](https://www.udemy.com/intro_python/) - Diego Mariano (Udemy)
 * [Python 3 na Prática](https://www.udemy.com/python-3-na-pratica/) - João Batista (Udemy)
 * [Python 3 na Web com Django (Básico e Intermediário)](https://www.udemy.com/python-3-na-web-com-django-basico-intermediario/) - Gileno Alves Santa Cruz Filho (Udemy)
+* [Python para Competições de Programação](https://www.youtube.com/playlist?list=PLMxflQ9_eOd9CY6Id5gfs3Edqt8vLC47p) - Adorilson (YouTube)
 * [Python para Iniciantes](https://www.udemy.com/python-para-iniciantes/) - Tiago Miguel (Udemy)
 * [Selenium com Python](https://www.youtube.com/playlist?list=PLOQgLBuj2-3LqnMYKZZgzeC7CKCPF375B) - Eduardo Mendes (YouTube)
 

--- a/free-programming-books-ta.md
+++ b/free-programming-books-ta.md
@@ -9,7 +9,6 @@
 * [PHP](#PHP)
 
 
-
 ### BigData
 
 * [எளிய தமிழில் Big Data](http://www.kaniyam.com/learn-bigdata-in-tamil-ebooks/)
@@ -17,7 +16,7 @@
 
 ### CSS
 
-* [எளிய தமிழில் CSS](http://www.kaniyam.com/download/learn-css-in-tamil.pdf)
+* [எளிய தமிழில் CSS](http://www.kaniyam.com/download/learn-css-in-tamil.pdf) (PDF)
 
 
 ### Database
@@ -44,4 +43,3 @@
 ### PHP
 
 * [எளிய தமிழில் PHP](https://freetamilebooks.com/ebooks/learn-php-in-tamil/)
-


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource and Improve Repo

## For resources
free-courses-pt_BR.md

### Description 
Added the link to the "Python para Competições de Programação" course and fix Travis errors of blank lines and pdf indicator in the `free-programming-books-ta.md` file.

### Why is this valuable (or not)?
Course focused on programming competitions using the Python language.
Fix Travis CI error.

### How do we know it's really free?
Available in open playlist on YouTube.

### For book lists, is it a book? For course lists, is it a course? etc.
It's a course and a fix.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)

