### PR TITLE
Mentioned users can get banned from Hacktoberfest in PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,10 @@
 ## Hacktoberfest notes:
 
-- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
-- please read our [contributing guidelines](/CONTRIBUTING.md)
-- be sure to check the output of Travis-CI for linter errors
-- if this is your first open source contribution, make sure it's not your last!
+- Due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
+- Please read our [contributing guidelines](/CONTRIBUTING.md).
+- Be sure to check the output of Travis CI for linter errors.
+- If this is your first open source contribution, make sure it's not your last!
+- Please note that users that do many PRs marked as invalid/spam, may now get [banned from **all** Hacktoberfests](https://hacktoberfest.digitalocean.com/hacktoberfest-update), not just this one.
 
 ## What does this PR do?
 Add Resource(s) | Remove Resource(s) | Add info | Improve Repo


### PR DESCRIPTION
## Hacktoberfest notes:

- Due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- Please read our [contributing guidelines](/CONTRIBUTING.md).
- Be sure to check the output of Travis CI for linter errors.
- If this is your first open-source contribution, make sure it's not your last!
- Please note that users that do many PRs marked as invalid/spam, may now get [banned from **all** Hacktoberfests](https://hacktoberfest.digitalocean.com/hacktoberfest-update), not just this one.

## What does this PR do?
Improve Repo?

## For resources
### Description 
(Look at the "Hacktoberfest notes" notes section, basically it changes it to that.)

There isn't much of Hacktoberfest left, and I'm not seeing too much spam, so this might be redundant.
This just adds a link to the new rules. It makes clear to users doing a PR, or at least the ones that bother to read the template, that they can get banned from not only this Hacktoberfest, but **all future Hacktoberfests** if they have too many PRs marked as spam or invalid.

(While I was at it, I also added capitalization and periods to the points.)

### Why is this valuable (or not)?
I'm hoping maybe some spam PRs (not that I saw too many) won't get made when this is mentioned to them, reducing effort for the maintainers. If not for this repository, then I hope people that read it decide not to spam other repositories.

### How do we know it's really free?
N/A

### For book lists, is it a book? For course lists, is it a course? etc.
N/A

### Checklist:
- [x] Not a duplicate
- N/A Included author(s) if appropriate
- N/A Lists are in alphabetical order
- N/A Needed indications added (PDF, access notes, under construction)
