### PR TITLE
Add The Rust Programming Language, check_urls=free-programming-books-ko.md

### DIFF
--- a/free-programming-books-ko.md
+++ b/free-programming-books-ko.md
@@ -149,7 +149,7 @@
 
 ### Rust
 
-* [러스트 프로그래밍 언어](https://rinthel.github.io/rust-lang-book-ko/) (:construction: *in process*)
+* [러스트 프로그래밍 언어](https://rinthel.github.io/rust-lang-book-ko/) - 스티브 클라브닉, 캐롤 니콜스 (:construction: *in process*)
 
 
 ### Scratch

--- a/free-programming-books-ko.md
+++ b/free-programming-books-ko.md
@@ -21,6 +21,7 @@
 * [R](#r)
 * [Raspberry Pi](#raspberry-pi)
 * [Ruby](#ruby)
+* [Rust](#rust)
 * [Scratch](#scratch)
 * [Swift](#swift)
 
@@ -144,6 +145,10 @@
 ### Ruby
 
 * [루비 스타일 가이드](https://github.com/dalzony/ruby-style-guide/blob/master/README-koKR.md)
+
+
+### Rust
+* [러스트 프로그래밍 언어](https://rinthel.github.io/rust-lang-book-ko/) (:construction: *in process*)
 
 
 ### Scratch

--- a/free-programming-books-ko.md
+++ b/free-programming-books-ko.md
@@ -149,7 +149,7 @@
 
 ### Rust
 
-* [러스트 프로그래밍 언어](https://rinthel.github.io/rust-lang-book-ko/) - 스티브 클라브닉, 캐롤 니콜스 (:construction: *in process*)
+* [러스트 프로그래밍 언어](https://rinthel.github.io/rust-lang-book-ko/) - 스티브 클라브닉, 캐롤 니콜스 (HTML) (:construction: *in process*)
 
 
 ### Scratch

--- a/free-programming-books-ko.md
+++ b/free-programming-books-ko.md
@@ -148,6 +148,7 @@
 
 
 ### Rust
+
 * [러스트 프로그래밍 언어](https://rinthel.github.io/rust-lang-book-ko/) (:construction: *in process*)
 
 


### PR DESCRIPTION
* Add The Rust Programming Language.

## What does this PR do?
Add resources

## For resources
### Description
Korean translated version of The Rust Programming Language.

2018 Version is undergoing translation, First and Second edition is completed translation.

### Why is this valuable (or not)?
The Book is considered important book between rust programmers.

### How do we know it's really free?
It has [own repo](https://github.com/rinthel/rust-lang-book-ko).

### For book lists, is it a book? For course lists, is it a course? etc.
It is book made of github pages.

## Checklist:
- [ V] Read our [contributing guidelines](/CONTRIBUTING.md)
- [ V] Search for duplicates.
- [ V] Include author(s) and platform where appropriate.
- [ V] Put lists in alphabetical order, correct spacing.
- [ V] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
