### PR TITLE
Add Official Matplotlib cheat sheets

### DIFF
--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -127,6 +127,7 @@
 * [Comprehensive Python Cheat Sheet for Beginners](https://medium.com/the-codehub/comprehensive-python-cheat-sheet-for-beginners-5d76bb038fa2)
 * [Comprehensive Python Cheatsheet](https://gto76.github.io/python-cheatsheet) - Jure Šorn (HTML)
 * [Learn Python in Y minutes](https://learnxinyminutes.com/docs/python/)
+* [Official Matplotlib cheat sheets](https://github.com/matplotlib/cheatsheets) - Matplotlib.org (LaTeX, PDF)
 * [Python Cheat Sheet](https://websitesetup.org/python-cheat-sheet/)
 * [Python Cheatsheet for beginners](https://www.codecademy.com/learn/learn-python-3/modules/learn-python3-syntax/cheatsheet) - Codeacademy (HTML)
 * [Python Crash Course Cheatsheet](https://ehmatthes.github.io/pcc/cheatsheets/README.html) - Eric Matthes (HTML)


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description
Add link to official Matplotlib.org cheat sheets github repo.

### Why is this valuable (or not)?
Resolves #5467

### How do we know it's really free?
It's the official github repo of this Python library.

### For book lists, is it a book? For course lists, is it a course? etc.
It's a cheatsheet

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
