### PR TITLE
Added link to opensource Git eBook

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -1466,6 +1466,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [How to Collaborate on Github](https://github.com/eonist/How-to-collaborate-on-github) - André J
 * [Intoduction to Git and Github](https://launchschool.com/books/git) - Launch School
 * [Intoduction to Git and Github - Tutorial](http://cse.unl.edu/~cbourke/gitTutorial.pdf) - Dr. Chris Bourke (PDF)
+* [Introduction to Git and GitHub eBook](https://github.com/bobbyiliev/introduction-to-git-and-github-ebook) - Bobby Iliev (Markdown, PDF)
 * [Learn Git - Learn Version Control with Git](http://www.git-tower.com/learn/git/ebook/command-line/introduction) - Tobias Günther
 * [Pro Git](http://git-scm.com/book/en/v2) - Scott Chacon
 * [Pro Git Reedited](https://leanpub.com/progitreedited/read) - Jon Forrest


### PR DESCRIPTION
## What does this PR do?
Adds a link to an open-source Git eBook

## For resources
### Description
This is a free open-source eBook that I've written a few days ago.

### Why is this valuable (or not)?
This is a good resource for anyone who wants to get started with Git and GitHub.

It is up to the point and easy to read. Unlike other books on that topic, it is not overwhelming and covers the basics that you need to know to start using Git.

### How do we know it's really free?
I wrote it and it is publicly available on GitHub

### For book lists, is it a book? For course lists, is it a course? etc.
eBook available in Markdown and PDF and on GitHub directly.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
