### PR TITLE
Add iOS Course from Harvard

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -276,7 +276,7 @@
 * [AppCoda Complete iOS Tutorial](http://www.appcoda.com/ios-programming-course/)
 * [CS193p Developing Apps for IOS](https://cs193p.sites.stanford.edu) - Stanford
 * [Developing iOS 11 Apps with Swift](https://itunes.apple.com/us/course/developing-ios-11-apps-with-swift/id1309275316)
-* [iOS Track - Harvard](https://cs50.harvard.edu/x/2020/tracks/mobile/ios/)
+* [iOS Track - Harvard](https://cs50.harvard.edu/x/2020/tracks/mobile/ios/) - David J. Malan (Harvard OpenCourseWare)
 * [Ray Wenderlich iOS Tutorial](https://www.raywenderlich.com/category/ios)
 
 

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -276,6 +276,7 @@
 * [AppCoda Complete iOS Tutorial](http://www.appcoda.com/ios-programming-course/)
 * [CS193p Developing Apps for IOS](https://cs193p.sites.stanford.edu) - Stanford
 * [Developing iOS 11 Apps with Swift](https://itunes.apple.com/us/course/developing-ios-11-apps-with-swift/id1309275316)
+* [iOS Track - Harvard](https://cs50.harvard.edu/x/2020/tracks/mobile/ios/)
 * [Ray Wenderlich iOS Tutorial](https://www.raywenderlich.com/category/ios)
 
 

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -275,8 +275,8 @@
 
 * [AppCoda Complete iOS Tutorial](http://www.appcoda.com/ios-programming-course/)
 * [CS193p Developing Apps for IOS](https://cs193p.sites.stanford.edu) - Stanford
+* [CS50 2019 - iOS Track](https://www.youtube.com/playlist?list=PLhQjrBD2T3810ZX79Xrgj8X382QaWbk_J) - David J. Malan (Harvard OpenCourseWare)
 * [Developing iOS 11 Apps with Swift](https://itunes.apple.com/us/course/developing-ios-11-apps-with-swift/id1309275316)
-* [iOS Track - Harvard](https://cs50.harvard.edu/x/2020/tracks/mobile/ios/) - David J. Malan (Harvard OpenCourseWare)
 * [Ray Wenderlich iOS Tutorial](https://www.raywenderlich.com/category/ios)
 
 


### PR DESCRIPTION
## What does this PR do?
This PR adds a free course to teach iOS basis made by Harvard

## For resources
### Description 
This is a track course about iOS from Harvard.

### Why is this valuable (or not)?
This is a course made by Harvard teaching iOS.

### How do we know it's really free?
At the 'CS50 Certificate' section you can read that you only need to pay for the certificate but the course is Free.

### For book lists, is it a book? For course lists, is it a course? etc.
This is a course.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
