### PR TITLE
Adds site reliability engineering workbook

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -828,10 +828,10 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Software Architecture Patterns](http://www.oreilly.com/programming/free/software-architecture-patterns.csp) (email address *requested*, not required)
 * [Software Engineering for Internet Applications](http://philip.greenspun.com/seia/)
 * [Test Driven Development, Extensive Tutorial](https://github.com/grzesiek-galezowski/tdd-ebook) - Grzegorz Gałęzowski
+* [The Site Reliability Workbook](https://landing.google.com/sre/workbook/toc/) - Betsy Beyer, Niall Richard Murphy, David K. Rensin, Kent Kawahara and Stephen Thorne
 * [Web API Design](https://pages.apigee.com/rs/apigee/images/api-design-ebook-2012-03.pdf) - Brian Mulloy (PDF)
 * [Working with Web APIs](https://launchschool.com/books/working_with_apis) - Launch School
 * [Your API Is Bad](https://leanpub.com/yourapiisbad/read) - Paddy Foran
-* [The Site Reliability Workbook](https://landing.google.com/sre/workbook/toc/) - Betsy Beyer, Niall Richard Murphy, David K. Rensin, Kent Kawahara and Stephen Thorne
 
 #### Standards
 

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -831,7 +831,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Web API Design](https://pages.apigee.com/rs/apigee/images/api-design-ebook-2012-03.pdf) - Brian Mulloy (PDF)
 * [Working with Web APIs](https://launchschool.com/books/working_with_apis) - Launch School
 * [Your API Is Bad](https://leanpub.com/yourapiisbad/read) - Paddy Foran
-
+* [The Site Reliability Workbook](https://landing.google.com/sre/workbook/toc/) - Betsy Beyer, Niall Richard Murphy, David K. Rensin, Kent Kawahara and Stephen Thorne
 
 #### Standards
 

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -833,6 +833,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Working with Web APIs](https://launchschool.com/books/working_with_apis) - Launch School
 * [Your API Is Bad](https://leanpub.com/yourapiisbad/read) - Paddy Foran
 
+
 #### Standards
 
 * [Linux Standard Base](http://refspecs.linuxfoundation.org/lsb.shtml)


### PR DESCRIPTION
## What does this PR do?
Adds site reliability engineering workbook 
https://landing.google.com/sre/workbook/toc/

## For resources
### Description 
The Site Reliability Workbook is the hands-on companion to the bestselling Site Reliability Engineering book and uses concrete examples to show how to put SRE principles and practices to work. This book contains practical examples from Google’s experiences and case studies from Google’s Cloud Platform customers. Evernote, The Home Depot, The New York Times, and other companies outline hard-won experiences of what worked for them and what didn’t.

### Why is this valuable (or not)?
It is a very practical book for SRE with guidelines and examples.

### How do we know it's really free?
It is listed to read online on Google SRE books page.
https://landing.google.com/sre/books/

### For book lists, is it a book? For course lists, is it a course? etc.
It s a book.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
