### PR TITLE
Add Web Programming Course from Harvard.

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -606,4 +606,4 @@
 * [Python Web Scraping & Crawling using Scrapy](https://www.youtube.com/playlist?list=PLhTjy8cBISEqkN-5Ku_kXG4QW33sxQo0t)
 * [The Odin Project - Learn Web Development for Free](http://www.theodinproject.com)
 * [Web Information Retrieval](https://www.youtube.com/playlist?list=PLAQopGWlIcya-9yzQ8c8UtPOuCv0mFZkr) - L. Becchetti, A. Vitaletti (University of Sapienza Rome)
-* [Web Programming with Python and JavaScript - Harvard](https://cs50.harvard.edu/web/2020/) - Brian Yu,David J. Milan (edX Harvard CS50)
+* [CS50’s Web Programming with Python and JavaScript](https://cs50.harvard.edu/web/2020/) - Brian Yu,David J. Milan (edX Harvard CS50)


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
This PR adds a free course to teach Web Programming made by Harvard

## For resources
### Description 
This is a track course about Web Programming with Python and JavaScript from Harvard.

### Why is this valuable (or not)?
This is a course from Harvard.

### How do we know it's really free?
At the 'CS50 Certificate' section you can read that you only need to pay for the certificate but the course is Free.

### For book lists, is it a book? For course lists, is it a course? etc.
This is a course.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
