### PR TITLE
fixing broken links

### DIFF
--- a/free-programming-books-es.md
+++ b/free-programming-books-es.md
@@ -54,7 +54,7 @@
 
 ### 0 - Meta-Listas
 
-* [Aprender Python](http://python.org.ar/wiki/AprendiendoPython) - Python Argentina
+* [Aprender Python](https://wiki.python.org.ar/aprendiendopython/) - Python Argentina
 * [Apuntes Completos de Desarrollo Web](http://jorgesanchez.net) - Jorge Sánchez
 * [Desarrollo de Aplicaciones Web - Temario Completo](https://github.com/statickidz/TemarioDAW#temario-daw) - José Luis Comesaña (Github)
 * [Desarrollo de Aplicaciones Web y Sistemas Microinformáticos y Redes](https://javiergarciaescobedo.es) - Javier García Escobedo

--- a/free-programming-books-ro.md
+++ b/free-programming-books-ro.md
@@ -30,7 +30,7 @@
 
 #### Symfony
 
-* [Symfony 5: Curs rapid](https://symfony.com/doc/5.0/the-fast-track/ro/index.html)
+* [Symfony 5: Curs rapid](https://symfony.com/doc/current/the-fast-track/ro/index.html)
 
 
 ### Scratch


### PR DESCRIPTION
fixing two broken links: 
There are some other broken links which i don't konw to fix

- 404 Errors
  - http://wecodesignpodcast.com -> 'free-podcasts-screencasts-es.md'
  - https://cezarywalenciuk.pl/blog/programing/kurs/kurs-podstaw-csharpa -> 'free-programming-books-pl.md' 
  - http://robotica.uv.es/Libro/Indice.html -> 'free-programming-books-es.md' 
  - http://www.amcham.hu/download/002/556/Robotkonyv_KR_BZS.pdf -> 'free-programming-books-hu.md'
- Other Errors
  - http://kodcu.com/aspectj-ebook -> 'free-programming-books-tr.md' -> kodcu.com under construction
  - http://www.job4j.ru/courses/java_beginner.html -> 'free-courses-ru.md' -> Only 5 Day Trial
  - https://go-tour-de.appspot.com/welcome/1 -> 'free-programming-books-de.md' -> Broken GO version (will probably be updated) 
  - https://go-tour-turkish.appspot.com/welcome/1 -> 'free-programming-books-tr.md' -> Broken GO version (will probably be updated) 
