### PR TITLE
Upgrade theme to version v0.2.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,17 @@
-theme: jekyll-theme-minimal
+# [Name of visual theme]
+#theme: jekyll-theme-minimal
+remote_theme: pages-themes/minimal@v0.2.0
+
+# [Used rubygem plugins]
 plugins:
+  - jekyll-remote-theme
   - jemoji
   - jekyll-relative-links
+
 relative_links:
   enabled: true
   collections: true
+
 include:
   - CONTRIBUTING.md
   - LICENSE.md


### PR DESCRIPTION
## What does this PR do?
Improves repo

## Description
Upgrades `jekyll-theme-minimal` to current version `v0.2.0`
See guidelines at: https://github.com/pages-themes/minimal#usage

Related with #2479

It could be checked working on:
- https://davorpa.github.io/free-programming-books
- see html generated sources to compare changes

### How do we know it's really free?
N/A

### For book lists, is it a book? For course lists, is it a course? etc.
N/A

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates. #2479
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
