### PR TITLE
Fix GitHub pages theme config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,12 @@
 theme: jekyll-theme-minimal
 plugins:
   - jemoji
+  - jekyll-relative-links
+relative_links:
+  enabled: true
+  collections: true
 include:
   - CONTRIBUTING.md
   - LICENSE.md
   - CODE_OF_CONDUCT.md
+

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,7 @@
 theme: jekyll-theme-minimal
 plugins:
   - jemoji
+include:
+  - CONTRIBUTING.md
+  - LICENSE.md
+  - CODE_OF_CONDUCT.md


### PR DESCRIPTION
## What does this PR do?
Improves repo pages at https://ebookfoundation.github.io/free-programming-books

In README.md there are a link to CONTRIBUTING.md that doesn't work as github pages so configure to include some of this meaningful files present in repo.

To compare, preview results are avaliable at
https://davorpa.github.io/free-programming-books

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
