### PR TITLE
Fix Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT-es.md
+++ b/CODE_OF_CONDUCT-es.md
@@ -22,5 +22,6 @@ Este código de conducta se aplica tanto dentro de los espacios del proyecto com
 
 Los casos de comportamiento abusivo, acosador o inaceptable pueden ser informado poniéndose en contacto con un responsable del proyecto en victorfelder en gmail.com. Todas las quejas serán revisadas e investigadas y resultarán en una respuesta que se considere necesaria y apropiada a las circunstancias. Los mantenedores están obligados a mantener la confidencialidad con respecto al informante de un incidente.
 
-Este Código de Conducta está adaptado del [Pacto de Colaboradores][homepage],versión 1.3.0, disponible en [https://contributor-covenant.org/version/1/3/0/]
+Este Código de Conducta está adaptado del [Pacto de Colaboradores][homepage], versión 1.3.0, disponible en https://contributor-covenant.org/version/1/3/0/
 
+[homepage]: https://contributor-covenant.org

--- a/CODE_OF_CONDUCT-hi.md
+++ b/CODE_OF_CONDUCT-hi.md
@@ -27,8 +27,7 @@ gmail.com पर winorfelder में एक परियोजना अनु
 के रिपोर्टर के संबंध में गोपनीयता बनाए रखने के लिए बाध्य घटना।
 
 
-उनकी आचार संहिता से अनुकूलित है[Contributor Covenant][homepage], संस्करण 1.3.0, पर उपलब्ध
-[https://contributor-covenant.org/version/1/3/0/][version]
+उनकी आचार संहिता से अनुकूलित है [Contributor Covenant][होमपेज], संस्करण 1.3.0, पर उपलब्ध
+https://contributor-covenant.org/version/1/3/0/
 
 [होमपेज]: https://contributor-covenant.org
-[संस्करण]: https://contributor-covenant.org/version/1/3/0/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -43,8 +43,6 @@ incident.
 
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.3.0, available at
-[https://contributor-covenant.org/version/1/3/0/][version]
+version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/
 
 [homepage]: https://contributor-covenant.org
-[version]: https://contributor-covenant.org/version/1/3/0/


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description
The code of conduct files were inconsistent through the files, so I just made them all match the English.

On the English one I did remove some redundancy since:

```md
[https://contributor-covenant.org/version/1/3/0/][version]

[version]: https://contributor-covenant.org/version/1/3/0/
```

and

```md
https://contributor-covenant.org/version/1/3/0/
```

Are functionally identical.

[version]: https://contributor-covenant.org/version/1/3/0/

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
