### PR TITLE
Added GDScript

### DIFF
--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -8,6 +8,7 @@
 * [Docker](#docker)
 * [Elm](#elm)
 * [Flutter](#flutter)
+* [GDScript](#gdscript)
 * [Go](#go)
 * [Haskell](#haskell)
 * [Ionic](#ionic)
@@ -78,6 +79,11 @@
 ### Flutter
 
 * [Codepen](https://codepen.io/topic/flutter/templates)
+
+
+### GDScript
+
+* [GDScript](https://gdscript-online.github.io/)
 
 
 ### Go

--- a/free-programming-playgrounds.md
+++ b/free-programming-playgrounds.md
@@ -83,7 +83,7 @@
 
 ### GDScript
 
-* [GDScript](https://gdscript-online.github.io/)
+* [GDScript](https://gdscript-online.github.io)
 
 
 ### Go


### PR DESCRIPTION
## Hacktoberfest notes:


## What does this PR do?
Added GDScript playground

## For resources
https://github.com/Calinou/gdscript-online

### Description 
Added GDScript programming playground. Now everyone can try GDScript without installing Godot.

### Why is this valuable ?
GDScript is a popular game development language used in Godot Engine.

### How do we know it's really free?
It's an open resource in github.

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
