### PR TITLE
Replace list Parameter from YouTube Video

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -383,7 +383,7 @@
 * [Egghead.io](https://egghead.io)
 * [ES6 and Typescript Tutorial](https://www.youtube.com/playlist?list=PLC3y8-rFHvwhI0V5mE9Vu6Nm-nap8EcjV) - Codevolution
 * [Intro to JavaScript ES6 programming](https://www.youtube.com/playlist?list=PL-xu4i_QDSxcoDNeh8rx5-pHCCTOg0XsI)
-* [Intro To JavaScript Unit Testing & BDD](https://www.youtube.com/watch?v=u5cLK1UrFyQ&list=RDCMUC29ju8bIPH5as8OGnQzwJyA) - Traversy Media
+* [Intro To JavaScript Unit Testing & BDD](https://www.youtube.com/watch?v=u5cLK1UrFyQ) - Traversy Media
 * [Javascript course](https://www.youtube.com/playlist?list=PLRAV69dS1uWSxUIk5o3vQY2-_VKsOpXLD) - Hitesh Choudhary
 * [Javascript Essentials](https://www.udemy.com/javascript-essentials/) - Lawrence Turton (Udemy)
 * [Javascript30](https://javascript30.com) - Wesbos


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description 
Closes #4966

I think #4966 has already been done and can be closed as is, since it looks like the pull request to add this book has already been merged. #4967

However, before closing the issue I just thought it might be worth swapping the link out for a non-mix link.
This is a 2+ hour course as a video, as established in the original PR, but what was added was an automatically generated playlist by YouTube with the intended video selected, not just a link to the video itself.

This just removes the `list` parameter, so it's a standalone video, and not part of a mix.

> A YouTube Mix is a nonstop playlist tailored to you.
> \- https://support.google.com/youtube/answer/9011078

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
