### PR TITLE
remove rethinkdb course

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -51,7 +51,6 @@
   * [Flask](#flask)
 * [QB64](#QB64)
 * [R](#r)
-* [RethinkDB](#rethinkdb)
 * [Ruby](#ruby)
 * [Sails.js](#sailsjs)
 * [Scala](#scala)
@@ -526,11 +525,6 @@
 * [R Programming](https://www.coursera.org/course/rprog)
 * [R Programming Tutorial](https://www.youtube.com/watch?v=_V8eKsto3Ug) - (Barton Poulson) - (freeCodeCamp)
 * [R Tutorial For Beginners | Edureka](https://www.youtube.com/watch?v=fDRa82lxzaU) - (Edureka)
-
-
-### RethinkDB
-
-* [RethinkDB: Distributed Databases](https://courses.platzi.com/courses/rethinkdb-databases/)
 
 
 ### Ruby


### PR DESCRIPTION
## What does this PR do?
Remove Resource

## For resources
### Description 
This PR removes Rethinkdb course as the authors has removed it from their website.

![image](https://user-images.githubusercontent.com/27624/97077822-7d63ed80-15ef-11eb-8363-9d802f6f0c3b.png)


### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
