### PR TITLE
Improve Japanese resource

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -415,7 +415,7 @@
 
 #### AngularJS
 
-> :information_source: See also &#8230; [Angular](#angular)
+> :information_source: 関連項目 - [Angular](#angular)
 
 * [AngularJS 1.2 日本語リファレンス](http://js.studio-kingdom.com/angularjs) - @tomof(翻訳)
 * [AngularJS's tutorial - あなたとともにAngularJS](http://lab.hisasann.com/AngularJSTutorial/) - @hisasann
@@ -690,7 +690,7 @@
 
 #### Angular
 
-> :information_source: See also &#8230; [AngularJS](#angularjs)
+> :information_source: 関連項目 - [AngularJS](#angularjs)
 
 * [Angular Docs](https://angular.jp/docs)
 * [Angular Tutorial](https://angular.jp/tutorial)

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -109,7 +109,7 @@
 #### グラフィックスプログラミング
 
 * [DirectX プログラミング](https://docs.microsoft.com/ja-jp/windows/uwp/gaming/directx-programming) - Microsoft Docs
-* [GLUTによる「手抜き」OpenGL入門](http://www.wakayama-u.ac.jp/~tokoi/opengl/libglut.html) - 床井浩平
+* [GLUTによる「手抜き」OpenGL入門](https://www.wakayama-u.ac.jp/~tokoi/opengl/libglut.html) - 床井浩平
 * [iOS OpenGL ES プログラミングガイド](https://developer.apple.com/jp/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/Introduction/Introduction.html) - Apple Developer (HTML)
 * [はじめてのBlenderアドオン開発 (Blender 2.7版)](https://colorful-pico.net/introduction-to-addon-development-in-blender/2.7/) - nutti
 * [仮想物理実験室構築のためのOpenGL, WebGL, GLSL入門](http://www.natural-science.or.jp/laboratory/opengl_intro.php) - 遠藤理平
@@ -117,7 +117,7 @@
 
 #### グラフィックユーザーインターフェイス
 
-* [Qtプログラミング入門](http://densan-labs.net/tech/qt/) - @nishio_dens
+* [Qtプログラミング入門](https://densan-labs.net/tech/qt) - @nishio_dens
 
 
 #### コンテナ
@@ -128,46 +128,46 @@
 
 #### セキュリティ
 
-* [RSA暗号体験入門](http://www.cybersyndrome.net/rsa/) - CyberSyndrome
+* [RSA暗号体験入門](http://www.cybersyndrome.net/rsa) - CyberSyndrome
 * [ウェブ健康診断仕様](https://www.ipa.go.jp/files/000017319.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [クラウドを支えるこれからの暗号技術](https://herumi.github.io/ango/) - 光成滋生 (PDF)
+* [クラウドを支えるこれからの暗号技術](https://herumi.github.io/ango) - 光成滋生 (PDF)
 * [セキュア・プログラミング講座](https://www.ipa.go.jp/security/awareness/vendor/programming) - 塩田英二 ([PDF](https://www.ipa.go.jp/files/000059838.pdf))
-* [はやわかり RSA](http://www.mew.org/~kazu/doc/rsa.html) - 山本和彦
+* [はやわかり RSA](https://www.mew.org/~kazu/doc/rsa.html) - 山本和彦
 * [安全なSQLの呼び出し方](https://www.ipa.go.jp/files/000017320.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 * [安全なウェブサイトの作り方](https://www.ipa.go.jp/files/000017316.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [暗号化アルゴリズム ([1])](http://fussy.web.fc2.com/algo/algo9-1.htm) - Fussy ([2](http://fussy.web.fc2.com/algo/algo9-2.htm)),  ([3](http://fussy.web.fc2.com/algo/algo9-3.htm)), ([4](http://fussy.web.fc2.com/algo/cipher4_elgamal.htm))
+* [暗号化アルゴリズム ([1])](https://fussy.web.fc2.com/algo/algo9-1.htm) - Fussy ([2](https://fussy.web.fc2.com/algo/algo9-2.htm)),  ([3](https://fussy.web.fc2.com/algo/algo9-3.htm)), ([4](https://fussy.web.fc2.com/algo/cipher4_elgamal.htm))
 
 
 #### その他の話題
 
-* [ケヴィン・ケリー著作選集　１](http://tatsu-zine.com/books/kk1) - ケヴィン・ケリー, 堺屋七左衛門(翻訳)
-* [ケヴィン・ケリー著作選集　２](http://tatsu-zine.com/books/kk2) - ケヴィン・ケリー, 堺屋七左衛門(翻訳)
-* [ケヴィン・ケリー著作選集　３](http://tatsu-zine.com/books/kk3) - ケヴィン・ケリー, 堺屋七左衛門(翻訳)
+* [ケヴィン・ケリー著作選集　１](https://tatsu-zine.com/books/kk1) - ケヴィン・ケリー, 堺屋七左衛門(翻訳)
+* [ケヴィン・ケリー著作選集　２](https://tatsu-zine.com/books/kk2) - ケヴィン・ケリー, 堺屋七左衛門(翻訳)
+* [ケヴィン・ケリー著作選集　３](https://tatsu-zine.com/books/kk3) - ケヴィン・ケリー, 堺屋七左衛門(翻訳)
 * [青木靖 翻訳集](http://www.aoky.net) - 青木靖
-* [川合史朗 翻訳集](http://practical-scheme.net/index-j.html) - 川合史朗
+* [川合史朗 翻訳集](https://practical-scheme.net/index-j.html) - 川合史朗
 
 
 #### ソフトウェアアーキテクチャ
 
-* [ギコ猫とデザインパターン](http://www.hyuki.com/dp/cat_index.html) - 結城浩
-* [デザインパターン](http://www.techscore.com/tech/DesignPattern/) - シナジーマーケティング株式会社
+* [ギコ猫とデザインパターン](https://www.hyuki.com/dp/cat_index.html) - 結城浩
+* [デザインパターン](https://www.techscore.com/tech/DesignPattern) - シナジーマーケティング株式会社
 
 
 #### ソフトウェア開発方法論
 
-* [塹壕より Scrum と  XP](http://www.infoq.com/jp/minibooks/scrum-xp-from-the-trenches) - Henrik Kniberg
+* [塹壕より Scrum と  XP](https://www.infoq.com/jp/minibooks/scrum-xp-from-the-trenches) - Henrik Kniberg
 
 
 #### ソフトウェア品質
 
-* [高信頼化ソフトウェアのための開発手法ガイドブック](http://www.ipa.go.jp/files/000005144.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みシステムの安全性向上の勧め（機能安全編）](http://www.ipa.go.jp/files/000005118.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア開発におけるプロジェクトマネジメント導入の勧め](http://www.ipa.go.jp/files/000005105.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア開発における品質向上の勧め [バグ管理手法編]](http://www.ipa.go.jp/files/000027629.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア開発における品質向上の勧め [ユーザビリティ編]](http://www.ipa.go.jp/files/000005114.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア開発における品質向上の勧め [設計モデリング編]](http://www.ipa.go.jp/files/000005113.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア開発における品質向上の勧め（コーディング編）](http://www.ipa.go.jp/files/000005106.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア開発における品質向上の勧め［テスト編～事例集～］](http://www.ipa.go.jp/files/000005149.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [高信頼化ソフトウェアのための開発手法ガイドブック](https://www.ipa.go.jp/files/000005144.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みシステムの安全性向上の勧め（機能安全編）](https://www.ipa.go.jp/files/000005118.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア開発におけるプロジェクトマネジメント導入の勧め](https://www.ipa.go.jp/files/000005105.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア開発における品質向上の勧め [バグ管理手法編]](https://www.ipa.go.jp/files/000027629.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア開発における品質向上の勧め [ユーザビリティ編]](https://www.ipa.go.jp/files/000005114.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア開発における品質向上の勧め [設計モデリング編]](https://www.ipa.go.jp/files/000005113.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア開発における品質向上の勧め（コーディング編）](https://www.ipa.go.jp/files/000005106.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア開発における品質向上の勧め［テスト編～事例集～］](https://www.ipa.go.jp/files/000005149.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 
 
 #### データベース
@@ -177,16 +177,16 @@
 
 #### ネットワーキング
 
-* [HTTP/3 explained](https://http3-explained.haxx.se/ja/) - Daniel Stenberg
+* [HTTP/3 explained](https://http3-explained.haxx.se/ja) - Daniel Stenberg
 * [http2 explained](https://http2-explained.haxx.se/ja) - Daniel Stenberg
-* [ネットワークプログラミングの基礎知識](http://x68000.q-e-d.net/~68user/net/) - 68user
+* [ネットワークプログラミングの基礎知識](http://x68000.q-e-d.net/~68user/net) - 68user
 
 
 #### 機械学習
 
-* [Jubatus : オンライン機械学習向け分散処理フレームワーク](http://jubat.us/ja/)
-* [Mahoutで体感する機械学習の実践](http://gihyo.jp/dev/serial/01/mahout) - やまかつ
-* [機械学習 はじめよう](http://gihyo.jp/dev/serial/01/machine-learning) - 中谷秀洋，恩田伊織
+* [Jubatus : オンライン機械学習向け分散処理フレームワーク](http://jubat.us/ja) - Jubatus
+* [Mahoutで体感する機械学習の実践](https://gihyo.jp/dev/serial/01/mahout) - やまかつ
+* [機械学習 はじめよう](https://gihyo.jp/dev/serial/01/machine-learning) - 中谷秀洋，恩田伊織
 * [強化学習入門](https://github.com/komi1230/Resume/raw/master/book_reinforcement/book.pdf) - 小南佑介 (PDF)
 
 
@@ -198,25 +198,25 @@
 
 #### 組み込みシステム
 
-* [【改訂版】 組込みソフトウェア開発向け コーディング作法ガイド［C言語版］](http://www.ipa.go.jp/files/000005123.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [【改訂版】 組込みソフトウェア開発向け 品質作り込みガイド](http://www.ipa.go.jp/files/000005146.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [【改訂版】 組込みソフトウェア向け 開発プロセスガイド](http://www.ipa.go.jp/files/000005126.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア開発向け コーディング作法ガイド［C++言語版］](http://www.ipa.go.jp/files/000005142.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア向け プロジェクトマネジメントガイド［計画書編］](http://www.ipa.go.jp/files/000005116.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア向け プロジェクト計画立案トレーニングガイド](http://www.ipa.go.jp/files/000005145.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア向け 設計ガイド ESDR［事例編］](http://www.ipa.go.jp/files/000005148.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [【改訂版】 組込みソフトウェア開発向け コーディング作法ガイド［C言語版］](https://www.ipa.go.jp/files/000005123.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [【改訂版】 組込みソフトウェア開発向け 品質作り込みガイド](https://www.ipa.go.jp/files/000005146.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [【改訂版】 組込みソフトウェア向け 開発プロセスガイド](https://www.ipa.go.jp/files/000005126.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア開発向け コーディング作法ガイド［C++言語版］](https://www.ipa.go.jp/files/000005142.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア向け プロジェクトマネジメントガイド［計画書編］](https://www.ipa.go.jp/files/000005116.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア向け プロジェクト計画立案トレーニングガイド](https://www.ipa.go.jp/files/000005145.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [組込みソフトウェア向け 設計ガイド ESDR［事例編］](https://www.ipa.go.jp/files/000005148.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 
 
 #### 並列プログラミング
 
-* [インテル コンパイラー OpenMP 入門](http://jp.xlsoft.com/documents/intel/compiler/525J-001.pdf) - 戸室隆彦 (PDF)
-* [これからの並列計算のためのGPGPU連載講座 [I]](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No1/201001gpgpu.pdf) - 大島聡史 ([II](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No2/201003gpgpu.pdf)),  ([III](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No3/201005_gpgpu2.pdf)),  ([VI](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No4/201007_gpgpu.pdf)),  ([V](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No5/201009_gpgpu.pdf)),  ([VI](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No6/201011_gpgpu.pdf)) (PDF)
-* [連載講座: 高生産並列言語を使いこなす [1]](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No1/Rensai201101.pdf) - 田浦健次朗 ([2](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No3/Rensai201105.pdf)), ([3](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No4/Rensai201107.pdf)), ([4](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No5/Rennsai201109.pdf)), ([5](http://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No6/Rennsai201111.pdf)) (PDF)
+* [インテル コンパイラー OpenMP 入門](https://jp.xlsoft.com/documents/intel/compiler/525J-001.pdf) - 戸室隆彦 (PDF)
+* [これからの並列計算のためのGPGPU連載講座 [I]](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No1/201001gpgpu.pdf) - 大島聡史 ([II](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No2/201003gpgpu.pdf)),  ([III](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No3/201005_gpgpu2.pdf)),  ([VI](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No4/201007_gpgpu.pdf)),  ([V](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No5/201009_gpgpu.pdf)),  ([VI](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL12/No6/201011_gpgpu.pdf)) (PDF)
+* [連載講座: 高生産並列言語を使いこなす [1]](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No1/Rensai201101.pdf) - 田浦健次朗 ([2](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No3/Rensai201105.pdf)), ([3](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No4/Rensai201107.pdf)), ([4](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No5/Rennsai201109.pdf)), ([5](https://www.cc.u-tokyo.ac.jp/support/press/news/VOL13/No6/Rennsai201111.pdf)) (PDF)
 
 
 #### 理論計算機科学
 
-* [計算機プログラムの構造と解釈 第二版](https://sicp.iijlab.net/fulltext/) - Gerald Jay Sussman et al.
+* [計算機プログラムの構造と解釈 第二版](https://sicp.iijlab.net/fulltext) - Gerald Jay Sussman et al.
 
 
 ### Android
@@ -230,49 +230,49 @@
 
 ### AppleScript
 
-* [Applescript のごく基本的なサンプル](http://www.asahi-net.or.jp/~va5n-okmt/factory/applescript/sample_code/) - Okamoto
+* [Applescript のごく基本的なサンプル](http://www.asahi-net.or.jp/~va5n-okmt/factory/applescript/sample_code) - Okamoto
 * [AppleScript 言語ガイド(改訂版)](https://sites.google.com/site/zzaatrans/home/applescriptlangguide)
 
 
 ### AWK
 
 * [AWK の第一歩](https://www.magata.net/memo/index.php?plugin=attach&pcmd=open&file=awk%A5%DE%A5%CB%A5%E5%A5%A2%A5%EB.pdf&refer=%A5%B7%A5%A7%A5%EB%A5%B3%A5%DE%A5%F3%A5%C9) - 小栗栖修 (PDF)
-* [AWK リファレンス](http://shellscript.sunone.me/awk.html) - SUNONE
+* [AWK リファレンス](https://shellscript.sunone.me/awk.html) - SUNONE
 * [Effective AWK Programming](http://www.kt.rim.or.jp/~kbk/gawk-30/gawk_toc.html) - Arnold D. Robbins
 
 
 ### Bash
 
-* [BASH Programming - Introduction HOW-TO](http://linuxjf.osdn.jp/JFdocs/Bash-Prog-Intro-HOWTO.html) - Mike G, 千旦裕司(翻訳)
-* [Bash 基礎文法最速マスター](http://d.hatena.ne.jp/nattou_curry_2/20100131/1264910483) - id:nattou\_curry
+* [BASH Programming - Introduction HOW-TO](https://linuxjf.osdn.jp/JFdocs/Bash-Prog-Intro-HOWTO.html) - Mike G, 千旦裕司(翻訳)
+* [Bash 基礎文法最速マスター](https://d.hatena.ne.jp/nattou_curry_2/20100131/1264910483) - id:nattou\_curry
 * [Bashのよくある間違い](https://yakst.com/ja/posts/2929) - GreyCat, @yakstcom(翻訳)
 * [The Art of Command Line](https://github.com/jlevy/the-art-of-command-line/blob/master/README-ja.md) - Joshua Levy, Hayato Matsuura(翻訳)
-* [UNIX & Linux コマンド・シェルスクリプト リファレンス](http://shellscript.sunone.me) - SUNONE
+* [UNIX & Linux コマンド・シェルスクリプト リファレンス](https://shellscript.sunone.me) - SUNONE
 
 
 ### C
 
-* [Ｃプログラミング診断室](http://www.pro.or.jp/~fuji/mybooks/cdiag/) - 藤原博文
+* [Ｃプログラミング診断室](http://www.pro.or.jp/~fuji/mybooks/cdiag) - 藤原博文
 * [C言語](https://ja.wikibooks.org/wiki/C%E8%A8%80%E8%AA%9E) - Wikibooks
 * [C言語のドキュメント](https://docs.microsoft.com/ja-jp/cpp/c-language) - Microsoft Docs
-* [C言語プログラミング入門](http://densan-labs.net/tech/clang/) - @nishio_dens
+* [C言語プログラミング入門](https://densan-labs.net/tech/clang) - @nishio_dens
 * [お気楽Ｃ言語プログラミング超入門](http://www.nct9.ne.jp/m_hiroi/linux/clang.html) - 広井誠
-* [ゲーム作りで学ぶ！実践的C言語プログラミング](http://densan-labs.net/tech/game/) - @nishio_dens
+* [ゲーム作りで学ぶ！実践的C言語プログラミング](https://densan-labs.net/tech/game) - @nishio_dens
 * [苦しんで覚えるＣ言語](https://9cguide.appspot.com) - MMGames/森口将憲
-* [計算物理のためのC/C++言語入門](http://cms.phys.s.u-tokyo.ac.jp/~naoki/CIPINTRO/) - 渡辺尚貴
-* [猫でもわかるプログラミング](http://kumei.ne.jp/c_lang/) - 粂井康孝
+* [計算物理のためのC/C++言語入門](http://cms.phys.s.u-tokyo.ac.jp/~naoki/CIPINTRO) - 渡辺尚貴
+* [猫でもわかるプログラミング](http://kumei.ne.jp/c_lang) - 粂井康孝
 
 
 <h3 id="cpp">C++</h3>
 
 * [C++11の文法と機能(C++11: Syntax and Feature)](https://ezoeryou.github.io/cpp-book/C++11-Syntax-and-Feature.xhtml) - 江添亮
-* [C++入門](http://www.asahi-net.or.jp/~yf8k-kbys/newcpp0.html) - 小林健一郎
+* [C++入門](https://www.asahi-net.or.jp/~yf8k-kbys/newcpp0.html) - 小林健一郎
 * [cpprefjp - C++ Reference Site in Japanese](https://cpprefjp.github.io)
 * [Google C++ スタイルガイド 日本語全訳](https://ttsuki.github.io/styleguide/cppguide.ja.html) - Benjy Weinberger, Craig Silverstein, Gregory Eitzmann, Mark Mentovai, Tashana Landray, ttsuki(翻訳)
-* [Standard Template Library プログラミング](https://web.archive.org/web/20170607163002/http://episteme.wankuma.com/stlprog/) - επιστημη
+* [Standard Template Library プログラミング](https://web.archive.org/web/20170607163002/http://episteme.wankuma.com/stlprog) - επιστημη
 * [お気楽Ｃ++プログラミング超入門](http://www.nct9.ne.jp/m_hiroi/linux/cpp.html) - 広井誠
-* [ロベールのＣ＋＋教室](http://www7b.biglobe.ne.jp/~robe/cpphtml/) - ロベール
-* [江添亮のC++入門](https://ezoeryou.github.io/cpp-intro/) - 江添亮
+* [ロベールのＣ＋＋教室](http://www7b.biglobe.ne.jp/~robe/cpphtml) - ロベール
+* [江添亮のC++入門](https://ezoeryou.github.io/cpp-intro) - 江添亮
 
 
 ### Clojure
@@ -285,24 +285,24 @@
 ### CoffeeScript
 
 * [CoffeeScript 言語リファレンス](http://memo.sappari.org/coffeescript/coffeescript-langref)
-* [CoffeeScript基礎文法最速マスター](http://blog.bokuweb.me/entry/2015/01/06/190240) - id:bokuweb
-* [The Little Book on CoffeeScript](http://minghai.github.io/library/coffeescript/) - Alex MacCaw, Narumi Katoh(翻訳)
-* [基本操作逆引きリファレンス（CoffeeScript）](http://kyu-mu.net/coffeescript/revref/) - 飯塚直
-* [正規表現リファレンス（CoffeeScript)](http://kyu-mu.net/coffeescript/regexp/) - 飯塚直
+* [CoffeeScript基礎文法最速マスター](https://blog.bokuweb.me/entry/2015/01/06/190240) - id:bokuweb
+* [The Little Book on CoffeeScript](https://minghai.github.io/library/coffeescript) - Alex MacCaw, Narumi Katoh(翻訳)
+* [基本操作逆引きリファレンス（CoffeeScript）](https://kyu-mu.net/coffeescript/revref) - 飯塚直
+* [正規表現リファレンス（CoffeeScript)](https://kyu-mu.net/coffeescript/regexp) - 飯塚直
 
 
 ### Common Lisp
 
 * [Common Lisp 入門](http://www.nct9.ne.jp/m_hiroi/xyzzy_lisp.html#abclisp) - 広井誠
 * [Google Common Lisp スタイルガイド 日本語訳](https://lisphub.jp/doc/google-common-lisp-style-guide/lispguide.xml) - Robert Brown, François-René Rideau, TOYOZUMIKouichi 他(翻訳)
-* [LISP and PROLOG](https://web.archive.org/web/20060526095202/http://home.soka.ac.jp/~unemi/LispProlog/) - 畝見達夫
-* [On Lisp (草稿)](http://www.asahi-net.or.jp/~kc7k-nd/) - Paul Graham, 野田開(翻訳)
-* [マンガで分かるLisp(Manga Guide to Lisp)](http://lambda.bugyo.tk/cdr/mwl/) - λ組
+* [LISP and PROLOG](https://web.archive.org/web/20060526095202/http://home.soka.ac.jp/~unemi/LispProlog) - 畝見達夫
+* [On Lisp (草稿)](http://www.asahi-net.or.jp/~kc7k-nd) - Paul Graham, 野田開(翻訳)
+* [マンガで分かるLisp(Manga Guide to Lisp)](http://lambda.bugyo.tk/cdr/mwl) - λ組
 
 
 ### Coq
 
-* [ソフトウェアの基礎](http://proofcafe.org/sf/) - Benjamin C. Pierce, Chris Casinghino, Michael Greenberg, Vilhelm Sjöberg, Brent Yorgey, 梅村晃広(翻訳), 片山功士(翻訳), 水野洋樹(翻訳), 大橋台地(翻訳), 増子萌(翻訳), 今井宜洋(翻訳)
+* [ソフトウェアの基礎](http://proofcafe.org/sf) - Benjamin C. Pierce, Chris Casinghino, Michael Greenberg, Vilhelm Sjöberg, Brent Yorgey, 梅村晃広(翻訳), 片山功士(翻訳), 水野洋樹(翻訳), 大橋台地(翻訳), 増子萌(翻訳), 今井宜洋(翻訳)
 
 
 ### D
@@ -312,12 +312,12 @@
 
 ### Elixir
 
-* [Elixir 基礎文法最速マスター](http://qiita.com/niku/items/729ece76d78057b58271) - niku
+* [Elixir 基礎文法最速マスター](https://qiita.com/niku/items/729ece76d78057b58271) - niku
 
 
 ### Emacs Lisp
 
-* [Emacs Lisp基礎文法最速マスター](http://d.hatena.ne.jp/rubikitch/20100201/elispsyntax) - id:rubikitch
+* [Emacs Lisp基礎文法最速マスター](https://d.hatena.ne.jp/rubikitch/20100201/elispsyntax) - るびきち
 * [GNU Emacs Lispリファレンスマニュアル](http://www.fan.gr.jp/~ring/doc/elisp_20/elisp.html)
 
 
@@ -328,22 +328,22 @@
 
 ### Git
 
-* [git - 簡単ガイド](http://rogerdudler.github.io/git-guide/index.ja.html) - Roger Dudler, @nacho4d(翻訳)
-* [Git ユーザマニュアル (バージョン 1.5.3 以降用)](http://cdn8.atwikiimg.com/git_jp/pub/git-manual-jp/Documentation/user-manual.html) - Yasuaki Narita
+* [git - 簡単ガイド](https://rogerdudler.github.io/git-guide/index.ja.html) - Roger Dudler, @nacho4d(翻訳)
+* [Git ユーザマニュアル (バージョン 1.5.3 以降用)](https://cdn8.atwikiimg.com/git_jp/pub/git-manual-jp/Documentation/user-manual.html) - Yasuaki Narita
 * [GitHubカンニング・ペーパー](https://github.com/tiimgreen/github-cheat-sheet/blob/master/README.ja.md) - Tim Green, marocchino(翻訳)
 * [Pro Git](http://git-scm.com/book/ja/) - Scott Chacon, 高木正弘 他(翻訳) ([PDF](https://raw.github.com/progit-ja/progit/master/progit.ja.pdf), [EPUB](https://raw.github.com/progit-ja/progit/master/progit.ja.epub), [MOBI](https://raw.github.com/progit-ja/progit/master/progit.ja.mobi))
-* [Steins;Git 第二版](http://o2project.github.io/steins-git/) - Shota Kubota
-* [サルでもわかるGit入門](https://backlog.com/ja/git-tutorial/) - 株式会社ヌーラボ
+* [Steins;Git 第二版](https://o2project.github.io/steins-git) - Shota Kubota
+* [サルでもわかるGit入門](https://backlog.com/ja/git-tutorial) - 株式会社ヌーラボ
 * [デザイナのための Git](https://github.com/hatena/Git-for-Designers) - はてな教科書
-* [図解 Git](http://marklodato.github.io/visual-git-guide/index-ja.html) - Mark Lodato, Kazu Yamamoto(翻訳)
+* [図解 Git](https://marklodato.github.io/visual-git-guide/index-ja.html) - Mark Lodato, Kazu Yamamoto(翻訳)
 
 
 ### Go
 
-* [Go Codereview Comments](https://knsh14.github.io/translations/go-codereview-comments/) - Kenshi Kamata
-* [Go Web プログラミング](https://astaxie.gitbooks.io/build-web-application-with-golang/content/ja/) - AstaXie
-* [お気楽 Go 言語プログラミング入門](http://www.nct9.ne.jp/m_hiroi/golang/) - 広井誠
-* [サンプルで学ぶ Go 言語](https://www.spinute.org/go-by-example/) - Mark McGranaghan, spinute(翻訳)
+* [Go Codereview Comments](https://knsh14.github.io/translations/go-codereview-comments) - Kenshi Kamata
+* [Go Web プログラミング](https://astaxie.gitbooks.io/build-web-application-with-golang/content/ja) - AstaXie
+* [お気楽 Go 言語プログラミング入門](http://www.nct9.ne.jp/m_hiroi/golang) - 広井誠
+* [サンプルで学ぶ Go 言語](https://www.spinute.org/go-by-example) - Mark McGranaghan, spinute(翻訳)
 * [テスト駆動開発でGO言語を学びましょう](https://andmorefine.gitbook.io/learn-go-with-tests/) - Christopher James, andmorefine(翻訳)
 * [はじめてのGo―シンプルな言語仕様，型システム，並行処理](https://gihyo.jp/dev/feature/01/go_4beginners) - Jxck
 * [プログラミング言語 Go ドキュメント](http://go.shibu.jp) - The Go Authors, SHIBUKAWA Yoshiki 他(翻訳)
@@ -351,32 +351,32 @@
 
 ### Groovy
 
-* [JGGUG G*Magazine](http://grails.jp/g_mag_jp/) - JGGUG(日本Grails/Groovyユーザーグループ) (PDF, EPUB)
+* [JGGUG G*Magazine](https://grails.jp/g_mag_jp) - JGGUG(日本Grails/Groovyユーザーグループ) (PDF, EPUB)
 
 
 #### Gradle
 
-* [Gradle 日本語ドキュメント](http://gradle.monochromeroad.com/docs/) - Hayashi Masatoshi, Sekiya Kazuchika, Sue Nobuhiro, Mochida Shinya ([PDF](http://gradle.monochromeroad.com/docs/userguide/userguide.pdf))
+* [Gradle 日本語ドキュメント](http://gradle.monochromeroad.com/docs) - Hayashi Masatoshi, Sekiya Kazuchika, Sue Nobuhiro, Mochida Shinya ([PDF](http://gradle.monochromeroad.com/docs/userguide/userguide.pdf))
 * [ビルドツールGradleスタートアップガイドの紹介](https://www.ntts.co.jp/column/tec/java_03/) - 鈴木雅貴
 
 
 #### Grails
 
-* [Grailsフレームワーク 日本語リファレンス](http://grails.jp/doc/latest/) - T.Yamamoto & Japanese Grails Doc Translating Team. Special thanks to NTT Software.
+* [Grailsフレームワーク 日本語リファレンス](https://grails.jp/doc/latest) - T.Yamamoto & Japanese Grails Doc Translating Team. Special thanks to NTT Software.
 * [Grailsを用いたファイルアップローダ作成](https://www.ntts.co.jp/column/tec/java_02/) - 須藤悠
 
 
 #### Spock Framework
 
 * [G*ワークショップZ May 2013 - Spockハンズオンの資料](https://github.com/yamkazu/spock-workshop/tree/master/docs) - Kazuki YAMAMOTO
-* [Spock Framework リファレンスドキュメント](http://spock-framework-reference-documentation-ja.readthedocs.org/ja/latest/) - Peter Niederwieser, Kazuki YAMAMOTO
+* [Spock Framework リファレンスドキュメント](https://spock-framework-reference-documentation-ja.readthedocs.org/ja/latest) - Peter Niederwieser, Kazuki YAMAMOTO
 
 
 ### Haskell
 
-* [Haskell のお勉強](http://www.shido.info/hs/) - 紫藤貴文
+* [Haskell のお勉強](https://www.shido.info/hs) - 紫藤貴文
 * [Haskell 基礎文法最速マスター](https://ruicc.hatenablog.jp/entry/20100131/1264905896) - id:ruicc
-* [Haskellでわかる代数的構造](https://aiya000.gitbooks.io/haskell_de_groupstructure/) - aiya000
+* [Haskellでわかる代数的構造](https://aiya000.gitbooks.io/haskell_de_groupstructure) - aiya000
 * [お気楽 Haskell プログラミング入門](http://www.nct9.ne.jp/m_hiroi/func/haskell.html) - 広井誠
 
 
@@ -389,38 +389,38 @@
 
 ### Java
 
-* [Java基礎文法最速マスター](http://d.hatena.ne.jp/nattou_curry_2/20100130/1264821094) - id:nattou\_curry
-* [お気楽 Java プログラミング入門](http://www.nct9.ne.jp/m_hiroi/java/) - 広井誠
+* [Java基礎文法最速マスター](https://d.hatena.ne.jp/nattou_curry_2/20100130/1264821094) - id:nattou\_curry
+* [お気楽 Java プログラミング入門](http://www.nct9.ne.jp/m_hiroi/java) - 広井誠
 * [頑健なJavaプログラムの書き方](http://seiza.dip.jp/link/files/writingrobustjavacode.pdf) - Scott W. Ambler, 高橋徹(翻訳) (PDF)
 
 
 ### JavaScript
 
-* [Airbnb JavaScript スタイルガイド](https://mitsuruog.github.io/javascript-style-guide/) - Airbnb, 小川充(翻訳)
-* [Google JavaScript スタイルガイド](https://w.atwiki.jp/aias-jsstyleguide2/) - Aaron Whyte, Bob Jervis, Dan Pupius, Erik Arvidsson, Fritz Schneider, Robby Walker, aiaswood(翻訳)
-* [JavaScript Garden](http://bonsaiden.github.io/JavaScript-Garden/ja/) - Ivo Wetzel, HIRAKI Satoru(翻訳)
-* [JavaScript Plugin Architecture](https://azu.gitbooks.io/javascript-plugin-architecture/content/) - azu
+* [Airbnb JavaScript スタイルガイド](https://mitsuruog.github.io/javascript-style-guide) - Airbnb, 小川充(翻訳)
+* [Google JavaScript スタイルガイド](https://w.atwiki.jp/aias-jsstyleguide2) - Aaron Whyte, Bob Jervis, Dan Pupius, Erik Arvidsson, Fritz Schneider, Robby Walker, aiaswood(翻訳)
+* [JavaScript Garden](https://bonsaiden.github.io/JavaScript-Garden/ja) - Ivo Wetzel, HIRAKI Satoru(翻訳)
+* [JavaScript Plugin Architecture](https://azu.gitbooks.io/javascript-plugin-architecture/content) - azu
 * [JavaScript Primer](https://jsprimer.net) - azu, Suguru Inatomi
-* [JavaScript Promiseの本](https://azu.github.io/promises-book/) - azu
+* [JavaScript Promiseの本](https://azu.github.io/promises-book) - azu
 * [JavaScript style guide](https://developer.mozilla.org/ja/docs/JavaScript_style_guide) - MDN
-* [JavaScript 基礎文法最速マスター](http://gifnksm.hatenablog.jp/entry/20100131/1264934942) - id:gifnksm
+* [JavaScript 基礎文法最速マスター](https://gifnksm.hatenablog.jp/entry/20100131/1264934942) - id:gifnksm
 * [JavaScript 言語リファレンス](https://msdn.microsoft.com/ja-jp/library/d1et7k7c.aspx) - MSDN Library
 * [Mozilla Developer Network 日本語ドキュメント](https://developer.mozilla.org/ja/docs/Web/JavaScript) - MDN
-* [The little book of Buster.JS](https://the-little-book-of-busterjs.readthedocs.io/en/latest/) - azu
+* [The little book of Buster.JS](https://the-little-book-of-busterjs.readthedocs.io/en/latest) - azu
 * [お気楽 JavaScript プログラミング超入門](http://www.nct9.ne.jp/m_hiroi/light/javascript.html) - 広井誠
 * [とほほのJavaScriptリファレンス](https://www.tohoho-web.com/js) - 杜甫々
-* [一撃必殺JavaScript日本語リファレンス](http://www.openspc2.org/JavaScript/) - 古籏一浩
-* [中上級者になるためのJavaScript](https://kenju.gitbooks.io/js_step-up-to-intermediate/) - Kenju
+* [一撃必殺JavaScript日本語リファレンス](http://www.openspc2.org/JavaScript) - 古籏一浩
+* [中上級者になるためのJavaScript](https://kenju.gitbooks.io/js_step-up-to-intermediate) - Kenju
 
 
 #### AngularJS
 
 > :information_source: 関連項目 - [Angular](#angular)
 
-* [AngularJS 1.2 日本語リファレンス](http://js.studio-kingdom.com/angularjs) - @tomof(翻訳)
-* [AngularJS's tutorial - あなたとともにAngularJS](http://lab.hisasann.com/AngularJSTutorial/) - @hisasann
+* [AngularJS 1.2 日本語リファレンス](https://js.studio-kingdom.com/angularjs) - @tomof(翻訳)
+* [AngularJS's tutorial - あなたとともにAngularJS](http://lab.hisasann.com/AngularJSTutorial) - @hisasann
 * [AngularJSスタイルガイド](https://github.com/mgechev/angularjs-style-guide/blob/master/README-ja-jp.md) - Minko Gechev, Morita Naoki, Yohei Sugigami et al.
-* [すぐできる AngularJS](http://8th713.github.io/LearnAngularJS) - @8th713
+* [すぐできる AngularJS](https://8th713.github.io/LearnAngularJS) - @8th713
 
 
 #### Backbone.js
@@ -430,20 +430,20 @@
 
 #### jQuery
 
-* [jQuery UI API 1.8.4 日本語リファレンス](http://stacktrace.jp/jquery/ui/) - いけまさ
-* [jQuery日本語リファレンス](http://semooh.jp/jquery/) - semooh.jp
+* [jQuery UI API 1.8.4 日本語リファレンス](https://stacktrace.jp/jquery/ui) - いけまさ
+* [jQuery日本語リファレンス](http://semooh.jp/jquery) - semooh.jp
 
 
 #### Node.js
 
-* [Felix's Node.js Style Guide](http://popkirby.github.io/contents/nodeguide/style.html) - Debuggable Limited., @popkirby(翻訳)
+* [Felix's Node.js Style Guide](https://popkirby.github.io/contents/nodeguide/style.html) - Debuggable Limited., @popkirby(翻訳)
 * [node.js 怒濤の50サンプル!! – socket.io編](https://github.com/omatoro/NodeSample) - omatoro
 * [Nodeビギナーズブック](https://www.nodebeginner.org/index-jp.html) - Manuel Kiessling, Yuki Kawashima(翻訳)
 
 
 #### React
 
-* [React 0.13 日本語リファレンス](http://js.studio-kingdom.com/react) - @tomof(翻訳)
+* [React 0.13 日本語リファレンス](https://js.studio-kingdom.com/react) - @tomof(翻訳)
 * [チュートリアル：React の導入](https://ja.reactjs.org/tutorial/tutorial.html) - Facebook Inc.
 
 
@@ -458,27 +458,27 @@
 ### LaTeX
 
 * [TeX/LaTeX入門](https://ja.wikibooks.org/wiki/TeX/LaTeX%E5%85%A5%E9%96%80) - Wikibooks
-* [TeX入門](http://www.comp.tmu.ac.jp/tsakai/lectures/intro_tex.html) - 酒井高司
+* [TeX入門](https://www.comp.tmu.ac.jp/tsakai/lectures/intro_tex.html) - 酒井高司
 * [TeX入門 TeX Wiki](https://texwiki.texjp.org/?TeX%E5%85%A5%E9%96%80) - 奥村晴彦
 
 
 ### Linux
 
-* [Linux Device Driver](http://www.mech.tohoku-gakuin.ac.jp/rde/contents/linux/drivers/indexframe.html) - 熊谷正朗
-* [Linux from Scratch (Version 7.4)](http://lfsbookja.osdn.jp/7.4.ja/) - Gerard Beekmans, 松山道夫(翻訳)
-* [Secure Programming for Linux and Unix HOWTO](http://linuxjf.osdn.jp/JFdocs/Secure-Programs-HOWTO/) - David A. Wheeler, 高橋聡(翻訳)
+* [Linux Device Driver](https://www.mech.tohoku-gakuin.ac.jp/rde/contents/linux/drivers/indexframe.html) - 熊谷正朗
+* [Linux from Scratch (Version 7.4)](https://lfsbookja.osdn.jp/7.4.ja/) - Gerard Beekmans, 松山道夫(翻訳)
+* [Secure Programming for Linux and Unix HOWTO](https://linuxjf.osdn.jp/JFdocs/Secure-Programs-HOWTO) - David A. Wheeler, 高橋聡(翻訳)
 
 
 ### Lua
 
 * [Lua 5.2 リファレンスマニュアル](http://milkpot.sakura.ne.jp/lua/lua52_manual_ja.html) - Lua.org, PUC-Rio.
 * [Lua Programming](http://www.nct9.ne.jp/m_hiroi/light/lua.html) - 広井誠
-* [Luaプログラミング入門](https://densan-labs.net/tech/lua/) - @nishio_dens
+* [Luaプログラミング入門](https://densan-labs.net/tech/lua) - @nishio_dens
 
 
 ### Maven
 
-* [Maven](https://www.techscore.com/tech/Java/ApacheJakarta/Maven/index/) - シナジーマーケティング株式会社
+* [Maven](https://www.techscore.com/tech/Java/ApacheJakarta/Maven) - シナジーマーケティング株式会社
 * [What is Maven?](https://github.com/KengoTODA/what-is-maven) - Kengo TODA
 
 
@@ -490,20 +490,20 @@
 
 ### ML
 
-* [ATSプログラミング入門](http://jats-ug.metasepi.org/doc/ATS2/INT2PROGINATS/)
+* [ATSプログラミング入門](http://jats-ug.metasepi.org/doc/ATS2/INT2PROGINATS)
 
 
 ### NoSQL
 
-* [Hibari アプリケーション開発者ガイド](http://hibari.github.io/hibari-doc/hibari-app-developer-guide.ja.html)
-* [MongoDBの薄い本](http://www.cuspy.org/diary/2012-04-17/the-little-mongodb-book-ja.pdf) - Karl Seguin, 濱野司(翻訳) (PDF)
+* [Hibari アプリケーション開発者ガイド](https://hibari.github.io/hibari-doc/hibari-app-developer-guide.ja.html)
+* [MongoDBの薄い本](https://www.cuspy.org/diary/2012-04-17/the-little-mongodb-book-ja.pdf) - Karl Seguin, 濱野司(翻訳) (PDF)
 * [The Little Redis Book](https://github.com/craftgear/the-little-redis-book) - Karl Seguin, @craftgear(翻訳)
 
 
 ### Objective-C
 
 * [Google Objective-C スタイルガイド 日本語訳](http://www.textdrop.net/google-styleguide-ja/objcguide.xml) - Mike Pinkerton, Greg Miller, Dave MacLachlan, Takashi Sasai(翻訳)
-* [Objective-C 2.0 基礎文法最速マスター](https://marycore.jp/prog/objective-c/basic-syntax/) - @_marycore
+* [Objective-C 2.0 基礎文法最速マスター](https://marycore.jp/prog/objective-c/basic-syntax) - @_marycore
 * [Objective-C によるプログラミング](https://developer.apple.com/jp/devcenter/ios/library/documentation/ProgrammingWithObjectiveC.pdf) - Apple Developer (PDF)
 * [Objective-C プログラミングの概念](https://developer.apple.com/jp/devcenter/ios/library/documentation/CocoaEncyclopedia.pdf) - Apple Developer (PDF)
 * [Objective-C プログラミング言語](https://developer.apple.com/jp/documentation/ProgrammingWithObjectiveC.pdf) - Apple Developer (PDF)
@@ -521,7 +521,7 @@
 * [2時間半で学ぶPerl](https://qntm.org/files/perl/perl_jp.html) - Sam Hughes, Kato Atsusi(翻訳)
 * [Perl](https://ja.wikibooks.org/wiki/Perl) - Wikibooks
 * [Perl でのデータベース操作](https://github.com/hatena/Hatena-Textbook/blob/master/database-programming-perl.md) - はてな教科書
-* [Perl のコアドキュメント](http://perldoc.jp/index/core) - 一般社団法人 Japan Perl Association (JPA)
+* [Perl のコアドキュメント](https://perldoc.jp/index/core) - 一般社団法人 Japan Perl Association (JPA)
 * [Perl 基礎文法最速マスター](https://tutorial.perlzemi.com/blog/20091226126425.html) - 木本裕紀
 * [お気楽 Perl プログラミング超入門](http://www.nct9.ne.jp/m_hiroi/linux/perl.html) - 広井誠
 
@@ -529,15 +529,15 @@
 ### PHP
 
 * [PHP によるデザインパターン入門](https://web.archive.org/web/20140703001758/http://www.doyouphp.jp/book/book_phpdp.shtml)
-* [PHP マニュアル](https://www.php.net/manual/ja/) - The PHP Group
-* [PHP 基礎文法最速マスター](http://www.1x1.jp/blog/2010/01/php-basic-syntax.html) - 新原雅司
+* [PHP マニュアル](https://www.php.net/manual/ja) - The PHP Group
+* [PHP 基礎文法最速マスター](https://www.1x1.jp/blog/2010/01/php-basic-syntax.html) - 新原雅司
 * [PHP4徹底攻略改訂版](https://prev.net-newbie.com/support/pdf2/)
 * [PSR-2 – コーディングスタイルガイド](https://github.com/maosanhioro/fig-standards/blob/master/translation/PSR-2-coding-style-guide.md) - maosanhioro
 
 
 #### Symfony
 
-* [Symfony 5: ファストトラック](https://symfony.com/doc/5.0/the-fast-track/ja/index.html)
+* [Symfony 5: ファストトラック](https://symfony.com/doc/5.0/the-fast-track/ja)
 
 
 ### PowerShell
@@ -548,16 +548,16 @@
 
 ### Processing
 
-* [Processing クイックリファレンス](http://www.musashinodenpa.com/p5/) - 株式会社武蔵野電波
-* [Processing 学習ノート](http://www.d-improvement.jp/learning/processing/) - @mathatelle
+* [Processing クイックリファレンス](http://www.musashinodenpa.com/p5) - 株式会社武蔵野電波
+* [Processing 学習ノート](https://www.d-improvement.jp/learning/processing) - @mathatelle
 * [Processing 入門講座](http://ap.kakoku.net/index.html) - maeda
 
 
 ### Prolog
 
 * [LISP and PROLOG](https://web.archive.org/web/20060526095202/http://home.soka.ac.jp/~unemi/LispProlog/) - 畝見達夫
-* [Prolog プログラミング入門](http://bach.istc.kobe-u.ac.jp/prolog/intro/) - 田村直之
-* [お気楽 Prolog プログラミング入門](http://www.nct9.ne.jp/m_hiroi/prolog/) - 広井誠
+* [Prolog プログラミング入門](https://tamura70.gitlab.io/web-prolog/intro) - 田村直之
+* [お気楽 Prolog プログラミング入門](http://www.nct9.ne.jp/m_hiroi/prolog) - 広井誠
 
 
 ### Python
@@ -566,28 +566,28 @@
 * [Google Python スタイルガイド](http://works.surgo.jp/translation/pyguide.html) - Amit Patel, Antoine Picard, Eugene Jhong, Jeremy Hylton, Matt Smart, Mike Shields, Kosei Kitahara(翻訳)
 * [Notes on scientific computing with python](http://japanichaos.appspot.com) - 花田康高
 * [php プログラマのための Python チュートリアル](https://web.archive.org/web/20160813152046/http://phpy.readthedocs.io/en/latest/) - INADA Naoki
-* [Python 2.7.16 ドキュメント日本語訳](https://docs.python.org/ja/2.7/) - Python Software Foundation
+* [Python ドキュメント日本語訳](https://docs.python.org/ja) - Python Software Foundation
 * [Python 3.4](https://stats.biopapyrus.jp/python) - 孫建強
-* [Python Scientific Lecture Notes](http://turbare.net/transl/scipy-lecture-notes/) - 打田旭宏(翻訳)
-* [Python で音声信号処理](http://aidiary.hatenablog.com/entry/20110514/1305377659) - id:aidiary
-* [python で心理実験](http://www.s12600.net/psy/python/) - 十河宏行
-* [Python による日本語自然言語処理](http://www.nltk.org/book-jp/ch12.html) - Steven Bird, Ewan Klein, Edward Loper, 萩原正人(翻訳), 中山敬広(翻訳), 水野貴明(翻訳)
-* [Python の学習](http://skitazaki.github.io/python-school-ja/) - KITAZAKI Shigeru
-* [Python ヒッチハイク・ガイド](https://python-guide-ja.readthedocs.io/en/latest/) - Kenneth Reitz, Tsuyoshi Tokuda(翻訳)
-* [Python プログラマーのための gevent チュートリアル](http://methane.github.io/gevent-tutorial-ja/) - Stephen Diehl, Jérémy Bethmont, sww, Bruno Bigras, David Ripton, Travis Cline, Boris Feld, youngsterxyf, Eddie Hebert, Alexis Metaireau, Daniel Velkov, methane(翻訳)
+* [Python Scientific Lecture Notes](http://turbare.net/transl/scipy-lecture-notes) - 打田旭宏(翻訳)
+* [Python で音声信号処理](https://aidiary.hatenablog.com/entry/20110514/1305377659) - id:aidiary
+* [python で心理実験](http://www.s12600.net/psy/python) - 十河宏行
+* [Python による日本語自然言語処理](https://www.nltk.org/book-jp/ch12.html) - Steven Bird, Ewan Klein, Edward Loper, 萩原正人(翻訳), 中山敬広(翻訳), 水野貴明(翻訳)
+* [Python の学習](https://skitazaki.github.io/python-school-ja) - KITAZAKI Shigeru
+* [Python ヒッチハイク・ガイド](https://python-guide-ja.readthedocs.io/en/latest) - Kenneth Reitz, Tsuyoshi Tokuda(翻訳)
+* [Python プログラマーのための gevent チュートリアル](https://methane.github.io/gevent-tutorial-ja) - Stephen Diehl, Jérémy Bethmont, sww, Bruno Bigras, David Ripton, Travis Cline, Boris Feld, youngsterxyf, Eddie Hebert, Alexis Metaireau, Daniel Velkov, methane(翻訳)
 * [Python 基礎文法最速マスター](https://dplusplus.hatenablog.com/entry/20100126/p1) - id:dplusplus
-* [The Programming Historian](https://sites.google.com/site/theprogramminghistorianja/) - William J. Turkel, Alan MacEachern, @moroshigeki(翻訳), @historyanddigi(翻訳), @Say\_no(翻訳), @knagasaki(翻訳), @mak\_goto(翻訳)
+* [The Programming Historian](https://sites.google.com/site/theprogramminghistorianja) - William J. Turkel, Alan MacEachern, @moroshigeki(翻訳), @historyanddigi(翻訳), @Say\_no(翻訳), @knagasaki(翻訳), @mak\_goto(翻訳)
 * [Think Python：コンピュータサイエンティストのように考えてみよう](http://www.cauldron.sakura.ne.jp/thinkpython/thinkpython/ThinkPython.pdf) - Allen Downey, 相川 利樹（翻訳）(PDF)
-* [お気楽 Python プログラミング入門](http://www.nct9.ne.jp/m_hiroi/light/) - 広井誠
+* [お気楽 Python プログラミング入門](http://www.nct9.ne.jp/m_hiroi/light) - 広井誠
 * [プログラミング演習 Python 2019](http://hdl.handle.net/2433/245698) - 喜多一 (PDF)
-* [みんなのPython Webアプリ編](https://coreblog.org/ats/stuff/minpy_web/) - 柴田淳
-* [機械学習の Python との出会い (Machine Learning Meets Python)](http://www.kamishima.net/mlmpyja/) - 神嶌敏弘 [PDF](http://www.kamishima.net/archive/mlmpyja.pdf), [EPUB](http://www.kamishima.net/archive/mlmpyja.epub)
+* [みんなのPython Webアプリ編](https://coreblog.org/ats/stuff/minpy_web) - 柴田淳
+* [機械学習の Python との出会い (Machine Learning Meets Python)](https://www.kamishima.net/mlmpyja) - 神嶌敏弘 [PDF](https://www.kamishima.net/archive/mlmpyja.pdf), [EPUB](https://www.kamishima.net/archive/mlmpyja.epub)
 
 
 #### Flask
 
-* [Flask ドキュメント](https://flask-docs-ja.readthedocs.io/en/latest/) - Armin Ronacher, Tsuyoshi Tokuda(翻訳)
-* [Flask ハンズオン](http://methane.github.io/flask-handson/) - INADA Naoki
+* [Flask ドキュメント](https://flask-docs-ja.readthedocs.io/en/latest) - Armin Ronacher, Tsuyoshi Tokuda(翻訳)
+* [Flask ハンズオン](https://methane.github.io/flask-handson) - INADA Naoki
 
 
 ### R
@@ -598,7 +598,7 @@
 * [R 言語定義](https://cran.r-project.org/doc/contrib/manuals-jp/R-lang.jp.v110.pdf) - R Development Core Team, 間瀬茂(翻訳) (PDF)
 * [R 入門](https://cran.r-project.org/doc/contrib/manuals-jp/R-intro-170.jp.pdf) - W. N. Venables, D. M. Smith and the R Development Core Team, 間瀬茂(翻訳) (PDF)
 * [Rチュートリアルセミナーテキスト](http://psycho.edu.yamaguchi-u.ac.jp/wordpress/wp-content/uploads/2014/01/R_tutorial20131.pdf) - 小杉考司, 押江隆 (PDF)
-* [Rによる統計解析の基礎](http://minato.sip21c.org/statlib/stat.pdf) - 中澤港 (PDF)
+* [Rによる統計解析の基礎](https://minato.sip21c.org/statlib/stat.pdf) - 中澤港 (PDF)
 * [Rによる保健医療データ解析演習](http://minato.sip21c.org/msb/medstatbook.pdf) - 中澤港 (PDF)
 * [統計解析ソフトRのスクリプト集](https://nuss.nagoya-u.ac.jp/index.php/s/kN6ZxsyReNzRPlM) - 石井秀宗 (PDF)
 * [統計解析フリーソフトRの備忘録](http://cse.naro.affrc.go.jp/takezawa/r-tips.pdf) - 竹澤邦夫 (PDF)
@@ -609,47 +609,47 @@
 
 * [Ruby on Rails ガイド](https://railsguides.jp) - Michael Hartl, 八田 昌三(翻訳), 安川 要平(翻訳)
 * [Ruby on Rails チュートリアル](https://railstutorial.jp) - Michael Hartl, 八田 昌三(翻訳), 安川 要平(翻訳)
-* [Ruby ソースコード完全解説](http://i.loveruby.net/ja/rhg/book/) - 青木峰郎
-* [Ruby リファレンスマニュアル](https://www.ruby-lang.org/ja/documentation/) - まつもとゆきひろ
-* [Ruby 基礎文法最速マスター](https://route477.net/d/?date=20100125)
-* [TremaでOpenFlowプログラミング](http://yasuhito.github.io/trema-book/) - 高宮安仁, 鈴木一哉, 松井暢之, 村木暢哉, 山崎泰宏
+* [Ruby ソースコード完全解説](https://i.loveruby.net/ja/rhg/book) - 青木峰郎
+* [Ruby リファレンスマニュアル](https://www.ruby-lang.org/ja/documentation) - まつもとゆきひろ
+* [Ruby 基礎文法最速マスター](https://route477.net/d/?date=20100125) - yhara
+* [TremaでOpenFlowプログラミング](https://yasuhito.github.io/trema-book) - 高宮安仁, 鈴木一哉, 松井暢之, 村木暢哉, 山崎泰宏
 * [お気楽 Ruby プログラミング入門](http://www.nct9.ne.jp/m_hiroi/light/ruby.html) - 広井誠
 * [つくって学ぶプログラミング言語 RubyによるScheme処理系の実装](https://tatsu-zine.com/books/scheme-in-ruby) - 渡辺昌寛
-* [ホワイの(感動的)Rubyガイド](http://www.aoky.net/articles/why_poignant_guide_to_ruby/) - why the lucky stiff, 青木靖(翻訳)
+* [ホワイの(感動的)Rubyガイド](http://www.aoky.net/articles/why_poignant_guide_to_ruby) - why the lucky stiff, 青木靖(翻訳)
 * [実用的Rubyスクリプティング](https://www.gentei.org/~yuuji/support/sr/scrp-2020-05.pdf) - 広瀬雄二 (PDF)
 
 
 ### Sather
 
-* [Sather を試そう](http://www.shido.info/sather/) - 紫藤貴文
+* [Sather を試そう](https://www.shido.info/sather) - 紫藤貴文
 
 
 ### Scala
 
-* [Effective Scala](http://twitter.github.io/effectivescala/index-ja.html)
-* [Learning Scalaz](http://eed3si9n.com/learning-scalaz/ja/)
-* [tetrix in Scala](http://eed3si9n.com/tetrix-in-scala-html5-book)
+* [Effective Scala](https://twitter.github.io/effectivescala/index-ja.html) - Marius Eriksen, Yuta Okamoto(翻訳), Satoshi Kobayashi(翻訳)
+* [独習 Scalaz](https://eed3si9n.com/learning-scalaz/ja) - Eugene Yokota
+* [Scala で書く tetrix](https://eed3si9n.com/tetrix-in-scala/ja) - Eugene Yokota
 
 
 ### Scheme
 
 * [Gauche プログラミング(立読み版)](https://web.archive.org/web/20140521224625/http://karetta.jp/book-cover/gauche-hacks) - 川合史朗(監修), Kahuaプロジェクト
-* [Gauche ユーザリファレンス](http://practical-scheme.net/gauche/man/gauche-refj.html) - 川合史朗
+* [Gauche ユーザリファレンス](https://practical-scheme.net/gauche/man/gauche-refj.html) - 川合史朗
 * [Scheme](https://ja.wikibooks.org/wiki/Scheme) - Wikibooks
 * [Scheme 入門 スーパービギナー編](https://sites.google.com/site/atponslisp/home/scheme/racket/schemenyuumon-1/schemenyuumon)
 * [お気楽 Scheme プログラミング入門](http://www.nct9.ne.jp/m_hiroi/func/scheme.html) - 広井誠
-* [もうひとつの Scheme 入門](http://www.shido.info/lisp/idx_scm.html) - 紫藤貴文
+* [もうひとつの Scheme 入門](https://www.shido.info/lisp/idx_scm.html) - 紫藤貴文
 * [入門Scheme](https://web.archive.org/web/20140812144348/http://www4.ocn.ne.jp/~inukai/scheme_primer_j.html) - 犬飼大
 
 
 ### Scratch
 
-* [炎の型 With Scratch (ゲームプログラム入門)](https://kyorohiro.gitbooks.io/doc_scratch/) - kyorohiro
+* [炎の型 With Scratch (ゲームプログラム入門)](https://kyorohiro.gitbooks.io/doc_scratch) - kyorohiro
 
 
 ### sed
 
-* [SED 教室](http://www.gcd.org/sengoku/sedlec/) - 仙石浩明
+* [SED 教室](https://www.gcd.org/sengoku/sedlec) - 仙石浩明
 
 
 ### Smalltalk
@@ -659,9 +659,9 @@
 
 ### SQL(実装非依存)
 
-* [SQL](https://www.techscore.com/tech/sql/) - シナジーマーケティング株式会社
-* [SQLアタマ養成講座](http://mickindex.sakura.ne.jp/database/WDP/WDP_44.pdf) - ミック WEB+DB Press Vol.44 (2008) p.47-72 (PDF)
-* [SQLプログラミング作法](http://mickindex.sakura.ne.jp) - ミック
+* [SQL](https://www.techscore.com/tech/sql) - シナジーマーケティング株式会社
+* [SQLアタマ養成講座](https://mickindex.sakura.ne.jp/database/WDP/WDP_44.pdf) - ミック WEB+DB Press Vol.44 (2008) p.47-72 (PDF)
+* [SQLプログラミング作法](https://mickindex.sakura.ne.jp) - ミック
 
 
 ### Standard ML
@@ -685,7 +685,7 @@
 ### TypeScript
 
 * [TypeScript Deep Dive 日本語版](https://typescript-jp.gitbook.io/deep-dive/) - basarat, yohamta(翻訳)
-* [TypeScriptの為のクリーンコード](https://msakamaki.github.io/clean-code-typescript/) - labs42io, 酒巻 瑞穂(翻訳)
+* [TypeScriptの為のクリーンコード](https://msakamaki.github.io/clean-code-typescript) - labs42io, 酒巻 瑞穂(翻訳)
 
 
 #### Angular
@@ -698,13 +698,13 @@
 
 ### VBA
 
-* [Excel 2013 で学ぶ Visual Basic for Applications (VBA)](https://brain.cc.kogakuin.ac.jp/~kanamaru/lecture/vba2013/) - 金丸隆志
+* [Excel 2013 で学ぶ Visual Basic for Applications (VBA)](https://brain.cc.kogakuin.ac.jp/~kanamaru/lecture/vba2013) - 金丸隆志
 * [VBA基礎文法最速マスター](https://nattou-curry-2.hatenadiary.org/entry/20100129/1264787849) - id:nattou\_curry
 * [Visual Basic for Applications (VBA) の言語リファレンス](https://docs.microsoft.com/ja-jp/office/vba/api/overview/language-reference) - Microsoft Docs
 
 
 ### Vim
 
-* [Vim スクリプトリファレンス](http://nanasi.jp/code.html) - 小見拓
+* [Vim スクリプトリファレンス](https://nanasi.jp/code.html) - 小見拓
 * [Vim スクリプト基礎文法最速マスター](https://thinca.hatenablog.com/entry/20100201/1265009821) - id:thinca
 * [Vim スクリプト書法](https://vim-jp.org/vimdoc-ja/usr_41.html) - Bram Moolenaar, vimdoc-ja プロジェクト(翻訳)

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -566,11 +566,11 @@
 * [Google Python スタイルガイド](http://works.surgo.jp/translation/pyguide.html) - Amit Patel, Antoine Picard, Eugene Jhong, Jeremy Hylton, Matt Smart, Mike Shields, Kosei Kitahara(翻訳)
 * [Notes on scientific computing with python](http://japanichaos.appspot.com) - 花田康高
 * [php プログラマのための Python チュートリアル](https://web.archive.org/web/20160813152046/http://phpy.readthedocs.io/en/latest/) - INADA Naoki
-* [Python ドキュメント日本語訳](https://docs.python.org/ja) - Python Software Foundation
 * [Python 3.4](https://stats.biopapyrus.jp/python) - 孫建強
 * [Python Scientific Lecture Notes](http://turbare.net/transl/scipy-lecture-notes) - 打田旭宏(翻訳)
 * [Python で音声信号処理](https://aidiary.hatenablog.com/entry/20110514/1305377659) - id:aidiary
 * [python で心理実験](http://www.s12600.net/psy/python) - 十河宏行
+* [Python ドキュメント日本語訳](https://docs.python.org/ja) - Python Software Foundation
 * [Python による日本語自然言語処理](https://www.nltk.org/book-jp/ch12.html) - Steven Bird, Ewan Klein, Edward Loper, 萩原正人(翻訳), 中山敬広(翻訳), 水野貴明(翻訳)
 * [Python の学習](https://skitazaki.github.io/python-school-ja) - KITAZAKI Shigeru
 * [Python ヒッチハイク・ガイド](https://python-guide-ja.readthedocs.io/en/latest) - Kenneth Reitz, Tsuyoshi Tokuda(翻訳)
@@ -626,8 +626,8 @@
 
 ### Scala
 
-* [Effective Scala](https://twitter.github.io/effectivescala/index-ja.html) - Marius Eriksen, Yuta Okamoto(翻訳), Satoshi Kobayashi(翻訳)
 * [独習 Scalaz](https://eed3si9n.com/learning-scalaz/ja) - Eugene Yokota
+* [Effective Scala](https://twitter.github.io/effectivescala/index-ja.html) - Marius Eriksen, Yuta Okamoto(翻訳), Satoshi Kobayashi(翻訳)
 * [Scala で書く tetrix](https://eed3si9n.com/tetrix-in-scala/ja) - Eugene Yokota
 
 

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -626,9 +626,9 @@
 
 ### Scala
 
-* [独習 Scalaz](https://eed3si9n.com/learning-scalaz/ja) - Eugene Yokota
 * [Effective Scala](https://twitter.github.io/effectivescala/index-ja.html) - Marius Eriksen, Yuta Okamoto(翻訳), Satoshi Kobayashi(翻訳)
 * [Scala で書く tetrix](https://eed3si9n.com/tetrix-in-scala/ja) - Eugene Yokota
+* [独習 Scalaz](https://eed3si9n.com/learning-scalaz/ja) - Eugene Yokota
 
 
 ### Scheme

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -201,7 +201,7 @@
 * [【改訂版】組込みソフトウェア開発向け コーディング作法ガイド［C言語版］ESCR Ver.3.0](https://www.ipa.go.jp/sec/publish/tn18-004.html) - 独立行政法人 情報処理推進機構(IPA) ([PDF](https://www.ipa.go.jp/files/000064005.pdf))
 * [【改訂版】 組込みソフトウェア開発向け 品質作り込みガイド](https://www.ipa.go.jp/files/000005146.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 * [【改訂版】 組込みソフトウェア向け 開発プロセスガイド](https://www.ipa.go.jp/files/000005126.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
-* [組込みソフトウェア開発向け コーディング作法ガイド［C++言語版］](https://www.ipa.go.jp/files/000005142.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [【改訂版】組込みソフトウェア開発向けコーディング作法ガイド[C++言語版] Ver. 2.0 （ESCR C++ Ver. 2.0）](https://www.ipa.go.jp/sec/publish/tn16-007.html) - 独立行政法人 情報処理推進機構(IPA) ([PDF](https://www.ipa.go.jp/files/000055043.pdf))
 * [組込みソフトウェア向け プロジェクトマネジメントガイド［計画書編］](https://www.ipa.go.jp/files/000005116.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 * [組込みソフトウェア向け プロジェクト計画立案トレーニングガイド](https://www.ipa.go.jp/files/000005145.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 * [組込みソフトウェア向け 設計ガイド ESDR［事例編］](https://www.ipa.go.jp/files/000005148.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -198,9 +198,9 @@
 
 #### 組み込みシステム
 
-* [【改訂版】組込みソフトウェア開発向け コーディング作法ガイド［C言語版］ESCR Ver.3.0](https://www.ipa.go.jp/sec/publish/tn18-004.html) - 独立行政法人 情報処理推進機構(IPA) ([PDF](https://www.ipa.go.jp/files/000064005.pdf))
 * [【改訂版】 組込みソフトウェア開発向け 品質作り込みガイド](https://www.ipa.go.jp/files/000005146.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 * [【改訂版】 組込みソフトウェア向け 開発プロセスガイド](https://www.ipa.go.jp/files/000005126.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [【改訂版】組込みソフトウェア開発向け コーディング作法ガイド［C言語版］ESCR Ver.3.0](https://www.ipa.go.jp/sec/publish/tn18-004.html) - 独立行政法人 情報処理推進機構(IPA) ([PDF](https://www.ipa.go.jp/files/000064005.pdf))
 * [【改訂版】組込みソフトウェア開発向けコーディング作法ガイド[C++言語版] Ver. 2.0 （ESCR C++ Ver. 2.0）](https://www.ipa.go.jp/sec/publish/tn16-007.html) - 独立行政法人 情報処理推進機構(IPA) ([PDF](https://www.ipa.go.jp/files/000055043.pdf))
 * [組込みソフトウェア向け プロジェクトマネジメントガイド［計画書編］](https://www.ipa.go.jp/files/000005116.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 * [組込みソフトウェア向け プロジェクト計画立案トレーニングガイド](https://www.ipa.go.jp/files/000005145.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -198,7 +198,7 @@
 
 #### 組み込みシステム
 
-* [【改訂版】 組込みソフトウェア開発向け コーディング作法ガイド［C言語版］](https://www.ipa.go.jp/files/000005123.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
+* [【改訂版】組込みソフトウェア開発向け コーディング作法ガイド［C言語版］ESCR Ver.3.0](https://www.ipa.go.jp/sec/publish/tn18-004.html) - 独立行政法人 情報処理推進機構(IPA) ([PDF](https://www.ipa.go.jp/files/000064005.pdf))
 * [【改訂版】 組込みソフトウェア開発向け 品質作り込みガイド](https://www.ipa.go.jp/files/000005146.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 * [【改訂版】 組込みソフトウェア向け 開発プロセスガイド](https://www.ipa.go.jp/files/000005126.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)
 * [組込みソフトウェア開発向け コーディング作法ガイド［C++言語版］](https://www.ipa.go.jp/files/000005142.pdf) - 独立行政法人 情報処理推進機構(IPA) (PDF)


### PR DESCRIPTION
## What does this PR do?
Improve repo


## For resources
### Description
* When I was editing Japanese resources, I noticed that many of them linked to "http" when they should have linked to "https". So I fixed those.
Similarly, I fixed the "/" and "index.html" at the end of the links.
I checked carefully to make sure that this would not break the links.
* Old links found during the above work have been brought up to date.
The names had changed, so I also reordered them.


### Why is this valuable (or not)?
"free-programming-books-ja.md" will now follow the guidelines more closely than before.


### How do we know it's really free?
I didn't add any books.


### For book lists, is it a book? For course lists, is it a course? etc.
I didn't add any books.


## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)


## Followup

- Check the output of Travis-CI for linter errors!
