### PR TITLE
Add JS course,check_urls=free-courses-en.md

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -364,6 +364,7 @@
 * [Learn how to program: JavaScript](https://www.learnhowtoprogram.com/javascript) - Epicodus Inc.
 * [Learn modern JavaScript](https://scrimba.com/learn/es6) - Beau Carnes (Scrimba) (Scrimba account *required*)
 * [learn:query](https://learnquery.infinum.co)
+* [Programming Foundations with Javascript, HTML and CSS](https://www.coursera.org/learn/duke-programming-web) - Owen Astrachan, Robert Duvall, Andrew D. Hilton, Susan H. Rodger (Coursera)
 
 
 #### Angular.js


### PR DESCRIPTION
## What does this PR do?
Add resource

## For resources
### Description 
- FIx #3940
  - Add first JavaScript(JS) course from Cousera
  - Did not add second course as unclear if JS and requires premium membership after introductory course
### Why is this valuable (or not)?
- Adds JS course
### How do we know it's really free?
- Coursera course
###  For course lists, is it a course?
- Yes
## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
