### PR TITLE
Add courses to both HOWTO.md and free-courses-en.md

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -6,6 +6,7 @@ Welcome to Free-Programming-Books! We welcome new contributors; even those makin
 * [Github Hello World](https://guides.github.com/activities/hello-world/)
 * [Youtube - Github Tutorial For Beginners](https://www.youtube.com/watch?v=0fKg7e37bQE)
 * [Youtube - How To Fork A GitHub Repo and Submit A Pull Request](https://www.youtube.com/watch?v=G1I3HF4YWEw)
+* [Youtube - Markdown Crash Course](https://www.youtube.com/watch?v=HUBNt18RFbo)
 
 
 Don't hesitate to ask questions; every contributor started with a first PR. You could be our thousandth!

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -283,6 +283,7 @@
 * [Git and GitHub for Poets](https://www.youtube.com/playlist?list=PLRqwX-V7Uu6ZF9C0YMKuns9sLDzK6zoiV)
 * [GitHowTo](https://githowto.com)
 * [How to Use Git and GitHub](https://www.udacity.com/course/how-to-use-git-and-github--ud775) (Udacity)
+* [Introduction to Git and GitHub](https://www.coursera.org/learn/introduction-git-github) - Google (Coursera)
 
 
 ### Go


### PR DESCRIPTION
## What does this PR do?
- Add resources
## For resources
### Description 
- Fix #4115; I think second resource belongs more in the course section than HowTo
  - Add Markdown Crash Course to HOWTO.md
  - Add Coursera course to free-courses-en.md
### Why is this valuable (or not)?
- Adds resources
### How do we know it's really free?
- YouTube and Coursera links
### For course lists, is it a course? 
- Yes
## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
