### PR TITLE
Apply "Getting Real" book redirect

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -675,7 +675,7 @@
 * [Game AI Pro](http://www.gameaipro.com) - Steve Rabin
 * [Game Design with AGS](https://ensadi.github.io/AGSBook/) - Dave Ensminger, A. G. Madi
 * [Game Programming Patterns](http://gameprogrammingpatterns.com) - Bob Nystrom
-* [Getting Real](http://gettingreal.37signals.com)
+* [Getting Real](https://basecamp.com/books/getting-real) - Basecamp, 37signals ([HTML](https://basecamp.com/gettingreal), [PDF](https://basecamp.com/gettingreal/getting-real.pdf))
 * [Google Maps API Succinctly](https://www.syncfusion.com/ebooks/google_maps_api_succinctly) - Mark Lewin
 * [Hacknot: Essays on Software Development](http://www.lulu.com/shop/ed-johnson/hacknot-essays-on-software-development/ebook/product-17544641.html) - Ed Johnson
 * [Hello SDL](https://lazyfoo.net/tutorials/SDL) - Lazy Foo' Productions


### PR DESCRIPTION
## What does this PR do?
Add info | Improve repo

## For resources
### Description
Apply 301 Redirect before resource link brokes.

From: http://gettingreal.37signals.com
To: https://basecamp.com/books/getting-real

Notified at EbookFoundation/free-programming-books#5253 by @Astrodevil

### Why is this valuable (or not)?
 Changes endpoint before resource link brokes.

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates. #5253
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
