### PR TITLE
Add Spring Framework Notes for Professionals book

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1609,6 +1609,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 * [Building Applications with Spring 5 and Vue.js 2](https://www.packtpub.com/free-ebooks/building-applications-spring-5-and-vuejs-2) - James J. Ye (Packt account *required*)
 * [Software Architecture with Spring 5.0](https://www.packtpub.com/free-ebooks/software-architecture-spring-50) - René Enríquez, Alberto Salazar (Packt account *required*)
+* [Spring Framework Notes for Professionals](https://books.goalkicker.com/SpringFrameworkBook) - Compiled from StackOverflow documentation
 * [Spring Framework Reference Documentation](https://docs.spring.io/spring/docs/current/spring-framework-reference/) - Rod Johnson et al.
 
 


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Book for Spring Framework (Spring Framework Notes for Professionals)

## For resources
### Description 
The Spring Framework Notes for Professionals book is compiled from Stack Overflow Documentation, the content is written by the beautiful people at Stack Overflow.

### Why is this valuable (or not)?

### How do we know it's really free?
Text content is released under Creative Commons BY-SA. See credits at the end 
of this book whom contributed to the various chapters. 
Images may be copyright of their respective owners unless otherwise specified

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
