### PR TITLE
Added credits to a graphics programming resource and removed vulkan subcategory

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1,4 +1,4 @@
-﻿### Index
+### Index
 
 * [ABAP](#abap)
 * [Ada](#ada)
@@ -282,7 +282,7 @@
 * [DirectX manual](http://user.xmission.com/~legalize/book/download/index.html) (draft)
 * [GPU Gems](https://developer.nvidia.com/gpugems/GPUGems/gpugems_pref01.html)
 * [Graphics Programming Black Book](http://www.gamedev.net/page/resources/_/technical/graphics-programming-and-theory/graphics-programming-black-book-r1698) - Michael Abrash
-* [Introduction to Modern OpenGL](https://open.gl)
+* [Introduction to Modern OpenGL](https://open.gl) - Alexander Overvoorde (HTML, EPUB, PDF) (C++)
 * [Introduction to TouchDesigner 099](https://leanpub.com/introductiontotouchdesigner/) *(Leanpub account or valid email requested)*
 * [Learn Computer Graphics From Scratch!](https://www.scratchapixel.com) - Scratchapixel (:construction: *in process*)
 * [Learn OpenGL](http://learnopengl.com) - Joey de Vries


### PR DESCRIPTION
## Hacktoberfest notes:

- due to volume of submissions, we may not be able to review PRs that do not pass tests and do not have informative titles.
- please read our [contributing guidelines](/CONTRIBUTING.md)
- be sure to check the output of Travis-CI for linter errors
- if this is your first open source contribution, make sure it's not your last!

## What does this PR do?
Add Resource(s) | Remove Resource(s) | Add info | Improve Repo
> Improve repo! (*subjective*)

## For resources
### Description 
> I added credits for [Introduction to OpenGL](https://open.gl/) by Alexander Overvoorde and removed the subcategory for Vulkan.

### Why is this valuable (or not)?
> There was only one tutorial under this subcategory and the base category is not that filled, so I felt like this was a good move. Vulkan is just a low level 3D graphics specification API, just like OpenGL, so it makes sense to just put them at the same level. Actually both, the guide I added credits for (Intro to OpenGL) and this lonely intro to Vulkan, are written by the same author and with the same style. Anyway I guess this is a little personal opinion so feel free so discard and close the PR, or comment anything.

### Checklist:
- [x] Not a duplicate
- [x] Included author(s) if appropriate
- [x] Lists are in alphabetical order
- [x] Needed indications added (PDF, access notes, under construction)
