### PR TITLE
fix: broken anchor link

### DIFF
--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -12,7 +12,7 @@
   * [Arquitetura de Software](#arquitetura-de-software)
   * [Metodologias de Desenvolvimento de Software](#metodologias-de-desenvolvimento-de-software)
   * [Outros](#outros)
-* [Fundamentos Matemáticos Computacionais](#fundamentos-matematicos-computacionais)
+* [Fundamentos Matemáticos Computacionais](#fundamentos-matemáticos-computacionais)
 * [Git](#git)
 * [Go](#go)
 * [Haskell](#haskell)


### PR DESCRIPTION
## What does this PR do?
The anchor link of topic `Fundamentos Matemáticos Computacionais` is broken. This PR corretc this

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists  in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
