### PR TITLE
move mooc list to courses

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -510,20 +510,6 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [Writing Native Mobile Apps in a Functional Language Succinctly](https://www.syncfusion.com/ebooks/writing_native_mobile_apps_in_a_functional_language_succinctly) - Vassili Kaplan
 
 
-### MOOC
-
-* [Coursera](https://www.coursera.org)
-* [edX](https://www.edx.org)
-* [freeCodeCamp](https://www.freecodecamp.org)
-* [FutureLearn](https://www.futurelearn.com)
-* [MIT OCW](http://ocw.mit.edu)
-* [NPTEL](https://onlinecourses.nptel.ac.in)
-* [openHPI](https://open.hpi.de)
-* [openSAP](https://open.sap.com)
-* [Platzi](https://courses.platzi.com)
-* [Udacity](https://www.udacity.com)
-
-
 ### Networking
 
 * [An Introduction to Computer Networks](http://intronetworks.cs.luc.edu) (HTML, PDF, Kindle)

--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -27,7 +27,6 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [Mathematics](#mathematics)
 * [Mathematics For Computer Science](#mathematics-for-computer-science)
 * [Misc](#misc)
-* [MOOC](#mooc)
 * [Networking](#networking)
 * [Open Source Ecosystem](#open-source-ecosystem)
 * [Operating Systems](#operating-systems)

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1,5 +1,6 @@
 ### Index
 
+* [0 - MOOC](#0---mooc)
 * [Algorithms & Data Structures](#algorithms--data-structures)
 * [Android](#android)
 * [Assembly](#assembly)
@@ -68,6 +69,21 @@
   * [Deno](#deno)
 * [Verilog / VHDL / SystemVerilog](#verilog--vhdl--systemverilog)
 * [Web Development](#web-development)
+
+
+### 0 - MOOC
+
+* [Coursera](https://www.coursera.org)
+* [edX](https://www.edx.org)
+* [freeCodeCamp](https://www.freecodecamp.org)
+* [FutureLearn](https://www.futurelearn.com)
+* [MIT OCW](http://ocw.mit.edu)
+* [MOOC.fi](https://www.mooc.fi/en/)
+* [NPTEL](https://onlinecourses.nptel.ac.in)
+* [openHPI](https://open.hpi.de)
+* [openSAP](https://open.sap.com)
+* [Platzi](https://courses.platzi.com)
+* [Udacity](https://www.udacity.com)
 
 
 ### Algorithms & Data Structures


### PR DESCRIPTION

moves list of moocs from books to courses
also add Mooc.fi from #5567

## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
