### PR TITLE
[Kotlin] Add Content (screencast, courses)

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -374,7 +374,7 @@
 
 ### Kotlin
 
-* [Android Kotlin Tutorial: Create Android Apps using Kotlin](https://www.youtube.com/watch?v=e7WIPwRd2s8&list=PLlxmoA0rQ-Lw5k_QCqVl3rsoJOnb_00UV) - Sriyank Siddhartha (Youtube)
+* [Android Kotlin Tutorial: Create Android Apps using Kotlin](https://www.youtube.com/playlist?list=PLlxmoA0rQ-Lw5k_QCqVl3rsoJOnb_00UV) - Sriyank Siddhartha (YouTube)
 * [Kotlin Bootcamp for Programmers](https://www.udacity.com/course/kotlin-bootcamp-for-programmers--ud9011) - Aleks Haecky, Asser Samak, Sean McQuillan (Udacity)
 
 

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -34,6 +34,7 @@
   * [Redux](#redux)
   * [Sails.js](#sailsjs)
   * [Vue.js](#vuejs)
+* [Kotlin](#kotlin)
 * [Kubernetes](#kubernetes)
 * [Linux](#linux)
 * [Lua](#lua)
@@ -369,6 +370,12 @@
 * [Intro to Vue 3](https://www.vuemastery.com/courses/intro-to-vue-3/intro-to-vue3)
 * [Vue.js Fundamentals](https://vueschool.io/courses/vuejs-fundamentals)
 * [Vuex for Everyone](https://vueschool.io/courses/vuex-for-everyone)
+
+
+### Kotlin
+
+* [Android Kotlin Tutorial: Create Android Apps using Kotlin](https://www.youtube.com/watch?v=e7WIPwRd2s8&list=PLlxmoA0rQ-Lw5k_QCqVl3rsoJOnb_00UV) (Smartherd)
+* [Kotlin Bootcamp for Programmers](https://www.udacity.com/course/kotlin-bootcamp-for-programmers--ud9011) (Udacity)
 
 
 ### Kubernetes

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -87,7 +87,6 @@
 * [Android Developer Fundamentals (Version 2) — Codelab](https://developer.android.com/courses/fundamentals-training/toc-v2)
 * [Android Developer Fundamentals (Version 2) — Concepts](https://google-developer-training.github.io/android-developer-fundamentals-course-concepts-v2/index.html)
 * [CS50 2019 - Android Track](https://www.youtube.com/playlist?list=PLhQjrBD2T381qULidYDKP55-4u1piASC1) - David J. Malan (Harvard OpenCourseWare)
-* [Developing Android Apps with Kotlin](https://www.udacity.com/course/developing-android-apps-with-kotlin--ud9012) (Udacity)
 * [Learn how to program: Android](https://www.learnhowtoprogram.com/android) - Epicodus Inc.
 * [Material design](https://material.io/guidelines/)
 * [Programming Cloud Services for Android Handheld Systems](https://www.coursera.org/course/mobilecloudprogram)
@@ -375,6 +374,7 @@
 ### Kotlin
 
 * [Android Kotlin Tutorial: Create Android Apps using Kotlin](https://www.youtube.com/playlist?list=PLlxmoA0rQ-Lw5k_QCqVl3rsoJOnb_00UV) - Sriyank Siddhartha (YouTube)
+* [Developing Android Apps with Kotlin](https://www.udacity.com/course/developing-android-apps-with-kotlin--ud9012) (Udacity)
 * [Kotlin Bootcamp for Programmers](https://www.udacity.com/course/kotlin-bootcamp-for-programmers--ud9011) - Aleks Haecky, Asser Samak, Sean McQuillan (Udacity)
 
 

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -374,8 +374,8 @@
 
 ### Kotlin
 
-* [Android Kotlin Tutorial: Create Android Apps using Kotlin](https://www.youtube.com/watch?v=e7WIPwRd2s8&list=PLlxmoA0rQ-Lw5k_QCqVl3rsoJOnb_00UV) (Smartherd)
-* [Kotlin Bootcamp for Programmers](https://www.udacity.com/course/kotlin-bootcamp-for-programmers--ud9011) (Udacity)
+* [Android Kotlin Tutorial: Create Android Apps using Kotlin](https://www.youtube.com/watch?v=e7WIPwRd2s8&list=PLlxmoA0rQ-Lw5k_QCqVl3rsoJOnb_00UV) - Sriyank Siddhartha (Youtube)
+* [Kotlin Bootcamp for Programmers](https://www.udacity.com/course/kotlin-bootcamp-for-programmers--ud9011) - Aleks Haecky, Asser Samak, Sean McQuillan (Udacity)
 
 
 ### Kubernetes

--- a/free-podcasts-screencasts-en.md
+++ b/free-podcasts-screencasts-en.md
@@ -192,7 +192,7 @@
 
 ### Kotlin
 
-* [freeCodeCamp - Tutorial for Beginners](https://www.youtube.com/watch?v=F9UC9DY-vIU) (screencast)
+* [freeCodeCamp - Tutorial for Beginners](https://www.youtube.com/watch?v=F9UC9DY-vIU) - Nate Ebel (screencast)
 * [Kotlin Beginners Tutorials](https://www.youtube.com/playlist?list=PLpg00ti3ApRweIhdOI4VCFFStx4uXC__u) (screencast)
 * [Talking Kotlin](http://talkingkotlin.com) (podcast)
 

--- a/free-podcasts-screencasts-en.md
+++ b/free-podcasts-screencasts-en.md
@@ -192,6 +192,7 @@
 
 ### Kotlin
 
+* [freeCodeCamp - Tutorial for Beginners](https://www.youtube.com/watch?v=F9UC9DY-vIU) (screencast)
 * [Kotlin Beginners Tutorials](https://www.youtube.com/playlist?list=PLpg00ti3ApRweIhdOI4VCFFStx4uXC__u) (screencast)
 * [Talking Kotlin](http://talkingkotlin.com) (podcast)
 


### PR DESCRIPTION
## What does this PR do?

Add Resource(s) | Improve Repo

A section for Kotlin is also introduced within the courses readme. I noticed there is one resource already in there, but it is under `Android` so I decided to leave it out of fear of messing with the repo's existing design flow (allowing maintainers to opt in to refactor).

### Description 

**This PR adds 3 new resources**. One screencast is added, as well as 2 tutorials/courses.

### Why is this valuable (or not)?

These are highly viewed and rated tutorials and courses on Kotlin. There seems to be a lack of Kotlin content on here, so I wanted to introduce more into the fold that have helped me learn!

### How do we know it's really free?

The tutorial screencast by _freeCodeCamp_ is on Youtube accessible by everyone.
One of the courses is on Youtube, and the other is designated as free by _Google/Udacity_

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction) _(not needed)_
