### PR TITLE
[books] Move HgInit to books

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -2145,7 +2145,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### Mercurial
 
-* [HGInit - Mercurial Tutorial](https://web.archive.org/web/20180926172759/http://hginit.com/) - Joel Spolsky
+* [Hg Init: a Mercurial Tutorial](https://hginit.github.io) - Joel Spolsky
 * [Mercurial: The Definitive Guide](http://hgbook.red-bean.com)
 * [Mercurial: The Definitive Guide 2nd edition](https://book.mercurial-scm.org)
 

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -45,7 +45,6 @@
 * [Machine Learning](#machine-learning)
 * [Markdown](#markdown)
 * [Matlab](#matlab)
-* [Mercurial](#mercurial)
 * [Misc](#misc)
 * [.NET](#net)
 * [OCaml](#ocaml)
@@ -532,11 +531,6 @@
 * [Introduction to Matlab in English](https://www.youtube.com/playlist?list=PLGED90Y_uL1KLpdRmVtwfpNoYCWU9RPkK) -Mohammed Mohammed
 * [MATLAB and Simulink Training](https://matlabacademy.mathworks.com)
 * [MIT 18.S997 Introduction to MATLAB Programming](http://ocw.mit.edu/courses/mathematics/18-s997-introduction-to-matlab-programming-fall-2011/)
-
-
-### Mercurial
-
-* [Hg Init: a Mercurial Tutorial](https://hginit.github.io) - Joel Spolsky
 
 
 ### Misc


### PR DESCRIPTION
## What does this PR do?
Improve repo. HgInit was listed twice - once as a course, and once as a book. This removes the Web Archive link from the book, and replaces it with the stable link.

## For resources
### Description

### Why is this valuable (or not)?

As discussed in https://github.com/EbookFoundation/free-programming-books/issues/5112#issuecomment-891993012

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!