### PR TITLE
Add three .NET podcasts (ru)

### DIFF
--- a/casts/free-podcasts-screencasts-ru.md
+++ b/casts/free-podcasts-screencasts-ru.md
@@ -10,6 +10,7 @@
 * [Java](#java)
   * [Spring](#spring)
 * [JavaScript](#javascript)
+* [.NET](#net)
 * [Node.js](#nodejs)
 * [PHP](#php)
 * [QA](#qa)
@@ -90,6 +91,13 @@
 * [RadioJS](http://radiojs.ru) (Podcast)
 * [UnderJS podcast](https://underjs.ru) (Podcast)
 * [Webstandards](https://soundcloud.com/web-standards) (Podcast)
+
+
+### .NET
+
+* [DotNet & More](https://more.dotnet.ru) - Александр Кугушев и Артём Акуляков (Podcast)
+* [RadioDotNet](https://radio.dotnet.ru) - Анатолий Кулаков и Игорь Лабутин (Podcast)
+* [Solo on .NET](https://youtube.com/playlist?list=PLAFX7TSEV7SOqEQKnrrFiV7bUY8kN5Qof) - Дмитрий Нестерук (Podcast)
 
 
 ### Node.js


### PR DESCRIPTION
* check_urls=free-podcasts-screencasts-ru.md

## What does this PR do?
Add resource(s)

## For resources
### Description
Add Russian .NET podcasts.

### Why is this valuable (or not)?
I am .NET developer, these podcasts are perfect way to be in touch with state of .NET in Russia and more.

### How do we know it's really free?
These podcasts on Anchor have links on other podcast platforms. On Anchor you can listen it without regestering. Same for podcasts on YouTube.

### For book lists, is it a book? For course lists, is it a course? etc.
These are all podcasts, but Solo on .NET has video where you can see the speaker.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
