### PR TITLE
Changed link that causes error 301 and redirect. Fix for #5313.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This page is available as an easy-to-read website at [https://ebookfoundation.gi
 
 ## Intro
 
-This list was originally a clone of [StackOverflow - List of Freely Available Programming Books](http://web.archive.org/web/20130824154208/http://stackoverflow.com/a/392926) with contributions from Karan Bhangui and George Stocker.
+This list was originally a clone of [StackOverflow - List of Freely Available Programming Books](https://web.archive.org/web/20140606191453/http://stackoverflow.com/questions/194812/list-of-freely-available-programming-books/392926#392926) with contributions from Karan Bhangui and George Stocker.
 
 The list was moved to GitHub by Victor Felder for collaborative updating and maintenance. It has grown to become one of [GitHub's most popular repositories](https://octoverse.github.com/), with 160,000+ stars, 6000+ commits, 1600+ contributors, and 39,000+ forks.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This page is available as an easy-to-read website at [https://ebookfoundation.gi
 
 ## Intro
 
-This list was originally a clone of [StackOverflow - List of Freely Available Programming Books](https://web.archive.org/web/20140606191453/http://stackoverflow.com/questions/194812/list-of-freely-available-programming-books/392926#392926) with contributions from Karan Bhangui and George Stocker.
+This list was originally a clone of [StackOverflow - List of Freely Available Programming Books](https://web.archive.org/web/20140606191453/http://stackoverflow.com/questions/194812/list-of-freely-available-programming-books/392926) with contributions from Karan Bhangui and George Stocker.
 
 The list was moved to GitHub by Victor Felder for collaborative updating and maintenance. It has grown to become one of [GitHub's most popular repositories](https://octoverse.github.com/), with 160,000+ stars, 6000+ commits, 1600+ contributors, and 39,000+ forks.
 


### PR DESCRIPTION
## What does this PR do?
This change switches the previous link that causes a 301 error and a redirect to a direct link to the correct page. It is a fix for #5313 

### Description
This PR switches an old stackoverflow link in the README as outlined in #5313 to a better link that does not cause a redirect.

Old Link: https://web.archive.org/web/20140407005216/http://stackoverflow.com/a/392926 < 301 and Redirect
New Link: https://web.archive.org/web/20140606191453/http://stackoverflow.com/questions/194812/list-of-freely-available-programming-books/392926#392926 < direct link with no error and redirect

### Why is this valuable (or not)?
Someone clicking the link will not receive an error, and an annoying redirect.