### PR TITLE
Fix file-changes-action error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: trilom/file-changes-action@v1.2.4
+      - uses: trilom/file-changes-action@v1.2.3
         id: file_changes
         with:
           output: ''


### PR DESCRIPTION
fixes file-changes-action error
```
Run trilom/file-changes-action@v1.2.4
Error: undefined
Exception: {
  "error": "404/HttpError",
  "from": "undefined/Error",
  "message": "There was an error getting change files for repo:free-programming-books owner:EbookFoundation base:0000000000000000000000000000000000000000 head:660e45f2a326dfa11d511aabfdfb51c44c15a94c",
  "payload": {
    "name": "HttpError",
    "status": 404,
```