### PR TITLE
Adds "Python Django Tutorial 2018 for Beginners" and "Belajar es6 - javacsript gaya baru"

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -648,7 +648,7 @@
 * [Django for Everybody](https://dj4e.sites.uofmhosting.net/lessons) (Coursera Reading Materials with YouTube Videos)
 * [Django Tutorial for Beginners](https://www.youtube.com/playlist?list=PLsyeobzWxl7r2ukVgTqIQcl-1T0C2mzau) - Navin Reddy
 * [Django Tutorials](https://www.youtube.com/playlist?list=PL-osiE80TeTtoQCKZ03TU5fNfx2UY6U4p) - Corey Schafer
-* [Django Untuk Pemula](https://www.youtube.com/playlist?list=PL-J2q3Ga50oOpni_xS2PPUe4mf9lM96dD) - Clever Programmer
+* [Python Django Tutorial 2018 for Beginners](https://www.youtube.com/playlist?list=PL-J2q3Ga50oOpni_xS2PPUe4mf9lM96dD) - Clever Programmer
 
 
 #### Flask

--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -648,6 +648,7 @@
 * [Django for Everybody](https://dj4e.sites.uofmhosting.net/lessons) (Coursera Reading Materials with YouTube Videos)
 * [Django Tutorial for Beginners](https://www.youtube.com/playlist?list=PLsyeobzWxl7r2ukVgTqIQcl-1T0C2mzau) - Navin Reddy
 * [Django Tutorials](https://www.youtube.com/playlist?list=PL-osiE80TeTtoQCKZ03TU5fNfx2UY6U4p) - Corey Schafer
+* [Django Untuk Pemula](https://www.youtube.com/playlist?list=PL-J2q3Ga50oOpni_xS2PPUe4mf9lM96dD) - Clever Programmer
 
 
 #### Flask

--- a/free-courses-id.md
+++ b/free-courses-id.md
@@ -138,6 +138,7 @@
 
 ### JavaScript
 
+* [Belajar es6 - javacsript gaya baru](https://www.youtube.com/playlist?list=PLCZlgfAG0GXBWhs2AwMdPyKtMG2cF4YSR) - Sekolah Koding
 * [Belajar JavaScript Async](https://www.youtube.com/playlist?list=PL-CtdCApEFH-I4CD6km3BcXqrhWAkY4et) - Programmer Zaman Now
 * [Belajar TypeScript Untuk Pemula](https://www.youtube.com/playlist?list=PL-CtdCApEFH_LJt-fhYfMMgqxirSu6EKo) - Programmer Zaman Now
 * [Dasar Pemrograman dengan JavaScriipt](https://www.youtube.com/playlist?list=PLFIM0718LjIWXagluzROrA-iBY9eeUt4w) - Web Programming UNPAS


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description 
* Fixes #4358
* Ignores some as they seem out of scope for the repository. (More like a challenge or "codethrough" than an educational resource or tutorial.)
  * `Build a Discord Clone with REACT JS for Beginners`
  * `Build a YouTube Clone with REACT JS for Beginners`
  * `The 5-Day React JavaScript Challenge`
  * `Membuat Clone Aplikasi Terkenal dengan REACT JS`
* `Efek Animasi Dengan Javascript` as this is not really a collection of videos for a course or series. It's an accumulation for random videos.
* Ignores `Challenge 5 hari ngoding REACT JS` as this link appears twice in this PR.
* Moves `Django Untuk Pemula` from `id.md` to `en.md` since the tutorial is in English and renamed it to `Python Django Tutorial 2018 for Beginners` to match the source title.

Everything I ignored was reviewed subjective, could be nice to give them a peek and comment if anyone disagrees with an ignored resource.

## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
