### PR TITLE
fix(docs): wrong french link target in other languages lists

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,4 +1,4 @@
-Read this in other languages: [Français](CONTRIBUTING-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh-TW.md), [Português (BR)](HOWTO.pt_BR.md), [فارسی](HOWTO-fa_IR.md)
+Read this in other languages: [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh-TW.md), [Português (BR)](HOWTO.pt_BR.md), [فارسی](HOWTO-fa_IR.md)
 
 Welcome to Free-Programming-Books! We welcome new contributors; even those making their very first pull request on Github. If you're one of those, here are some resources that might help:
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Fix french link target into other languages lists

### Why is this valuable (or not)?

Completes review https://github.com/EbookFoundation/free-programming-books/pull/5554#pullrequestreview-763701519

Resolves https://github.com/EbookFoundation/free-programming-books/pull/5554#discussion_r716211068

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates. #5554

## Followup

- Check the output of Travis-CI for linter errors!
