### PR TITLE
Add "and contributors" to Attribution in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,5 +3,5 @@ Creative Commons Attribution 4.0 International License. To view a copy of
 this license, visit https://creativecommons.org/licenses/by/4.0/ or send
 a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
-It is attributed to Victor Felder and the Free Ebook Foundation.
+It is attributed to Victor Felder, the Free Ebook Foundation, and contributors.
 https://github.com/EbookFoundation/free-programming-books


### PR DESCRIPTION
## What does this PR do?
Improve repo 

**Disclaimer: I'm not a lawyer, the issue/PR is only to the best of my knowledge and understanding.**

This updates the attribution in the license file to include "and contributors", as all contributors are copyright holders of their contributions if no transfer or assignment of copyright is otherwise agreed. (ie a CLA)  
This means to attribute _all_ authors, should also mean to attribute the contributors.

This is intended to be a catch-all solution rather than actually maintaining a list of every unique person to contribute to the repository, based on what I've seen quite often in other repositories on GitHub/GitLab.

Fixes #4598

## For resources
N/A

## Followup

- Check the output of Travis-CI for linter errors!
