### PR TITLE
Fix link  #5224

### DIFF
--- a/books/free-programming-books-ru.md
+++ b/books/free-programming-books-ru.md
@@ -139,7 +139,7 @@
 * [Заметки о языке программирования Си/Си++](https://yurichev.com/writings/C-notes-ru.pdf) - Денис Юричев (PDF)
 * [Сетевое программирование от Биджа - Использование Интернет Сокетов](http://beej.us/guide/bgnet/translations/bgnet_A4_rus.pdf) - B. Hall, Перевод Андрея Косенко (PDF)
 * [Краткое руководство Beej к GDB](https://paintingvalley.com/ru-bggdb) - (HTML)
-* [Особенности языка C. Учебное пособие](https://younglinux.info/с) - C. Шапошникова (PDF)
+* [Особенности языка C. Учебное пособие](https://younglinux.info/c) - C. Шапошникова (PDF)
 * [Разработка сетевых приложений](http://zed.karelia.ru/mmedia/docs/nets.pdf) (PDF)
 * [Руководство по языку программирования C](https://metanit.com/cpp/c) - Евгений Попов
 * [Си/Си++. От дилетанта до профессионала](http://ermak.cs.nstu.ru/cprog/html) - Романов Е.Л.


### PR DESCRIPTION
Closes #5224 

Fix broken link:

Replace the cyrillic `с` with the latin one.

## Checklist:
- [x] Read our contributing guidelines
- [x] Search for duplicates.

After fix:

![image](https://user-images.githubusercontent.com/17143820/102272128-910d3f80-3f20-11eb-8a56-a4327bd1675c.png)

