### PR TITLE
Fix broken link: Arduino Programming Notebook by Brian Evans

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -1020,7 +1020,7 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### Arduino
 
-* [Arduino Programming Notebook](http://www.lulu.com/shop/brian-evans/arduino-programming-notebook/ebook/product-18598708.html) - Brian Evans
+* [Arduino Programming Notebook](https://unglue.it/work/152452) - Brian Evans (PDF) (:card_file_box: *archived at unglue.it*)
 * [Arduino Tips, Tricks, and Techniques](https://cdn-learn.adafruit.com/downloads/pdf/arduino-tips-tricks-and-techniques.pdf) - lady ada (PDF)
 * [Getting started with Arduino – A Beginner’s Guide](http://manuals.makeuseof.com.s3.amazonaws.com/for-mobile/Arduino_-_MakeUseOf.com.pdf) - Brad Kendall (PDF)
 * [Getting Started with Arduino products](https://www.arduino.cc/en/Guide) - Official Arduino Documentation (:construction: *in process*)


### PR DESCRIPTION
## What does this PR do?
 Improve repo

## For resources
### Description

Arduino Programming Notebook
By: Brian Evans

Broken: http://www.lulu.com/shop/brian-evans/arduino-programming-notebook/ebook/product-18598708.html
Options: 
- **Unglued**: https://unglue.it/work/152452/ :heavy_check_mark:
- Archive: https://archive.org/details/arduino_notebook

### Why is this valuable (or not)?
Resolves #5504

### How do we know it's really free?
Unglued :wink:

### For book lists, is it a book? For course lists, is it a course? etc.
It's a book

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
