### PR TITLE
Corrects Competitive Programmer's Handbook and Competitive Programming

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -393,8 +393,8 @@
 #### Competitive Programming
 
 * [Competitive Programmer's Handbook](https://cses.fi/book/book.pdf) - Antti Laaksonen (PDF)
-* [Competitive Programming, 1st Edition](https://cpbook.net/#CP1details) [(PDF)](https://www.comp.nus.edu.sg/~stevenha/myteaching/competitive_programming/cp1.pdf)
-* [Competitive Programming, 2nd Edition](https://cpbook.net/#CP2details) [(PDF)](https://www.comp.nus.edu.sg/~stevenha/myteaching/competitive_programming/cp2.pdf)
+* [Competitive Programming, 1st Edition](https://cpbook.net/#CP1details) - Steven Halim [(PDF)](https://www.comp.nus.edu.sg/~stevenha/myteaching/competitive_programming/cp1.pdf)
+* [Competitive Programming, 2nd Edition](https://cpbook.net/#CP2details) - Steven Halim [(PDF)](https://www.comp.nus.edu.sg/~stevenha/myteaching/competitive_programming/cp2.pdf)
 * [Principles of Algorithmic Problem Solving](http://www.csc.kth.se/~jsannemo/slask/main.pdf) - Johan Sannemo (PDF)
 
 

--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -392,8 +392,9 @@
 
 #### Competitive Programming
 
-* [Competitive Programmer's Handbook](https://cses.fi/book.html) - Antti Laaksonen (PDF)
-* [Competitive Programming, 1st Edition](https://cpbook.net/#CP1details) (PDF)
+* [Competitive Programmer's Handbook](https://cses.fi/book/book.pdf) - Antti Laaksonen (PDF)
+* [Competitive Programming, 1st Edition](https://cpbook.net/#CP1details) [(PDF)](https://www.comp.nus.edu.sg/~stevenha/myteaching/competitive_programming/cp1.pdf)
+* [Competitive Programming, 2nd Edition](https://cpbook.net/#CP2details) [(PDF)](https://www.comp.nus.edu.sg/~stevenha/myteaching/competitive_programming/cp2.pdf)
 * [Principles of Algorithmic Problem Solving](http://www.csc.kth.se/~jsannemo/slask/main.pdf) - Johan Sannemo (PDF)
 
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description 
* Fixes #5204 
  * Corrects the URL for `Competitive Programmer's Handbook` to the actual document.
  * Adds author for `Competitive Programming, 1st Edition` and links the `(PDF)` text to a direct download to the PDF.
  * Adds `Competitive Programming, 2nd Edition` as this is also available for free.

The issue is correct that `Competitive Programmer's Handbook` was linked to the wrong location.
Regarding `Competitive Programming`, however, I think it's just a bit hard to find the link to download the resource, so I put the direct download link on the PDF text.

### How do we know it's really free?
The website appears to be owned by the author of the book.

## Checklist:
- [x] Read our [contributing guidelines](/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!

---

Edit: Excuse the title spam... ^-^'