### PR TITLE
Standardize C++ Headings

### DIFF
--- a/books/free-programming-books-bg.md
+++ b/books/free-programming-books-bg.md
@@ -2,7 +2,7 @@
 
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-plus-plus)
+* [C++](#cpp)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [LaTeX](#latex)
@@ -23,7 +23,7 @@
 * [Програмиране за .NET Framework](http://www.devbg.org/dotnetbook/) - Светлин Наков и колектив
 
 
-### C Plus Plus
+<h3 id="cpp">C++</h3>
 
 * [Основи на програмирането със C++](https://cpp-book.softuni.bg) - Светлин Наков и колектив
 

--- a/books/free-programming-books-bl.md
+++ b/books/free-programming-books-bl.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C++](#c-plus-plus)
+* [C++](#cpp)
 * [Competitive Programming](#competitive-programming)
 * [JavaScript](#JavaScript)
 * [Machine Learning](#machine-learning)
@@ -16,7 +16,7 @@
 * [Computer Programming](http://cpbook.subeen.com/p/blog-page.html) - Tamim Shahriar Subeen 
 
 
-### C Plus Plus
+<h3 id="cpp">C++</h3>
 
 * [C++ Bangla Tutorial Course](https://www.youtube.com/playlist?list=PLgH5QX0i9K3q0ZKeXtF--CZ0PdH1sSbYL) - Anisul Islam 
 

--- a/books/free-programming-books-cs.md
+++ b/books/free-programming-books-cs.md
@@ -2,7 +2,7 @@
 
 * [Bash](#bash)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Git](#git)
 * [HTML](#html)
 * [Java](#java)
@@ -37,7 +37,7 @@
 * [Systémové programování v jazyce C#](https://phoenix.inf.upol.cz/esf/ucebni/sysprog.pdf) (PDF)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Moderní programování objektových aplikací v C++](https://akela.mendelu.cz/~xvencal2/CPP/opora.pdf) (PDF)
 * [Objektové programování v C++](http://media1.jex.cz/files/media1:49e6b94e79262.pdf.upl/07.%20Objektov%C3%A9%20programov%C3%A1n%C3%AD%20v%20C%2B%2B.pdf) (PDF)

--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -6,7 +6,7 @@
 * [Assembly Language](#assembly-language)
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Component Pascal](#component-pascal)
 * [Git](#git)
 * [Go](#go)
@@ -73,7 +73,7 @@
 * [Visual C# 2012](http://openbook.rheinwerk-verlag.de/visual_csharp_2012) - Andreas Kühnel (Online)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Die Boost C++ Bibliotheken](http://dieboostcppbibliotheken.de) - Boris Schäling (Online)
 * [Lean Testing für C++-Programmierer (2018)](https://www.assets.dpunkt.de/openbooks/Openbook_Lean_Testing.pdf) - Andreas Spillner, Ulrich Breymann (PDF)

--- a/books/free-programming-books-dk.md
+++ b/books/free-programming-books-dk.md
@@ -2,7 +2,7 @@
 
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Java](#java)
 * [Pascal](#pascal)
 
@@ -17,7 +17,7 @@
 * [Object-oriented Programming in C#](http://people.cs.aau.dk/~normark/oop-csharp/pdf/all.pdf) - Kurt Nørmark (PDF)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Notes about C++](http://people.cs.aau.dk/~normark/ap/index.html) - Kurt Nørmark (HTML)
 

--- a/books/free-programming-books-es.md
+++ b/books/free-programming-books-es.md
@@ -10,7 +10,7 @@
   * [Sistemas Operativos](#sistemas-operativos)
 * [Android](#android)
 * [C](#c)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Coffeescript](#coffeescript)
 * [Emacs](#emacs)
 * [Ensamblador](#ensamblador)
@@ -128,7 +128,7 @@
 * [Introducción a la programación con C](http://repositori.uji.es/xmlui/bitstream/handle/10234/24306/s29.pdf) (PDF) (descarga directa)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Aprenda C++ avanzado como si estuviera en primero](https://web.archive.org/web/20100701020037/http://www.tecnun.es/asignaturas/Informat1/AyudaInf/aprendainf/cpp/avanzado/cppavan.pdf) (PDF)
 * [Aprenda C++ básico como si estuviera en primero](https://web.archive.org/web/20100701020025/http://www.tecnun.es/asignaturas/Informat1/AyudaInf/aprendainf/cpp/basico/cppbasico.pdf) (PDF)

--- a/books/free-programming-books-fi.md
+++ b/books/free-programming-books-fi.md
@@ -2,7 +2,7 @@
 
 * [C](#c)
 * [C Sharp](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [JavaScript](#javascript)
 * [MySQL](#mysql)
 * [OpenGL](#opengl)
@@ -34,7 +34,7 @@
 * [Ohjelmointi 1: C#](https://jyx.jyu.fi/bitstream/handle/123456789/47417/978-951-39-4859-7.pdf) - Martti Hyvönen, Vesa Lappalainen, Antti-Jussi Lakanen (PDF)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++](https://fi.wikibooks.org/wiki/C%2B%2B) - Wikikirjasto
 * [C++-ohjelmointi](https://www.ohjelmointiputka.net/oppaat/opas.php?tunnus=cpp_ohj_01)

--- a/books/free-programming-books-gr.md
+++ b/books/free-programming-books-gr.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C++](#c++)
+* [C++](#cpp)
 * [Java](#java)
 * [Javascript](#javascript)
 * [Python](#python)
@@ -14,7 +14,7 @@
 * [Διαδικαστικός προγραμματισμός](https://repository.kallipos.gr/bitstream/11419/1346/1/00_master%20document_KOY.pdf) - Μαστοροκώστας Πάρις (PDF)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Εισαγωγή στη C++](http://www.ebooks4greeks.gr/2011.Download_free-ebooks/Pliroforikis/glossa_programmatismoy_C++__eBooks4Greeks.gr.pdf) (PDF)
 * [Προγραμματισμός με τη γλώσσα C++](https://repository.kallipos.gr/bitstream/11419/6443/1/00_master_document-KOY.pdf) - Θεόδωρος Αλεβίζος (PDF)

--- a/books/free-programming-books-hu.md
+++ b/books/free-programming-books-hu.md
@@ -3,7 +3,7 @@
 * [0 - Programozási nyelv független](#0---programozasi-nyelv-fuggetlen)
 * [Ada](#ada)
 * [Arduino](#arduino)
-* [C++](#c)
+* [C++](#cpp)
 * [HTML / CSS](#html-css)
 * [Java](#java)
 * [Lego Mindstorms](#lego-mindstorms)
@@ -37,7 +37,7 @@
 * [Arduino programozási kézikönyv](http://avr.tavir.hu) - Brian W. Evans írása alapján fordította, kiegészítette és frissítette Cseh Róbert (PDF - regisztráció szükséges)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Fejlett programozási technikák](http://www.ms.sapientia.ro/~manyi/teaching/c++/cpp.pdf) - Antal Margit (PDF)
 

--- a/books/free-programming-books-id.md
+++ b/books/free-programming-books-id.md
@@ -2,7 +2,7 @@
 
 * [Android](#android)
 * [C#](#c-sharp)
-* [C++](#cplusplus)
+* [C++](#cpp)
 * [CodeIgniter](#codeigniter)
 * [Deno](#deno)
 * [Emacs](#emacs)
@@ -32,7 +32,7 @@
 * [Menguasai Pemrograman Berorientasi Objek Dengan Bahasa C#](https://mahirkoding.id/ebook-pemrograman-berorientasi-objek-c-pdf/)
 
 
-### <a id="cplusplus"></a> C++
+<h3 id="cpp">C++</h3>
 
 * [Belajar C++ Dasar Bahasa Indonesia](https://github.com/kelasterbuka/CPP_dasar-dasar-programming) - Kelas Terbuka
 * [Koding C++ Dengan Qt](https://leanpub.com/koding-cpp-qt) *(Membutuhkan akun Leanpub atau email yang valid)*

--- a/books/free-programming-books-it.md
+++ b/books/free-programming-books-it.md
@@ -12,7 +12,7 @@
 * [BASH](#bash)
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-plus-plus)
+* [C++](#cpp)
 * [CSS](#css)
 * [Database](#database)
   * [NoSQL](#nosql)
@@ -103,7 +103,7 @@
 * [ABC# - Guida alla programmazione](http://antoniopelleriti.it/wp-content/uploads/2019/04/ABCsharp-guida-alla-programmazione-in-csharp.pdf) - A. Pelleriti (PDF)
 
 
-### C Plus Plus
+<h3 id="cpp">C++</h3>
 
 * [Corso C++ standard](http://didatticait.altervista.org/programmazione/CPP/CPP-dispense/CORSO_C.pdf) - (PDF)
 * [Il linguaggio C++](https://hpc-forge.cineca.it/files/CoursesDev/public/2012%20Autumn/Introduzione%20alla%20programmazioni%20a%20oggetti%20in%20C++/corsocpp.pdf) - (PDF)

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -23,7 +23,7 @@
 * [AWK](#awk)
 * [Bash](#bash)
 * [C](#c)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Clojure](#clojure)
 * [CoffeeScript](#coffeescript)
 * [Common Lisp](#common-lisp)
@@ -254,7 +254,7 @@
 * [猫でもわかるプログラミング](http://kumei.ne.jp/c_lang/) - 粂井康孝
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++11の文法と機能(C++11: Syntax and Feature)](https://ezoeryou.github.io/cpp-book/C++11-Syntax-and-Feature.xhtml) - 江添亮
 * [C++入門](http://www.asahi-net.or.jp/~yf8k-kbys/newcpp0.html) - 小林健一郎

--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -4,7 +4,7 @@
 * [Amazon Web Service](#amazon-web-service)
 * [Assembly Language](#assembly-language)
 * [C](#c)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Docker](#docker)
 * [GIT](#git)
 * [Go](#go)
@@ -49,7 +49,7 @@
 * [BeeJ's Guide to Network Programming - 인터넷 소켓 활용](https://blogofscience.com/Socket_Programming-KLDP.html)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [씹어먹는 C++](https://github.com/kev0960/ModooCode/raw/master/book/cpp/main.pdf) - 이재범 (PDF)
 

--- a/books/free-programming-books-pl.md
+++ b/books/free-programming-books-pl.md
@@ -5,7 +5,7 @@
 * [Bash](#bash)
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Common Lisp](#common-lisp)
 * [Coq](#coq)
 * [CSS](#css)
@@ -67,7 +67,7 @@
 * [Wstęp do programowania w C#](http://c-sharp.ue.katowice.pl/ksiazka/c_sharp_wer2_0.pdf) - Anna Kempa, Tomasz Staś (PDF)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++](https://pl.wikibooks.org/wiki/C++) - Wikibooks
 * [Język C++ – podstawy programowania](http://www.dz5.pl/ti/cpp/zz_dodatki/kurs_cpp_szczegolowy2.pdf) - Paweł Mikołajczak (PDF)

--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -6,7 +6,7 @@
 * [Android](#android)
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Docker](#docker)
 * [Engenharia de software](#engenharia-de-software)
   * [Arquitetura de Software](#arquitetura-de-software)
@@ -82,7 +82,7 @@
 * [C# e Orientação a Objetos](https://www.caelum.com.br/apostila-csharp-orientacao-objetos/) - Caelum
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Apostila Linguagem C++](http://www.ime.usp.br/~slago/slago-C++.pdf) - Silvio Lago (PDF)
 * [Estrutura de Dados](http://calhau.dca.fee.unicamp.br/wiki/images/0/01/EstruturasDados.pdf) (PDF)

--- a/books/free-programming-books-ru.md
+++ b/books/free-programming-books-ru.md
@@ -11,7 +11,7 @@
 * [Bash](#bash)
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Clojure](#clojure)
 * [CoffeeScript](#coffeescript)
 * [Elasticsearch](#elasticsearch)
@@ -154,7 +154,7 @@
 * [Design Patterns via C#](http://itvdn.com/ru/patterns) - Александр Шевчук, Дмитрий Охрименко, Андрей Касьянов (PDF) *(Требуется аккаунт)*
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Введение в язык программирования С++](http://lib.ru/CPPHB/cpptut.txt_with-big-pictures.html) - Бьерн Страуструп
 * [Введение в язык Си++](http://stolyarov.info/books/cppintro) - Андрей Столяров (PDF)

--- a/books/free-programming-books-se.md
+++ b/books/free-programming-books-se.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C++](#c-1)
+* [C++](#cpp)
 * [PHP](#php)
 
 
@@ -10,7 +10,7 @@
 * [C-programmering](https://sv.wikibooks.org/wiki/C-programmering) - Wikibooks
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Programmera spel i C++ för nybörjare](https://sv.wikibooks.org/wiki/Programmera_spel_i_C%2B%2B_f%C3%B6r_nyb%C3%B6rjare) - Wikibooks
 

--- a/books/free-programming-books-tr.md
+++ b/books/free-programming-books-tr.md
@@ -3,7 +3,7 @@
 * [Algoritma ve Veri Yapıları](#algoritma-ve-veri-yapilari)
 * [Android](#android)
 * [C](#c)
-* [C++](#c-1)
+* [C++](#cpp)
 * [CSS](#css)
 * [D](#d)
 * [Dart](#dart)
@@ -48,7 +48,7 @@
 * [GNU C Kütüphanesi Basvuru Klavuzu](http://www.belgeler.org/glibc/glibc.html)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++ Dersleri](https://www.yusufsezer.com.tr/cpp-dersleri/) - Yusuf Sezer
 

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -28,7 +28,7 @@
   * [AWK](#awk)
   * [C](#c)
   * [C#](#c-sharp)
-  * [C++](#c-1)
+  * [C++](#cpp)
   * [CoffeeScript](#coffeescript)
   * [Dart](#dart)
   * [Elasticsearch](#elasticsearch)
@@ -329,7 +329,7 @@
 * [精通C#(第6版)](http://book.douban.com/subject/24827879/)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [100个gcc小技巧](https://github.com/hellogcc/100-gcc-tips/blob/master/src/index.md)
 * [100个gdb小技巧](https://github.com/hellogcc/100-gdb-tips/blob/master/src/index.md)

--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -19,7 +19,7 @@
 * [Blazor](#blazor)
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Chapel](#chapel)
 * [Cilk](#cilk)
 * [Clojure](#clojure)
@@ -1171,7 +1171,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Xamarin.Forms Succinctly](https://www.syncfusion.com/ebooks/xamarin-forms-succinctly) - Alessandro Del Sole
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++ Annotations](https://fbb-git.gitlab.io/cppannotations/) - Frank B. Brokken (HTML, PDF)
 * [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md) - Editors: Bjarne Stroustrup, Herb Sutter

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -2,7 +2,7 @@
 
 * [Android](#android)
 * [C#](#c)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Clojure](#clojure)
 * [Common Lisp](#common-lisp)
 * [CSS](#css)
@@ -43,7 +43,7 @@
 * [How to program in C# - Beginner Course \| Brackeys](https://www.youtube.com/playlist?list=PLPV2KyIb3jR6ZkG8gZwJYSjnXxmfPAl51) (screencast)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++ Programming Video Lectures](https://www.youtube.com/playlist?list=PLTZbNwgO5ebo64D1k0DJQGX30X6iSTmRr) (screencast)
 * [C++ STL](https://www.youtube.com/playlist?list=PL5jc9xFGsL8G3y3ywuFSvOuNm3GjBwdkb) (screencast)

--- a/courses/free-courses-de.md
+++ b/courses/free-courses-de.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C++](#c++)
+* [C++](#cpp)
 * [Haskell](#haskell)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -11,7 +11,7 @@
 * [Spieleentwicklung](#spieleentwicklung)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++ Grundlagen Tutorials von Pilzschaf](https://www.youtube.com/playlist?list=PLStQc0GqppuVs05kWvLBoHcWCULX3ueIM) - Pilzschaf
 

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -8,7 +8,7 @@
 * [Bootstrap](#bootstrap)
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Clojure](#clojure)
 * [Compilers](#compilers)
 * [CUDA](#cuda)
@@ -168,7 +168,7 @@
 * [Learn how to program: C#](https://www.learnhowtoprogram.com/c) - Epicodus Inc.
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++ For Programmers](https://www.udacity.com/course/c-for-programmers--ud210) - Catherine Gamboa (Udacity)
 * [C++ Programming Tutorial for Beginners (For Absolute Beginners)](https://www.youtube.com/playlist?list=PLS1QulWo1RIYSyC6w2-rDssprPrEsgtVK) - ProgrammingKnowledge

--- a/courses/free-courses-hi.md
+++ b/courses/free-courses-hi.md
@@ -2,7 +2,7 @@
 
 * [Android](#Android)
 * [C](#C)
-* [C++](#C++)
+* [C++](#cpp)
 * [Data Structures](#DataStructures)
 * [DevOps](#DevOps)
 * [Java](#Java)
@@ -27,7 +27,7 @@
 * [C Language Tutorials In Hindi](https://www.youtube.com/playlist?list=PLu0W_9lII9aiXlHcLx-mDH1Qul38wD3aR) - CodeWithHarry
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++ Full Course | C++ Tutorial \| Data Structures & Algorithms](https://www.youtube.com/playlist?list=PLfqMhTWNBTe0b2nM6JHVCnAkhQRGiZMSJ) - Apna College
 * [C++ Programming in Hindi](https://www.youtube.com/playlist?list=PLDA2q3s0-n15yszaZ2yRKEoxY-WWkuAt4) - Sumit Bisht (Edutainment 1.0)

--- a/courses/free-courses-it.md
+++ b/courses/free-courses-it.md
@@ -5,7 +5,7 @@
 * [Assembly](#assembly)
 * [C](#c)
 * [C Sharp](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Database](#database)
   * [SQL](#sql)
 * [Delphi](#delphi)
@@ -61,7 +61,7 @@
 * [Programmazione ad oggetti in C#](https://www.youtube.com/watch?v=aSgikNnGEKM&list=PLktbfd3yXeH8yQpHM3O468k8l-aTC6Hl6) - G. Pellegrini Parisi 
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++ 11](https://www.youtube.com/playlist?list=PL0qAPtx8YtJfZpJD7uFxAXglkiHSEhktG) (F. Camuso)
 * [C++ libreria QT - playlist 1](https://www.youtube.com/playlist?list=PL0qAPtx8YtJdH4GVwL_3QeJjPcz3DHE2t) (F. Camuso)

--- a/courses/free-courses-pl.md
+++ b/courses/free-courses-pl.md
@@ -5,7 +5,7 @@
 * [Brainfuck](#brainfuck)
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [CSS](#css)
 * [HTML](#html)
 * [Java](#java)
@@ -42,7 +42,7 @@
 * [Podstawy programowania w języku C#](https://www.youtube.com/playlist?list=PLk5dbESAmUZh1cLITav0ZmDEqRujsPa93)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Kurs C++](https://www.youtube.com/playlist?list=PLE84826ABF088F7E8)
 * [Podejście obiektowe dla znających już podstawy C++ (VIDEO)](https://www.youtube.com/playlist?list=PLOYHgt8dIdozvOVheSRb_qPVU-4ZJA7uB) - Mirosław Zelent, Damian Stelmach

--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -4,7 +4,7 @@
 * [Angular](#angular)
 * [C](#c)
 * [C Sharp](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [CSS](#css)
 * [Dart](#dart)
 * [Database](#database)
@@ -66,7 +66,7 @@
 * [Manipulando Listas Genéricas em C#](https://www.udemy.com/listas-genericas-em-csharp/) - Gilseone Moraes, Training4All Cursos (Udemy)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Curso de C++ - A linguagem de programação fundamental para quem quer ser um programador](https://www.youtube.com/playlist?list=PLx4x_zx8csUjczg1qPHavU1vw1IkBcm40) - Canal Fessor Bruno (CFBCursos)
 

--- a/courses/free-courses-ru.md
+++ b/courses/free-courses-ru.md
@@ -1,7 +1,7 @@
 ### Cодержание
 
 * [Дизайн и Aрхитектура](#design-architecture)
-* [C++](#C++)
+* [C++](#cpp)
 * [Clojure](#clojure)
 * [CSS](#css)
 * [Go](#go)
@@ -31,7 +31,7 @@ ADV - Продвинутый. Тонкости.
 * [Туториал по SOLID](https://ota-solid.now.sh) - Саша Беспоясов и Артём Самофалов (INT)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Введение в программирование (C++)](https://stepik.org/course/363) - Stepik (BEG)
 

--- a/courses/free-courses-th.md
+++ b/courses/free-courses-th.md
@@ -23,7 +23,7 @@
 * [ภาษา C#](http://marcuscode.com/lang/csharp) - MarcusCode
 
 
-### CPP
+<h3 id="cpp">C++</h3>
 
 * [ภาษา C++](http://marcuscode.com/lang/cpp) - MarcusCode
 

--- a/courses/free-courses-ua.md
+++ b/courses/free-courses-ua.md
@@ -1,11 +1,11 @@
 ### Index
 
-* [C++](#C++)
+* [C++](#cpp)
 * [Java](#java)
 * [Python](#python)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [Мова програмування C++](https://stepik.org/course/67114) - Stepik
 

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -3,7 +3,7 @@
 * [Artificial Intelligence](#artificial-intelligence)
 * [Bash](#bash)
 * [C](#C)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Clojure](#clojure)
 * [Data Science](#data-science)
 * [Git](#git)
@@ -38,7 +38,7 @@
 * [The C Cheat Sheet: An Introduction to Programming in C](https://sites.ualberta.ca/~ygu/courses/geoph624/codes/C.CheatSheet.pdf) - Andrew Sterian (PDF)
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++ Quick Reference](https://www.hoomanb.com/cs/quickref/CppQuickRef.pdf) (PDF)
 

--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -5,7 +5,7 @@
 * [Bash](#bash)
 * [C](#c)
 * [C#](#c-sharp)
-* [C++](#c-1)
+* [C++](#cpp)
 * [Clojure](#clojure)
 * [Cloud Computing](#cloud-computing)
 * [CoffeeScript](#coffeescript)
@@ -71,7 +71,7 @@
 * [Learn C#](https://www.codecademy.com/learn/learn-c-sharp) - Codecademy
 
 
-### C++
+<h3 id="cpp">C++</h3>
 
 * [C++ Tutorial](https://www.w3schools.com/cpp) - W3Schools
 * [CppKoans](https://github.com/torbjoernk/CppKoans)


### PR DESCRIPTION
## What does this PR do?
Improve repo 

## For resources
### Description 
C++/CPP/CPlusPlus/C Plus Plus is written in several ways in the repository. This is mostly to accommodate the confliction with C as they both get the same ID after the Markdown is parsed and transformed into HTML, so the 2nd one gets assigned `c-1` instead.

Even this has been done incorrectly for some files (free-programming-books-cs.md) as `c-1` doesn't mean C++, it means the 2nd heading called C, which doesn't exist if there is a C++, but no C in the file.

I noticed a particular solution in the repository that stood out, however.

> ```md
> ### <a id="cplusplus"></a> C++
> ```
> \- https://raw.githubusercontent.com/EbookFoundation/free-programming-books/d703553631a600511a82035a1d736a206d80661c/books/free-programming-books-id.md

Instead of playing with the wording, or trying to accommodate the automatic IDs, it could be nice if for a case like this we just explicitly assign an ID to C++ instead by using the HTML equivalent of `###`.

### Why is this valuable (or not)?
I think this would be a great way to standardize how we add C++ in the repository in a way that semantically differentiates from C both as a reader, and for machines.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!