### PR TITLE
issue-4337 : change broken urls

### DIFF
--- a/free-programming-books-ko.md
+++ b/free-programming-books-ko.md
@@ -41,14 +41,13 @@
 ### GIT
 
 * [Git - 간편 안내서](http://rogerdudler.github.io/git-guide/index.ko.html)
-* [Pro Git 한글 번역](http://git-scm.com/book/ko/)
+* [Pro Git 한글 번역](https://git-scm.com/book/ko/v2) - 최신 버전
 * [깃허브 치트 시트](https://github.com/tiimgreen/github-cheat-sheet/blob/master/README.ko.md)
 
 
 ### Go
 
 * [AN INTRODUCTION TO PROGRAMMING IN GO 한글 번역](http://www.codingnuri.com/golang-book/index.html)
-* [Go Tour 한글 번역](http://go-tour-kr.appspot.com)
 * [Go 언어 웹 프로그래밍 철저 입문](https://thebook.io/006806/)
 * [가장 빨리 만나는 Go 언어](http://www.pyrasis.com/private/2015/06/01/publish-go-for-the-really-impatient-book)
 
@@ -61,8 +60,6 @@
 ### JavaScript
 
 * [JavaScript Garden](http://bonsaiden.github.io/JavaScript-Garden/ko)
-* Meteor
-  * [Discover Meteor](http://kr.discovermeteor.com)
 
 
 #### Node.js
@@ -72,7 +69,7 @@
 
 ### LaTeX
 
-* [The Not So short Introduction to LaTeX 2ε](http://www.ctan.org/tex-archive/info/lshort/korean)
+* [The Not So short Introduction to LaTeX 2ε](https://ctan.org/tex-archive/info/lshort/korean)
 
 
 ### Linux
@@ -114,7 +111,7 @@
 
 #### Flask
 
-* [Flask의 세계에 오신것을 환영합니다.](http://flask-docs-kr.readthedocs.io/ko/latest/) (HTML)
+* [Flask의 세계에 오신것을 환영합니다.](https://flask-docs-kr.readthedocs.io/ko/latest/) (HTML)
 
 
 ### R
@@ -138,6 +135,3 @@
 * [창의컴퓨팅(Creative Computing) 가이드북](http://digital.kyobobook.co.kr/digital/ebook/ebookDetail.ink?barcode=480150000247P)
 
 
-### Swift
-
-* [Swift 언어 개발문서](http://swift.leantra.kr) - 이전 버젼


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource(s) | Remove Resource(s) | Add info | Improve Repo
Removed Resource which does not exist anymore and Improved Resources to change HTTP to HTTPS or up to date url 
## For resources
### Description 
Some resource does not exist anymore and some resource urls is updated. 

http://swift.leantra.kr - not exist
http://go-tour-kr.appspot.com - not exist
http://kr.discovermeteor.com  - not exist
http://git-scm.com/book/ko/ - https://git-scm.com/book/ko/v2 (Newest)
http://www.ctan.org/tex-archive/info/lshort/korean - HTTPS changed 
http://flask-docs-kr.readthedocs.io/ko/latest/ - HTTPS changed

### Why is this valuable (or not)?
The user will not confuse for missing URL 

### How do we know it's really free?
Yes I did not add a new Resource 

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
