### PR TITLE
Update Ubuntu Server guide to latest LTS 20.04 to fix link redirection

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -2070,7 +2070,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [The Linux Kernel Module Programming Guide](https://sysprog21.github.io/lkmpg/)
 * [The Linux System Administrator's Guide](http://www.tldp.org/LDP/sag/html/index.html)
 * [Ubuntu Pocket Guide and Reference](http://www.ubuntupocketguide.com/index_main.html)
-* [Ubuntu Server Guide](https://help.ubuntu.com/16.04/serverguide/serverguide.pdf) (PDF)
+* [Ubuntu Server Guide](https://help.ubuntu.com/20.04/serverguide/serverguide.pdf) (PDF)
 * [Understanding the Linux Virtual Memory Manager](https://www.kernel.org/doc/gorman/) - Mel Gorman (HTML, PDF)
 * [UNIX Systems Programming for SVR4](http://www.bitsinthewind.com/about-dac/publications/unix-systems-programming) - David A. Curry
 * [Upstart Intro, Cookbook and Best Practises](http://upstart.ubuntu.com/cookbook/)


### PR DESCRIPTION
## What does this PR do?
Improve Repo by fixing broken link

## For resources
### Description
Fixed a broken link for the Ubuntu Server guide, which had been using 16.04 in the URL. This was then redirected to the PDF version of the guide, but the URL was no longer supported by Ubuntu and resulted in a 404. Updating to 20.04 LTS fixed the redirection and results in the PDF for the guide loading in browser.

### Why is this valuable (or not)?

### How do we know it's really free?
Same link as previous version, except for the current LTS where redirection is supported.

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
