### PR TITLE
Fix broken link: C Programming Boot Camp by Paul Gribble

### DIFF
--- a/books/free-programming-books.md
+++ b/books/free-programming-books.md
@@ -1159,7 +1159,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [C for Python Programmers - Carl Burch](http://www.toves.org/books/cpy/)
 * [C Notes for Professionals](https://goalkicker.com/CBook) - Compiled from StackOverflow Documentation (PDF)
 * [C Programming](https://en.wikibooks.org/wiki/Programming%3AC) - Wikibooks
-* [C Programming Boot Camp - Paul Gribble](http://www.gribblelab.org/CBootCamp/)
+* [C Programming Boot Camp - Paul Gribble](https://gribblelab.org/teaching/CBootCamp/)
 * [Deep C](http://www.slideshare.net/olvemaudal/deep-c)
 * [Essential C](http://cslibrary.stanford.edu/101/EssentialC.pdf) - Nick Parlante (PDF)
 * [Everything you need to know about pointers in C - Peter Hosey](http://boredzo.org/pointers/)


### PR DESCRIPTION
## What does this PR do?

Improve repo

## For resources
### Description

C Programming Boot Camp by Paul Gribble

### Why is this valuable (or not)?

The resource appears to have moved from http://www.gribblelab.org/CBootCamp/ to https://gribblelab.org/teaching/CBootCamp/

### How do we know it's really free?

This work is licensed under a Creative Commons Attribution 4.0 International License

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
