### PR TITLE
Reformatting: add linebreaks to meet the rule of blank line number

### DIFF
--- a/free-programming-cheatsheets.md
+++ b/free-programming-cheatsheets.md
@@ -51,9 +51,11 @@
 
 * [Handy Cheat Sheet for Kubernetes Beginners](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) - Kubernetes Documentation: kubectl Cheat Sheet
 
+
 ### Language Translations
 
 * [Swift and C# Quick Reference - Language Equivalents and Code Examples](http://www.globalnerdy.com/wordpress/wp-content/uploads/2015/03/SwiftCSharpPoster.pdf) - Globalnerdy (PDF)
+
 
 ### Markdown
 


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Improve Repo

## For resources
### Description 

This PR is trying to fix a formatting problem cause by a recent PR (#4767 )

The problem is the incorrect number (except 2 but have 1) of blank lines above and below the "Language Translations" section of  free-programming-cheatsheets.md

After #4767 merged, all commits did not pass the Travis-CI format check.

### Why is this valuable (or not)?

All commits after #4767 won't pass the Travis-CI format check. This PR is trying to fix this problem.

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

### Checklist:
- [ ] Not a duplicate
- [ ] Included author(s) if appropriate
- [ ] Lists are in alphabetical order
- [ ] Needed indications added (PDF, access notes, under construction)
