### PR TITLE
Update 'Clojure in Small Pieces' to a working link

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -1240,7 +1240,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Clojure Cookbook](https://github.com/clojure-cookbook/clojure-cookbook)
 * [Clojure Distilled Beginner Guide](http://yogthos.github.io/ClojureDistilled.html)
 * [Clojure for the Brave and True](http://www.braveclojure.com)
-* [Clojure in Small Pieces](http://daly.axiom-developer.org/clojure.pdf) - Rich Hickey (PDF)
+* [Clojure in Small Pieces](https://github.com/robleyhall/clojure-small-pieces/raw/master/clojure-in-small-pieces.pdf) - Rich Hickey (PDF)
 * [Clojure Koans](http://clojurekoans.com)
 * [Clojure Programming](https://en.wikibooks.org/wiki/Clojure_Programming) - Wikibooks
 * [ClojureScript Koans](http://clojurescriptkoans.com)


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description
Clojure in Small Pieces

### Why is this valuable (or not)?
The current link to the PDF is broken (404). This change adds a working link to the PDF.

### How do we know it's really free?
N/A

### For book lists, is it a book? For course lists, is it a course? etc.
Yes

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
