### PR TITLE
Add LaTex and React, check_urls=free-programming-interactive-tutorial…

### DIFF
--- a/free-programming-interactive-tutorials-en.md
+++ b/free-programming-interactive-tutorials-en.md
@@ -16,12 +16,16 @@
 * [Go](#go)
 * [Haskell](#haskell)
 * [HTML / CSS](#html--css)
+  * [Bootstrap](#bootstrap)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [Angular.js](#angularjs)
+  * [jQuery](#jquery)
+  * [React](#react)
 * [Kotlin](#kotlin)
 * [Language Agnostic](#language-agnostic)
   * [Operating Systems](#operating-systems)
+* [LaTeX](#latex)
 * [Lisp](#lisp)
 * [MATLAB](#matlab)
 * [Node](#node)
@@ -145,6 +149,11 @@
 * [Prototyping a professional website](https://www.codecademy.com/learn/make-a-website)
 
 
+#### Bootstrap
+
+* [Front End Libraries: Bootstrap](https://www.freecodecamp.org/learn/front-end-libraries/bootstrap)
+
+
 ### Java
 
 * [CodingBat code practice](http://codingbat.com/java)
@@ -180,11 +189,6 @@
 * [Learn AngularJS with free interactive lessons](http://www.learn-angular.org)
 
 
-#### Bootstrap
-
-* [Front End Libraries: Bootstrap](https://www.freecodecamp.org/learn/front-end-libraries/bootstrap)
-
-
 #### jQuery
 
 * [Front End Libraries: jQuery](https://www.freecodecamp.org/learn/front-end-libraries/jquery)
@@ -193,6 +197,7 @@
 #### React
 
 * [Front End Libraries: React](https://www.freecodecamp.org/learn/front-end-libraries/react)
+* [React Tutorial](https://react-tutorial.app)
 
 
 ### Kotlin
@@ -211,6 +216,11 @@
 #### Operating systems
 
 * [Learning operating system development using Linux kernel and Raspberry Pi](https://github.com/s-matyukevich/raspberry-pi-os) - Sergey Matyukevich (:construction: *in process*)
+
+
+### LaTeX
+
+* [Learn LaTeX in 30 minutes](https://www.overleaf.com/learn/latex/Learn_LaTeX_in_30_minutes)
 
 
 ### Lisp


### PR DESCRIPTION
## What does this PR do?
- Add resource(s) | Improve repo

## For resources
### Description 
- Fixes #4138 
  - Add LaTeX and React Tutorials
- Reorganize files in correct locations
  - Bootstrap under "HTML/CSS" instead of "JavaScript"
  - Add headings for "jQuery" and "React"

### Why is this valuable (or not)?
- Adds tutorials; cleans PR; reorganizes files to correct ordering
### How do we know it's really free?
- On LaTeX and React's main websites for all to use
### For book lists, is it a book? For course lists, is it a course? etc.
- Interactive Tutorials
## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
