### PR TITLE
Change Programming with gtkmm 3 -> Programming with gtkmm 4

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -308,7 +308,7 @@
 
 ### Graphical User Interfaces
 
-* [Programming with gtkmm 3](https://developer.gnome.org/gtkmm-tutorial/stable/)
+* [Programming with gtkmm 4](https://developer.gnome.org/gtkmm-tutorial/stable/)
 * [Search User Interfaces](http://searchuserinterfaces.com/book/) - Marti A. Hearst
 * [The GLib/GTK+ Development Platform](https://people.gnome.org/~swilmet/glib-gtk-dev-platform.pdf) - Sébastien Wilmet (PDF)
 


### PR DESCRIPTION
The book has changed its title to this.

## What does this PR do?
Renames the "Programming with gtkmm 3" book to "Programming with gtkmm 4" to reflect upstream changes.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [X] Search for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists  in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
