### PR TITLE
grey_ph4ntom.md

### DIFF
--- a/Naeemk.md
+++ b/Naeemk.md
@@ -1,0 +1,37 @@
+BUG BOUNTY TIPS & References
+============================
+
+#TOOLS 
+./././.
+Corsy - CORS Misconfiguration Scanner  >>  https://github.com/s0md3v/Corsy/
+Auto tool use to find CORS bug .
+
+#Prerequisites
+=============
+BURP HEADER> Origin: https://evil.com <br>
+VICTIM HEADER> Access-Control-Allow-Credential: true<br>
+VICTIM HEADER> Access-Control-Allow-Origin: https://evil.com OR Access-Control-Allow-Origin: null
+
+#Exploitation
+-------------
+<b>
+Usually you want to target an API endpoint. Use the following payload to exploit a CORS misconfiguration on target https://victim.example.com/endpoint.
+<b>
+<br>
+
+Vulnerable Example: Origin Reflection
+--------------------------------------
+<link>https://victim.example.com/endpoint</link>
+
+#Bug Bounty reports
+====================
+https://hackerone.com/reports/168574<br>
+https://hackerone.com/reports/426147<br>
+https://hackerone.com/reports/235200<br>
+https://hackerone.com/reports/430249<br>
+https://hackerone.com/reports/470298<br>
+
+
+
+
+


### PR DESCRIPTION
#CORS Misconfiguration

for find CORS Misconfiguration 

Vulnerable Implementation
It's possible that the server does not reflect the complete Origin header but that the null origin is allowed. This would look like this in the server's response

## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource(s) | Remove Resource(s) | Add info | Improve Repo

## For resources
### Description 

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
