### PR TITLE
Add Ruby on Rails book "Api on Rails 6"

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2540,6 +2540,7 @@ Kerridge (PDF) (email address *requested*, not required)
 #### Ruby on Rails
 
 * [A community-driven Rails style guide](https://github.com/bbatsov/rails-style-guide)
+* [Api on Rails 6](https://github.com/madeindjs/api_on_rails) - Alexandre Rousseau
 * [Building REST APIs with Rails](http://apionrails.icalialabs.com/book)
 * [Kestrels, Quirky Birds, and Hopeless Egocentricity](https://leanpub.com/combinators/read) - Reg Braithwaite
 * [Learn Ruby on Rails as You Modify a Craigslist Clone](http://www.thinkful.com/learn/ruby-on-rails-tutorial/)


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource

## For resources
### Description 

### Why is this valuable (or not)?
It is based on the free book [Building REST APIs with Rails](http://apionrails.icalialabs.com/book), which is written for Ruby on Rails 4 and is no longer maintained. The propesed new book is updated and covers the topic API for Ruby on Rails 6.

### How do we know it's really free?
The repository has instructions how to build the pdf for free.

### For book lists, is it a book? For course lists, is it a course? etc.
Book
### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
