### PR TITLE
Adds Google CodeLabs

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -554,6 +554,7 @@
 * [Elements of AI](https://www.elementsofai.com)
 * [Embedded Software Safety](https://www.youtube.com/playlist?list=PLAQopGWlIcyaqDBW1zSKx7lHfVcOmWSWt) (P. Koopman)
 * [FindLectures.com](https://www.findlectures.com/?class1=Technology) - Index of conference talks by language / topic
+* [Google Codelabs](https://codelabs.developers.google.com)
 * [Introduction to Reinforcement Learning with David Silver](https://deepmind.com/learning-resources/-introduction-reinforcement-learning-david-silver) - David Silver
 * [LouvainX Paradigms of Computer Programming – Abstraction and Concurrency](https://www.edx.org/course/paradigms-computer-programming-louvainx-louv1-2x-1#!)
 * [LouvainX Paradigms of Computer Programming – Fundamentals](https://www.edx.org/course/paradigms-computer-programming-louvainx-louv1-1x-1)


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description 
* Fixes #4474 
* Renamed `Google Codelabs Android Tutorials` to just `Google Codelabs`
* Removed trailing `/` from URL.
* Moves resource from `Android` to `Misc`. (This is for all Google things, like Android, TensorFlow (Machine Learning), Google Cloud Platform, it's not representative to put it in a single category.)

## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
