### PR TITLE
Update free-programming-books.md

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2392,6 +2392,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Django Official Documentation](https://media.readthedocs.org/pdf/django/1.10.x/django.pdf) (PDF) (1.10)
 * [Django Official Documentation](https://buildmedia.readthedocs.org/media/pdf/django/2.2.x/django.pdf) (PDF) (2.2)
 * [Django RESTful Web Services](https://www.packtpub.com/free-ebooks/django-restful-web-services) - Gaston C. Hillar (Packt account *required*)
+* [Django Web Framework (Python)](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django) - MDN contributors
 * [Djen of Django](http://agiliq.com/books/djenofdjango/)
 * [Effective Django](https://web.archive.org/web/20181130092020/http://www.effectivedjango.com/) (1.5)
 * [How to Tango With Django](http://www.tangowithdjango.com/book17/) (1.7)


### PR DESCRIPTION
Added MDN Django tutorial:  https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django

## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource(s) 

## For resources
### Description 
MDN developers Django tutorial.

### Why is this valuable (or not)?
Step by step and in depth tutorial with assessments. More user-friendly compared to the official tutorial. More in depth compared to the already linked Django girls tutorial.

### How do we know it's really free?
From the MDN about of the site (https://developer.mozilla.org/en-US/docs/MDN/About): "MDN's content is available free of charge, and under open source licenses."

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
