### PR TITLE
Moved English link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@ This page is available as an easy-to-read website at [https://ebookfoundation.gi
 
 # List of Free Learning Resources In Many Languages [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-[View the English list](free-programming-books.md)
-
-
 ## Intro
 
 This list was originally a clone of [StackOverflow - List of Freely Available Programming Books](http://web.archive.org/web/20130824154208/http://stackoverflow.com/a/392926) with contributions from Karan Bhangui and George Stocker.
@@ -27,7 +24,11 @@ Please read [CONTRIBUTING](/CONTRIBUTING.md). If you're new to GitHub, [welcome]
 + [Share on Telegram](https://t.me/share/url?url=https://github.com/EbookFoundation/free-programming-books)
 
 
-### In Other Written Languages
+### Books
+
+[English](free-programming-books.md)
+
+#### Other Languages
 
 + [Arabic / al arabiya / العربية](free-programming-books-ar.md)
 + [Azerbaijani / Азәрбајҹан дили / آذربايجانجا ديلي](free-programming-books-az.md)
@@ -38,7 +39,6 @@ Please read [CONTRIBUTING](/CONTRIBUTING.md). If you're new to GitHub, [welcome]
 + [Czech / čeština / český jazyk](free-programming-books-cs.md)
 + [Danish / dansk](free-programming-books-dk.md)
 + [Dutch / Nederlands](free-programming-books-nl.md)
-+ [English](free-programming-books.md)
 + [Estonian / eesti keel](free-programming-books-et.md)
 + [Finnish / suomi / suomen kieli](free-programming-books-fi.md)
 + [French / français](free-programming-books-fr.md)


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description 

The 'View the English list' link is easy to miss at the top - especially on the https://ebookfoundation.github.io site because the links are much smaller there.

The link is squashed in under the main title and before the Intro title - so skimming the page skips over the link.

But then if you miss this link you come to the title 'In Other Written Languages' which then makes no sense - because you can't see the English list anywhere.

I've create a 'Books' section so that its similar to the 'Free Online Courses' and 'Cheat Sheets' and then put the English link at the top. This seems more logical and easier to skim.

### Why is this valuable (or not)?

It's easier to find the main 'English' books link. More logical layout of the page. Consistency of titles.

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md) (**Your contributing link for PRs is broken it goes to https://github.com/CONTRIBUTING.md instead of https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md**
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
