### PR TITLE
Fix non-free links to free links

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -939,7 +939,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Google Android Developer Training](https://developer.android.com/guide)
 * [Styling Android](https://blog.stylingandroid.com)
 * [The Busy Coder's Guide to Android Development](https://commonsware.com/Android/4-2-free) (PDF - older versions)
-* [Tutorial Point Android Tutorial](http://www.tutorialspoint.com/android/android_tutorial.pdf) (PDF)
+* [Tutorial Point Android Tutorial](http://www.tutorialspoint.com/android) - Tutorials Point
 
 
 ### APL
@@ -1350,7 +1350,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 * [Cookbook](https://flutter.dev/docs/cookbook)
 * [Flutter Succinctly, Syncfusion](https://www.syncfusion.com/ebooks/flutter-succinctly) (PDF, Kindle) (email address *requested*, not required)
-* [Flutter Tutorial](https://www.tutorialspoint.com/flutter/flutter_tutorial.pdf) (PDF)
+* [Flutter Tutorial](https://www.tutorialspoint.com/flutter) - Tutorials Point
 * [Flutter Tutorials Handbook](https://kodestat.gitbook.io/flutter)
 
 
@@ -2657,7 +2657,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Scala for the Impatient (A1 Scala Level chapters)](http://www.typesafe.com/resources/e-books) - Cay S. Horstmann
 * [Scala School by Twitter](http://twitter.github.io/scala_school/)
 * [Scala Succinctly](https://www.syncfusion.com/ebooks/scala_succinctly) - Chris Rose
-* [Scala Tutorial](http://www.tutorialspoint.com/scala/scala_tutorial.pdf) (PDF)
+* [Scala Tutorial](https://www.tutorialspoint.com/scala) - Tutorials Point
 * [tetrix in Scala](http://eed3si9n.com/tetrix-in-scala-html5-book)
 * [The Neophyte's Guide to Scala](http://danielwestheide.com/scala/neophytes.html) - Daniel Westheide
 * [The Type Astronaut's Guide to Shapeless](http://underscore.io/books/shapeless-guide/) - Dave Gurnell (PDF, HTML, EPUB) (email address *requested*, not required)


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description 
- Working on PR #5089 made me notice that some `tutorialspoint` links were the non-free pdf files! 
  - Switched to the free website link instead for `Android`, `Flutter`, and `Scala` links
- Possible conflict due to #5089, however.
### Why is this valuable (or not)?
- Changes non-free ($9.99) pdf links to free website links
### How do we know it's really free?
- Just updated to the correct links
### For book lists, is it a book?
Yes
## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
