### PR TITLE
Add App Inventor category and book

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -1001,6 +1001,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### App Inventor
 
+* [Absolute App Inventor 2](https://rm3bukz.ga/read.php?id=Q4GxBgAAQBAJ) - Hossein Amerkashi
 * [App Inventor 2](http://www.appinventor.org/book2) - David Wolber, Hal Abelson, Ellen Spertus, Liz Looney
 
 

--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -999,7 +999,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Mastering Dyalog APL](http://www.dyalog.com/mastering-dyalog-apl.htm) (PDF)
 
 
-#### App Inventor
+### App Inventor
 
 * [App Inventor 2](http://www.appinventor.org/book2) - David Wolber, Hal Abelson, Ellen Spertus, Liz Looney
 

--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -6,6 +6,7 @@
 * [Alef](#alef)
 * [Android](#android)
 * [APL](#apl)
+* [App Inventor](#app-inventor)
 * [Arduino](#arduino)
 * [ASP.NET](#aspnet)
 * [ASP.NET Core](#aspnet-core)
@@ -996,6 +997,11 @@ Kerridge (PDF) (email address *requested*, not required)
 * [A Practical Introduction to APL3 & APL4](http://robertson.uk.net) - Graeme Donald Robertson (PDF)
 * [Introduction to College Mathematics with A Programming Language (1978)](http://www.softwarepreservation.org/projects/apl/Books/CollegeMathematicswithAPL) - E. J. LeCuyer (PDF)
 * [Mastering Dyalog APL](http://www.dyalog.com/mastering-dyalog-apl.htm) (PDF)
+
+
+#### App Inventor
+
+* [App Inventor 2](http://www.appinventor.org/book2) - David Wolber, Hal Abelson, Ellen Spertus, Liz Looney
 
 
 ### Arduino

--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -1001,7 +1001,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### App Inventor
 
-* [Absolute App Inventor 2](https://rm3bukz.ga/read.php?id=Q4GxBgAAQBAJ) - Hossein Amerkashi
+* [Absolute App Inventor 2](https://amerkashi.wordpress.com/2015/02/16/absolute-app-inventor-2-book/) - Hossein Amerkashi
 * [App Inventor 2](http://www.appinventor.org/book2) - David Wolber, Hal Abelson, Ellen Spertus, Liz Looney
 
 


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description

Add App Inventor category and book.

I added "App Inventor" as a category because "Scratch" is a category. Both are block programming languages.

If the maintainers prefer, it could be put in the existing "Android" category because App Inventor (currently) creates apps only for Android.

### Why is this valuable (or not)?

It's a free book.

### How do we know it's really free?

- I'm a co-author.
- There is a Creative Commons license on the linked page.

### For book lists, is it a book? For course lists, is it a course? etc.

It is a book.

## Checklist:
- [ X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [ X] Search for duplicates.
- [ X] Include author(s) and platform where appropriate.
- [ X] Put lists  in alphabetical order, correct spacing.
- [ X] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
