### PR TITLE
Add Scrum Manager BoK books

### DIFF
--- a/free-programming-books-es.md
+++ b/free-programming-books-es.md
@@ -104,6 +104,8 @@
 * [Diseño Ágil con TDD](http://www.carlosble.com/downloads/disenoAgilConTdd_ebook.pdf) (PDF)
 * [Ingeniería de Software: Una Guía para Crear Sistemas de Información](https://web.archive.org/web/20150824055042/http://www.wolnm.org/apa/articulos/Ingenieria_Software.pdf) (PDF)
 * [Scrum & Extreme Programming (para programadores)](https://web.archive.org/web/20140209204645/http://www.cursosdeprogramacionadistancia.com/static/pdf/material-sin-personalizar-agile.pdf) (PDF)
+* [Scrum Level](https://scrumlevel.com/files/scrumlevel.pdf) - Scrum Manager (PDF) [(EPUB)](https://scrumlevel.com/files/scrumlevel.epub)
+* [Scrum Master - Temario troncal 1](https://scrummanager.net/files/scrum_master.pdf) - Scrum Manager (PDF) [(EPUB)](https://scrummanager.net/files/scrum_master.epub)
 * [Scrum y XP desde las trincheras](http://www.proyectalis.com/wp-content/uploads/2008/02/scrum-y-xp-desde-las-trincheras.pdf) (PDF)
 
 


### PR DESCRIPTION
## What does this PR do?
Add Resources:
* [Scrum Level](https://scrumlevel.com/files/scrumlevel.pdf)
* [Scrum Master - Temario troncal 1](https://scrummanager.net/files/scrum_master.pdf)

## For resources
### Description 

Scrum certification training material.
[https://scrummanager.com](https://scrummanager.com/website/)
[Scrum Manager BoK](https://www.scrummanager.net/bok/index.php?title=Scrum_Manager_BoK)

### Why is this valuable?

For Scrum Master certification.

### How do we know it's really free?

Creative Commons Attribution-NonCommercial 4.0

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
