### PR TITLE
Add spring boot guide in free-programming-books.md

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1616,6 +1616,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 #### Spring Boot
 
+* [Building modern Web Apps with Spring Boot and Vaadin](https://v.vaadin.com/hubfs/Pdfs/Building%20Modern%20Web%20Apps%20with%20Spring%20Boot%20and%20Vaadin.pdf) (PDF)
 * [Spring Boot Reference Guide](https://docs.spring.io/spring-boot/docs/current/reference/html/) - Phillip Webb et al. ([PDF](https://docs.spring.io/spring-boot/docs/current/reference/pdf/spring-boot-reference.pdf))
 
 


### PR DESCRIPTION
#3624  What does this PR do?
This PR adds a book/guide to the Spring Boot section in free-programming-books.md

## For resources
### Description 
This book is a practical introduction to web application development using Java.
### Why is this valuable (or not)?
I checked the repository and found that there are no guides about web app development in Vaadin, so I wanted to add it.
### How do we know it's really free?
Anyone can access the book since it is part of an [open-source  project](https://github.com/vaadin-learning-center/crm-tutorial/) 
### For book lists, is it a book? For course lists, is it a course? etc.
It is a book. But it doesn't mention authors.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
