### PR TITLE
Remove broken 'exploring elastic search' link.

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -866,7 +866,6 @@ Kerridge (PDF) (email address *requested*, not required)
 #### Search Engines
 
 * [Elasticsearch: The Definitive Guide](https://www.elastic.co/guide/en/elasticsearch/guide/current/index.html) ([fork it on GH](https://github.com/elastic/elasticsearch-definitive-guide))
-* [Exploring Elasticsearch](http://exploringelasticsearch.com)
 * [Solr for newbies workshop (2019)](https://github.com/hectorcorrea/solr-for-newbies) - Hector Correa ([PDF](https://github.com/hectorcorrea/solr-for-newbies/blob/master/tutorial.pdf))
 
 


### PR DESCRIPTION
## What does this PR do?
Remove resource(s)

## For resources
### Description

Removed a broken link to http://exploringelasticsearch.com from the Search Engines list.

### Why is this valuable (or not)?

Changes satisfy the [Guidelines](https://github.com/EbookFoundation/free-programming-books/blob/7023637f37d453a4ccee61c49af7eaaeccc9e8af/CONTRIBUTING.md#guidelines) set for removal of a link from the list.

### How do we know it's really free?

Not Applicable

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
