### PR TITLE
Add Lua, MATLAB, and Ruby courses, check_urls=free-courses-en.md

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -436,9 +436,9 @@
 
 ### Lua
 
+* [Learn Lua in 15 Minutes](http://tylerneylon.com/a/learn-lua/) - Tyler Neylon (HTML)
 * [Lua Interactive Crash Course](http://luatut.com/crash_course.html)
 * [Lua Tutorial](http://www.tutorialspoint.com/lua/)
-* [Learn Lua in 15 Minutes](http://tylerneylon.com/a/learn-lua/) - Tyler Neylon (HTML)
 
 
 ### Machine Learning

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -438,6 +438,7 @@
 
 * [Lua Interactive Crash Course](http://luatut.com/crash_course.html)
 * [Lua Tutorial](http://www.tutorialspoint.com/lua/)
+* [Learn Lua in 15 Minutes](http://tylerneylon.com/a/learn-lua/) - Tyler Neylon (HTML)
 
 
 ### Machine Learning
@@ -462,6 +463,7 @@
 ### MATLAB
 
 * [Data Processing and Feature Engineering with MATLAB](https://www.coursera.org/learn/feature-engineering-matlab) (coursera)
+* [MATLAB and Simulink Training](https://matlabacademy.mathworks.com)
 * [MIT 18.S997 Introduction to MATLAB Programming](http://ocw.mit.edu/courses/mathematics/18-s997-introduction-to-matlab-programming-fall-2011/)
 
 
@@ -592,6 +594,7 @@
 
 ### Ruby
 
+* [An Introduction to Ruby Programming Language](https://www.researchgate.net/publication/322222154_An_Introduction_to_Ruby_Programming_Language) - Ali Tourani (HTML, PDF)
 * [Learn how to program: Ruby](https://www.learnhowtoprogram.com/ruby) - Epicodus Inc.
 * [Learn Ruby](https://www.learnrubyonline.org)
 * [RESTful API with Ruby On Rails 5](https://www.udemy.com/course/restful-api-with-ruby-on-rails-5/) - Udemy


### PR DESCRIPTION
## What does this PR do?
Add resources | Improve repo

## For resources
### Description 
-Fix #3789
  - Add "An Introduction to Ruby Programming Language" course
  - Add "MATLAB and Simulink Training" course
  - Add "Learn Lua in 15 Minutes" course

- Did not add geeksforgeeks Machine Learning "course" as it seems more of an article than a course.
- Did not add the Coursera "Introduction to Programming with MATLAB" course as it is not free unless you have Coursera Plus.
- Did not add "Matlab Tutorial" or "Perl Tutorial" from Tutorialspoint as they seem to be more "book" than "course" related. See Discussion here #4573 

### Why is this valuable (or not)?
Fixes PR and adds relevant courses
### How do we know it's really free?
All courses are credited to the author or available on free hosting sites.
### For course lists, is it a course? etc.
Yes
## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
