### PR TITLE
fix: CI linter config

### DIFF
--- a/.github/workflows/fpb-lint.yml
+++ b/.github/workflows/fpb-lint.yml
@@ -12,6 +12,9 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '6.x'
+        node-version: '14.x'
     - run: npm install -g free-programming-books-lint
-    - run: fpb-lint .
+    - run: fpb-lint ./books/
+    - run: fpb-lint ./casts/
+    - run: fpb-lint ./courses/
+    - run: fpb-lint ./more/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ jobs:
     -
       language: node_js
       node_js:
-        - 6
+        - 14
       before_script:
         - npm install -g free-programming-books-lint
       script:
-        - fpb-lint .
+        - fpb-lint ./books/
+        - fpb-lint ./casts/
+        - fpb-lint ./courses/
+        - fpb-lint ./more/

--- a/books/free-programming-books-bg.md
+++ b/books/free-programming-books-bg.md
@@ -11,9 +11,9 @@
 
 ### C
 
+* [Програмиране = ++Алгоритми;](https://programirane.org/download-now/) - Преслав Наков и Панайот Добриков
 * [ANSI C - Курс за начинаещи](http://www.progstarter.com/index.php?option=com_content&view=article&id=8&Itemid=121&lang=bg) - Димо Петков
 * [ANSI C - Пълен справочник](http://progstarter.com/index.php?option=com_content&view=article&id=9&Itemid=122&lang=bg) - Димо Петков
-* [Програмиране = ++Алгоритми;](https://programirane.org/download-now/) - Преслав Наков и Панайот Добриков
 
 
 ### C Sharp
@@ -30,16 +30,16 @@
 
 ### Java
 
-* [Java за цифрово подписване на документи в уеб](https://nakov.com/books/signatures/) - Светлин Наков
 * [Въведение в програмирането с Java](https://introprogramming.info/intro-java-book/) - Светлин Наков и колектив
 * [Интернет програмиране с Java](https://nakov.com/books/inetjava/) - Светлин Наков
 * [Основи на програмирането с Java](https://java-book.softuni.bg) - Светлин Наков и колектив
+* [Java за цифрово подписване на документи в уеб](https://nakov.com/books/signatures/) - Светлин Наков
 
 
 ### JavaScript
 
-* [Eloquent JavaScript](https://to6esko.github.io) - Marijn Haverbeke (HTML)
 * [Основи на програмирането с JavaScript](https://js-book.softuni.bg) - Светлин Наков и колектив
+* [Eloquent JavaScript](https://to6esko.github.io) - Marijn Haverbeke (HTML)
 
 
 ### LaTeX

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -462,7 +462,7 @@
 * [Spring Boot参考指南](https://github.com/qibaoguang/Spring-Boot-Reference-Guide) (:construction: *翻译中*)
 * [Spring Framework 4.x参考文档](https://github.com/waylau/spring-framework-4-reference)
 * [用jersey构建REST服务](https://github.com/waylau/RestDemo)
-* [阿里巴巴 Java 开发手册](https://github.com/alibaba/p3c/blob/master/Java%E5%BC%80%E5%8F%91%E6%89%8B%E5%86%8C%EF%BC%88%E5%B5%A9%E5%B1%B1%E7%89%88%EF%BC%89.pdf)（PDF）
+* [阿里巴巴 Java 开发手册](https://github.com/alibaba/p3c/blob/master/Java%E5%BC%80%E5%8F%91%E6%89%8B%E5%86%8C%EF%BC%88%E5%B5%A9%E5%B1%B1%E7%89%88%EF%BC%89.pdf) (PDF)
 
 
 ### JavaScript

--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -1063,11 +1063,11 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### BETA
 
-* [Object-Oriented Programming in the BETA Programming Language](https://beta.cs.au.dk/Books/) - Ole Lehrmann Madsen, Birger Møller-Pedersen, Kristen Nygaard
 * [MIA 90-02: BETA Compiler - Reference Manual](https://beta.cs.au.dk/Manuals/latest/compiler/index.html) - Mjølner Informatics
 * [MIA 94-26: BETA Language Introduction - Tutorial](https://beta.cs.au.dk/Manuals/latest/beta-intro/index.html) - Mjølner Informatics
 * [MIA 99-41: BETA Language Modifications - Reference Manual](https://beta.cs.au.dk/Manuals/latest/beta/beta-index.html) - Mjølner Informatics
 * [MIA 99-42: The Fragment System: Further Specification](https://beta.cs.au.dk/Manuals/latest/beta/fragment.html) - Mjølner Informatics 
+* [Object-Oriented Programming in the BETA Programming Language](https://beta.cs.au.dk/Books/) - Ole Lehrmann Madsen, Birger Møller-Pedersen, Kristen Nygaard
 
 
 ### Blazor


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description 

CI was telling the linter to lint all files at the root (`fpb-lint .`), this PR makes it run on all four relevant subdirectories.

I might add a 2nd commit to fix the files that haven't been linted lately if this PR fails.

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists  in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
