### PR TITLE
Add Japanese books on Java, C, and Julia

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -399,6 +399,7 @@
 * [Mozilla Developer Network 日本語ドキュメント](https://developer.mozilla.org/ja/docs/Web/JavaScript) - MDN
 * [The little book of Buster.JS](https://the-little-book-of-busterjs.readthedocs.io/en/latest/) - azu
 * [お気楽 JavaScript プログラミング超入門](http://www.nct9.ne.jp/m_hiroi/light/javascript.html) - 広井誠
+* [とほほのJavaScriptリファレンス](https://www.tohoho-web.com/js) - 杜甫々
 * [一撃必殺JavaScript日本語リファレンス](http://www.openspc2.org/JavaScript/) - 古籏一浩
 * [中上級者になるためのJavaScript](https://kenju.gitbooks.io/js_step-up-to-intermediate/) - Kenju
 

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -246,6 +246,7 @@
 
 * [Ｃプログラミング診断室](http://www.pro.or.jp/~fuji/mybooks/cdiag/) - 藤原博文
 * [C言語](https://ja.wikibooks.org/wiki/C%E8%A8%80%E8%AA%9E) - Wikibooks
+* [C言語のドキュメント](https://docs.microsoft.com/ja-jp/cpp/c-language) - Microsoft Docs
 * [C言語プログラミング入門](http://densan-labs.net/tech/clang/) - @nishio_dens
 * [お気楽Ｃ言語プログラミング超入門](http://www.nct9.ne.jp/m_hiroi/linux/clang.html) - 広井誠
 * [ゲーム作りで学ぶ！実践的C言語プログラミング](http://densan-labs.net/tech/game/) - @nishio_dens

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -443,6 +443,7 @@
 * [Julia 0.3.8](https://stats.biopapyrus.jp/julia) - 孫建強
 * [Julia Language Programming](http://www.nct9.ne.jp/m_hiroi/light/julia.html) - 広井誠
 * [実例で学ぶ Julia-0.4.1](https://www.dropbox.com/s/lk7y8lifjcr1vf2/JuliaBook-20151201.pdf) - Yuichi Motoyama (PDF)
+* [物理で使う数値計算入門：Julia言語による簡単数値計算](https://github.com/cometscome/Julianotes) - 永井佑紀
 
 
 ### LaTeX


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description
Added links to books on JavaScript, C, Julia.

### Why is this valuable (or not)?
- JavaScript book (とほほのJavaScriptリファレンス) :
It is a famous site in Japan. It is an excellent resource that is polite and easy to understand.
- C book (C言語のドキュメント) :
This was written by Microsoft in Japanese. I think it is valuable.
- Julia book (物理で使う数値計算入門：Julia言語による簡単数値計算) :
There are few documents about Julia written in Japanese, so it is valuable.

### How do we know it's really free?
- The JavaScript book (とほほのJavaScriptリファレンス) is published on a non-profit website.
- The C book (C言語のドキュメント) is the document published by Microsoft.
- The Julia book (物理で使う数値計算入門：Julia言語による簡単数値計算) is available on Github.

### For book lists, is it a book? For course lists, is it a course? etc.
Yes, these are all books.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
