### PR TITLE
Update SoloLearn playground links

### DIFF
--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -2,8 +2,8 @@
 
 * [Angular](#angular)
 * [C](#c)
-* [C++](#cpp)
 * [C#](#csharp)
+* [C++](#cpp)
 * [ClojureScript](#clojurescript)
 * [Crystal](#crystal)
 * [CSS](#css)
@@ -50,14 +50,14 @@
 * [SoloLearn](https://code.sololearn.com/c)
 
 
-### <a name="cpp"></a>C++
-
-* [SoloLearn](https://code.sololearn.com/cpp)
-
-
 ### <a name="csharp"></a>C#
 
 * [SoloLearn](https://code.sololearn.com/csharp)
+
+
+### <a name="cpp"></a>C++
+
+* [SoloLearn](https://code.sololearn.com/cpp)
 
 
 ### ClojureScript

--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -1,6 +1,9 @@
 ### Index
 
 * [Angular](#angular)
+* [C](#c)
+* [C++](#cpp)
+* [C#](#csharp)
 * [ClojureScript](#clojurescript)
 * [Crystal](#crystal)
 * [CSS](#css)
@@ -42,6 +45,21 @@
 * [StackBlitz](https://stackblitz.com/fork/angular)
 
 
+### <a name="c"></a>C
+
+* [SoloLearn](https://code.sololearn.com/c)
+
+
+### <a name="cpp"></a>C++
+
+* [SoloLearn](https://code.sololearn.com/cpp)
+
+
+### <a name="csharp"></a>C#
+
+* [SoloLearn](https://code.sololearn.com/csharp)
+
+
 ### ClojureScript
 
 * [Replumb REPL](https://clojurescript.io)
@@ -60,6 +78,7 @@
 * [CSSdesk](http://cssdesk.com)
 * [Dabblet](http://dabblet.com)
 * [Flexy Boxes](http://the-echoplex.net/flexyboxes/)
+* [SoloLearn](https://code.sololearn.com/web#css)
 
 
 ### Dart
@@ -98,6 +117,7 @@
 ### Go
 
 * [Go Playground](https://play.golang.org)
+* [SoloLearn](https://code.sololearn.com/go)
 
 
 ### Haskell
@@ -113,7 +133,7 @@
 ### Java
 
 * [repl.it](https://repl.it) (_including a separate Java/Swing_)
-* [SoloLearn](https://code.sololearn.com/#java)
+* [SoloLearn](https://code.sololearn.com/java)
 
 
 ### JavaScript
@@ -124,13 +144,14 @@
 * [JSBin](http://jsbin.com)
 * [JSFiddle](http://jsfiddle.net)
 * [Plunker](http://plnkr.co)
-* [SoloLearn](https://code.sololearn.com/#html)
+* [SoloLearn](https://code.sololearn.com/web#javascript)
 
 
 ### Kotlin
 
 * [Kotlin](https://play.kotlinlang.org)
 * [Kotlin Playground](https://developer.android.com/training/kotlinplayground)
+* [SoloLearn](https://code.sololearn.com/kotlin)
 
 
 ### Kubernetes
@@ -147,6 +168,7 @@
 ### NodeJS
 
 * [Ideone](http://ideone.com)
+* [SoloLearn](https://code.sololearn.com/nodejs)
 
 
 ### OCaml
@@ -165,6 +187,7 @@
 * [ExtendsClass](https://extendsclass.com/php.html)
 * [PHPFiddle](http://phpfiddle.org)
 * [PHPTester](http://phptester.net)
+* [SoloLearn](https://code.sololearn.com/php)
 
 
 ### Python
@@ -173,13 +196,14 @@
 * [Python Trinket](https://trinket.io/python)
 * [Python.org Shell](https://www.python.org/shell)
 * [Repl.it - NiceDualPoin](https://repl.it/repls/NiceDualPoint#main.py)
-* [SoloLearn](https://code.sololearn.com/#py)
+* [SoloLearn](https://code.sololearn.com/python)
 
 
 ### R
 
 * [R-Fiddle](http://www.r-fiddle.org)
 * [Rextester](https://rextester.com/l/r_online_compiler)
+* [SoloLearn](https://code.sololearn.com/r)
 
 
 ### React
@@ -197,7 +221,7 @@
 ### Ruby
 
 * [Codepad](http://codepad.org)
-* [Sololearn](https://code.sololearn.com/#rb)
+* [SoloLearn](https://code.sololearn.com/ruby)
 * [TryRuby](https://try.ruby-lang.org)
 
 
@@ -233,12 +257,10 @@
 ### Swift
 
 * [Online Swift Playground](http://online.swiftplayground.run)
+* [SoloLearn](https://code.sololearn.com/swift)
 
 
 ### TypeScript
 
 * [Playground](https://www.typescriptlang.org/play/index.html)
 * [StackBlitz](https://stackblitz.com/fork/typescript)
-
-
-


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description
- Update SoloLearn playground links: Web, Node.js, Java, Python, Ruby
- Add missing language support: C, C++, C#, Go, Kotlin, PHP, R, Swift

### Why is this valuable (or not)?
It fixes current links to it direct url and also completes list with all supported languages. 

### How do we know it's really free?
Sololearn is mostly free, including playground use. If you need save playground codes, then an account is neccesary.

### For book lists, is it a book? For course lists, is it a course? etc.
A programming playground

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
