### PR TITLE
Removed Fortran book. Fixes #5408

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -1454,7 +1454,6 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### Fortran
 
-* [Introduction to fortran 95 and numerical computing: a jump-start for scientists and engineers](http://people.cs.vt.edu/~asandu/Deposit/Fortran95_notes.pdf) (PDF)
 * [Professional Programmer’s Guide to Fortran77](https://www.star.le.ac.uk/~cgp/prof77.pdf) (PDF)
 * [Self Study Guide: Programming in Fortran 95](http://www.mrao.cam.ac.uk/~rachael/compphys/SelfStudyF95.pdf) (PDF)
 


### PR DESCRIPTION
## What does this PR do?
Remove resource

## For resources
### Description
Remove Fortran Book. Only the first link - http://people.cs.vt.edu/~asandu/Deposit/Fortran95_notes.pdf - was found.

### Why is this valuable (or not)?
It Fixes #5408.

### How do we know it's really free?
Not applicable.

### For book lists, is it a book? For course lists, is it a course? etc.
It is a book removal.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
