### PR TITLE
fix: broken link

### DIFF
--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -40,7 +40,7 @@
 
 <h3 id="cpp">C++</h3>
 
-* [C++ Quick Reference](https://www.cs.ccu.edu.tw/~damon/oop/,c++refcard.pdf) (PDF)
+* [C++ Quick Reference](http://www.hoomanb.com/cs/quickref/CppQuickRef.pdf) - Hooman Baradaran (PDF)
 
 
 ### Clojure

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -40,7 +40,7 @@
 
 <h3 id="cpp">C++</h3>
 
-* [C++ Quick Reference](https://www.hoomanb.com/cs/quickref/CppQuickRef.pdf) (PDF)
+* [C++ Quick Reference](https://www.cs.ccu.edu.tw/~damon/oop/,c++refcard.pdf) (PDF)
 
 
 ### Clojure


### PR DESCRIPTION
Fixes #5378
## Description: Fixed the broken pdf link of C++ Cheat Sheet.

### New Link :  https://www.cs.ccu.edu.tw/~damon/oop/,c++refcard.pdf

## What does this PR do?
 Adds info | Improve repo



