### PR TITLE
ci(deps): configure dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,8 @@ updates:
       # Separate sections of the branch name with a hyphen
       # for example, `dependabot/github_actions/actions/checkout-2.3.1`
       separator: "/"
+    # Add the arrays of assignees and reviewers
+    assignees:
+      - "EbookFoundation/maintainers"
+    reviewers:
+      - "EbookFoundation/reviewers"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Github Dependabot. Config file
+# Github Dependabot config file
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,9 @@ updates:
       timezone: "Europe/Paris"
     # Specify labels for `gha` pull requests
     labels:
-      - "dependencies"
-      - "dependencies:github-actions"
-      - "automation"
+      - "🔗 dependencies"
+      - "🔗 dependencies:github-actions"
+      - "🤖 automation"
     commit-message:
       # Prefix all commit messages with `chore` (follow conventional-commits)
       # include a list of updated dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Github Dependabot. Config file
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "12:00"
+      timezone: "Europe/Paris"
+    # Specify labels for `gha` pull requests
+    labels:
+      - "github-actions"
+      - "dependencies"
+    commit-message:
+      # Prefix all commit messages with `gha`
+      # include a list of updated dependencies
+      prefix: "gha"
+      include: "scope"
+    # Allow up to N open pull requests (0 to disable)
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      # for example, `dependabot/github_actions/actions/checkout-2.3.1`
+      separator: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,12 +16,13 @@ updates:
       timezone: "Europe/Paris"
     # Specify labels for `gha` pull requests
     labels:
-      - "github-actions"
       - "dependencies"
+      - "dependencies:github-actions"
+      - "automation"
     commit-message:
-      # Prefix all commit messages with `gha`
+      # Prefix all commit messages with `chore` (follow conventional-commits)
       # include a list of updated dependencies
-      prefix: "gha"
+      prefix: "chore"
       include: "scope"
     # Allow up to N open pull requests (0 to disable)
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this PR do?

1. *Dependabot checks for updates*. Dependabot pulls down your dependency files and looks for any outdated or insecure requirements.
2. *Dependabot opens pull requests*. If any of your dependencies are out-of-date, Dependabot opens individual pull requests to update each one.
3. *You review and merge*. You check that your tests pass, scan the included changelog and release notes, then hit merge with confidence.

So, **this PR configures [Dependabot](https://dependabot.com/) to automatize** this process for github-actions artifacts used in repository workflows.

As is config provided **needes add this labels** to github repo/org:
https://github.com/EbookFoundation/free-programming-books/blob/786ae8b00b09a418f9d70b6ea5f6c944bd813afd/.github/dependabot.yml#L17-L22

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Provide `dependabot.yml` config file.
- [x] Choose labels and add them to repo or if config is centralized, do it in organization.
- [ ] Enable dependabot in repo settings

## Followup

- Check the output of Travis-CI for linter errors!
