### PR TITLE
Add mongoDB course/book to check_urls=free-courses-en.md free-programming-books.md

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -15,6 +15,8 @@
 * [Dart](#dart)
 * [Data Science](#data-science)
 * [Databases](#databases)
+  * [NoSQL](#nosql)
+  * [SQL](#sql)
 * [Deep Learning](#deep-learning)
 * [Docker](#docker)
 * [Game Development](#game-development)
@@ -58,7 +60,6 @@
 * [Scala](#scala)
 * [Security](#security)
 * [Software Engineering](#software-engineering)
-* [SQL](#sql)
 * [Swift](#swift)
   * [Vapor](#vapor)
 * [Theory](#theory)
@@ -219,6 +220,20 @@
 * [DML Server Administration](https://alison.com/course/databases-dml-statements-and-sql-server-administration-revised) - (Alison)
 * [Introduction to Databases](https://lagunita.stanford.edu/courses/Engineering/db/2014_1/about) (Stanford University)
 * [Learn SQL Basic for Data Science Specialisation](https://www.coursera.org/specializations/learn-sql-basics-data-science#about) (Coursera)
+
+
+#### NoSQL
+
+* [MongoDB University](https://university.mongodb.com) - MongoDB, Inc. (email address *required*)
+
+
+#### SQL
+
+* [Introduction to Database Queries](https://www.edx.org/course/introduction-to-database-queries) - (edX New York University) - (Aspen Olmsted)
+* [Introduction to Databases and SQL Querying](https://www.udemy.com/course/introduction-to-databases-and-sql-querying/) - Rakesh Gopalakrishnan (Udemy)
+* [SQL Foundations](https://www.udemy.com/course/sql-essentials-for-beginners/) - Sagar Uppuluri (Udemy)
+* [SQL Tutorial](https://www.youtube.com/playlist?list=PL_RGaFnxSHWr_6xTfF2FrIw-NAOo3iWMy)
+* [SQL Tutorial - Full Database Course for Beginners](https://www.youtube.com/watch?v=HXV3zeQKqGY) - (Mike Dane) - (freeCodeCamp)
 
 
 ### Deep Learning
@@ -642,15 +657,6 @@
 * [Agile Development Using Ruby on Rails - Advanced](https://www.edx.org/course/agile-development-using-ruby-rails-uc-berkeleyx-cs169-2x#!)
 * [Agile Development Using Ruby on Rails - Basics](https://www.edx.org/course/agile-development-using-ruby-rails-uc-berkeleyx-cs169-1x#!)
 * [Software Construction in Java](https://www.edx.org/course/software-construction-java-mitx-6-005-1x)
-
-
-### SQL
-
-* [Introduction to Database Queries](https://www.edx.org/course/introduction-to-database-queries) - (edX New York University) - (Aspen Olmsted)
-* [Introduction to Databases and SQL Querying](https://www.udemy.com/course/introduction-to-databases-and-sql-querying/) - Rakesh Gopalakrishnan (Udemy)
-* [SQL Foundations](https://www.udemy.com/course/sql-essentials-for-beginners/) - Sagar Uppuluri (Udemy)
-* [SQL Tutorial](https://www.youtube.com/playlist?list=PL_RGaFnxSHWr_6xTfF2FrIw-NAOo3iWMy)
-* [SQL Tutorial - Full Database Course for Beginners](https://www.youtube.com/watch?v=HXV3zeQKqGY) - (Mike Dane) - (freeCodeCamp)
 
 
 ### Swift

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -2126,6 +2126,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [CouchDB: The Definitive Guide](http://guide.couchdb.org)
 * [Extracting Data from NoSQL Databases: A Step towards Interactive Visual Analysis of NoSQL Data](http://publications.lib.chalmers.se/records/fulltext/155048.pdf) - Petter Nasholm (PDF)
 * [Graph Databases](http://graphdatabases.com)
+* [Introduction to MongoDB](https://www.tutorialspoint.com/mongodb) - Tutorials Point
 * [MongoDB Koans](https://github.com/chicagoruby/MongoDB_Koans)
 * [MongoDB Succinctly, Syncfusion](https://www.syncfusion.com/resources/techportal/ebooks/mongodb) (PDF, Kindle) (email address *requested*, not required)
 * [NoSQL Databases](http://www.christof-strauch.de/nosqldbs.pdf) - Christof Strauch (PDF)


### PR DESCRIPTION
## What does this PR do?
Add resources | Improve repo

## For resources
### Description 
- Fixes #3890
  - Organize free-courses-en.md
    - NoSQL and SQL sections under Database, as agreed upon in #3890
  - Add MongoDB course under NoSQL 
  - Add MongoDB book under NoSQL, tutorial points is more so a book. Refer to discussion on #4573 

### Why is this valuable (or not)?
-Adds course and book; Cleans PR; improves repo

### How do we know it's really free?
- Free course and book site online!
### For book lists, is it a book? For course lists, is it a course?
 - Yes
## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
