### PR TITLE
Added link to opensource SQL eBook

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -2848,6 +2848,7 @@ Kerridge (PDF) (email address *requested*, not required)
 ### SQL (implementation agnostic)
 
 * [Developing Time-Oriented Database Applications in SQL](https://www2.cs.arizona.edu/~rts/tdbbook.pdf) - Richard T. Snodgrass (PDF)
+* [Introduction to SQL](https://github.com/bobbyiliev/introduction-to-sql) - Bobby Iliev (Markdown, PDF)
 * [SQL For Web Nerds](http://philip.greenspun.com/sql/)
 * [SQL Notes for Professionals](http://goalkicker.com/SQLBook/) - Compiled from StackOverflow Documentation (PDF)
 * [SQL Queries Succinctly](https://www.syncfusion.com/ebooks/sql_queries_succinctly) - Nick Harrison


### PR DESCRIPTION
## What does this PR do?
Adds a link to an open-source SQL eBook

## For resources
### Description
This is a free open-source eBook that I've written a few days ago.

### Why is this valuable (or not)?
This is a good resource for anyone who wants to get started with SQL.

It is up to the point and easy to read. Unlike other books on that topic, it is not overwhelming and covers the basics that you need to know to start using SQL.

### How do we know it's really free?
I wrote it and it is publicly available on GitHub

### For book lists, is it a book? For course lists, is it a course? etc.
eBook available in Markdown and PDF and on GitHub directly.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists  in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
