### PR TITLE
Replace Em Dash with Hyphen and Sync Titles

### DIFF
--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -136,7 +136,7 @@
 * [鸟哥的 Linux 私房菜 服务器架设篇](http://cn.linux.vbird.org/linux_server/)
 * [鸟哥的 Linux 私房菜 基础学习篇](http://cn.linux.vbird.org/linux_basic/linux_basic.php)
 * [嵌入式 Linux 知识库 (eLinux.org 中文版)](https://tinylab.gitbooks.io/elinux/content/zh/)
-* [Docker —— 从入门到实践](https://github.com/yeasy/docker_practice)
+* [Docker — 从入门到实践](https://github.com/yeasy/docker_practice)
 * [Docker入门实战](http://yuedu.baidu.com/ebook/d817967416fc700abb68fca1)
 * [Docker中文指南](https://github.com/widuu/chinese_docker)
 * [FreeBSD 使用手册](http://www.freebsd.org/doc/zh_CN.UTF-8/books/handbook/)

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -136,7 +136,7 @@
 ### Haskell
 
 * [Haskell Tutorial](https://www.youtube.com/watch?v=02_H3LjqMr8) - Derek Banas (screencast)
-* [HaskellRank](https://www.youtube.com/playlist?list=PLguYJK7ydFE4aS8fq4D6DqjF6qsysxTnx) — Tsoding (screencast)
+* [HaskellRank](https://www.youtube.com/playlist?list=PLguYJK7ydFE4aS8fq4D6DqjF6qsysxTnx) - Tsoding (screencast)
 * [The Haskell Cast](http://www.haskellcast.com) (podcast)
 
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description
Closes #4683

* Replaces one em dash in the repository and replaces it with a regular hyphen. (To fit the conventions of the repository.)
* Replaces one of the uses of double em dash with a single em dash. (To match the title given to the source.)

There are a few other uses of em dashes, but they all look correct to me. (ie In other files like HOWTO, or in titles where the original title used it too.)

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
