### PR TITLE
Added Math for Machine Learning by Marc Peter Deisenroth

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -488,7 +488,7 @@
 * [Machine Learning from Scratch](https://dafriedman97.github.io/mlbook/content/introduction.html) - Danny Friedman
 * [Machine Learning, Neural and Statistical Classification](http://www1.maths.leeds.ac.uk/~charles/statlog/)
 * [Mathematics for Machine Learning](https://gwthomas.github.io/docs/math4ml.pdf) - Garrett Thomas (PDF)
-* [Mathematics for Machine Learning](https://mml-book.github.io/book/mml-book.pdf) - Marc Peter Deisenroth, A Aldo Faisal, and Cheng Soon Ong (PDF)
+* [Mathematics for Machine Learning](https://mml-book.github.io) - Marc Peter Deisenroth, A Aldo Faisal, and Cheng Soon Ong
 * [Neural Networks and Deep Learning](http://neuralnetworksanddeeplearning.com)
 * [Probabilistic Models in the Study of Language](http://idiom.ucsd.edu/~rlevy/pmsl_textbook/text.html) (Draft, with R code)
 * [Reinforcement Learning: An Introduction](http://incompleteideas.net/book/RLbook2020.pdf) - Richard S. Sutton, Andrew G. Barto (PDF)

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -488,6 +488,7 @@
 * [Machine Learning from Scratch](https://dafriedman97.github.io/mlbook/content/introduction.html) - Danny Friedman
 * [Machine Learning, Neural and Statistical Classification](http://www1.maths.leeds.ac.uk/~charles/statlog/)
 * [Mathematics for Machine Learning](https://gwthomas.github.io/docs/math4ml.pdf) - Garrett Thomas (PDF)
+* [Mathematics for Machine Learning](https://mml-book.github.io/book/mml-book.pdf) - Marc Peter Deisenroth, A Aldo Faisal, and Cheng Soon Ong
 * [Neural Networks and Deep Learning](http://neuralnetworksanddeeplearning.com)
 * [Probabilistic Models in the Study of Language](http://idiom.ucsd.edu/~rlevy/pmsl_textbook/text.html) (Draft, with R code)
 * [Reinforcement Learning: An Introduction](http://incompleteideas.net/book/RLbook2020.pdf) - Richard S. Sutton, Andrew G. Barto (PDF)

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -488,7 +488,7 @@
 * [Machine Learning from Scratch](https://dafriedman97.github.io/mlbook/content/introduction.html) - Danny Friedman
 * [Machine Learning, Neural and Statistical Classification](http://www1.maths.leeds.ac.uk/~charles/statlog/)
 * [Mathematics for Machine Learning](https://gwthomas.github.io/docs/math4ml.pdf) - Garrett Thomas (PDF)
-* [Mathematics for Machine Learning](https://mml-book.github.io/book/mml-book.pdf) - Marc Peter Deisenroth, A Aldo Faisal, and Cheng Soon Ong
+* [Mathematics Machine Learning Book](https://mml-book.github.io/book/mml-book.pdf) - Marc Peter Deisenroth, A Aldo Faisal, and Cheng Soon Ong
 * [Neural Networks and Deep Learning](http://neuralnetworksanddeeplearning.com)
 * [Probabilistic Models in the Study of Language](http://idiom.ucsd.edu/~rlevy/pmsl_textbook/text.html) (Draft, with R code)
 * [Reinforcement Learning: An Introduction](http://incompleteideas.net/book/RLbook2020.pdf) - Richard S. Sutton, Andrew G. Barto (PDF)

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -488,7 +488,7 @@
 * [Machine Learning from Scratch](https://dafriedman97.github.io/mlbook/content/introduction.html) - Danny Friedman
 * [Machine Learning, Neural and Statistical Classification](http://www1.maths.leeds.ac.uk/~charles/statlog/)
 * [Mathematics for Machine Learning](https://gwthomas.github.io/docs/math4ml.pdf) - Garrett Thomas (PDF)
-* [Mathematics Machine Learning Book](https://mml-book.github.io/book/mml-book.pdf) - Marc Peter Deisenroth, A Aldo Faisal, and Cheng Soon Ong
+* [Mathematics for Machine Learning](https://mml-book.github.io/book/mml-book.pdf) - Marc Peter Deisenroth, A Aldo Faisal, and Cheng Soon Ong (PDF)
 * [Neural Networks and Deep Learning](http://neuralnetworksanddeeplearning.com)
 * [Probabilistic Models in the Study of Language](http://idiom.ucsd.edu/~rlevy/pmsl_textbook/text.html) (Draft, with R code)
 * [Reinforcement Learning: An Introduction](http://incompleteideas.net/book/RLbook2020.pdf) - Richard S. Sutton, Andrew G. Barto (PDF)


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource

## For resources
### Description 
Mathematics for Machine Learning is a book developed by Marc Peter Deisenroth, A Aldo Faisal, and Cheng Soon Ong, with the aim of motivating people to learn mathematical concepts

### Why is this valuable?
The purpose of this book is to provide the math skills needed to read books on more sophisticated machine learning topics

### How do we know it's really free?
You can download the PDF of the book [here](https://mml-book.github.io/book/mml-book.pdf). Even though the book will be published this year, the author will continue to make the PDF book available for free download after publication.

### For book lists, is it a book?
Yes it's a book

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
