### PR TITLE
fix: add more resources about Rust

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2025,16 +2025,23 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 ### Rust
 
-* [A Gentle Introduction To Rust](https://stevedonovan.github.io/rust-gentle-intro/) - Steve J Donovan
-* [Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial.github.io/too-many-lists/) - Alexis Beingessner
-* [Rust by Example](https://doc.rust-lang.org/stable/rust-by-example/)
-* [Rust for Rubyists](https://web.archive.org/web/20190520171322/http://www.rustforrubyists.com/book/index.html) - Steve Klabnik
+* [A Gentle Introduction To Rust](https://stevedonovan.github.io/rust-gentle-intro) - Steve J Donovan
+* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book)
+* [Guide to Rustc Development](https://rustc-dev-guide.rust-lang.org)
+* [Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial.github.io/too-many-lists) - Alexis Beingessner
+* [Rust by Example](https://doc.rust-lang.org/stable/rust-by-example)
+* [Rust Cookbook](https://rust-lang-nursery.github.io/rust-cookbook)
+* [Rust for Rubyists](https://web.archive.org/web/20190520171322/http://www.rustforrubyists.com/book) - Steve Klabnik
 * [Rust For Systems Programmers](https://github.com/nrc/r4cppp) - Nick Cameron
 * [The Embedded Rust Book](https://docs.rust-embedded.org/book/intro/index.html)
+* [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/book)
 * [The Rust Language Reference](https://github.com/rust-lang/reference)
-* [The Rust Programming Language](http://doc.rust-lang.org/book/)
-* [The Rustonomicon](https://doc.rust-lang.org/nomicon/)
-* [Why Rust?](https://www.oreilly.com/content/why-rust/)
+* [The Rust Performance Book](https://nnethercote.github.io/perf-book)
+* [The Rust Programming Language](http://doc.rust-lang.org/book)
+* [The Rust RFC Book](https://rust-lang.github.io/rfcs)
+* [The Rustc Book](https://doc.rust-lang.org/rustc)
+* [The Rustonomicon](https://doc.rust-lang.org/nomicon)
+* [Why Rust?](https://www.oreilly.com/content/why-rust)
 
 
 ### Sage

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -21,6 +21,7 @@
 * [Python](#python)
 * [R](#r)
 * [Ruby](#ruby)
+* [Rust](#rust)
 * [SQL](#sql)
 
 
@@ -154,6 +155,11 @@
 ### Ruby
 
 * [Ruby Cheat Sheet](https://www.codeconquest.com/wp-content/uploads/Ruby-Cheat-Sheet-by-CodeConquestDOTcom.pdf) - CodeConquest.com (PDF)
+
+
+### Rust
+
+* [Rust Language Cheat Sheet](https://cheats.rs) (HTML)
 
 
 ### SQL

--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -304,6 +304,7 @@
 
 ### Rust
 
+* [Rust Quiz](https://dtolnay.github.io/rust-quiz)
 * [Rustlings](https://github.com/rust-lang/rustlings)
 
 

--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -229,7 +229,7 @@
 
 ### Rust
 
-* [Rust Playground](http://play.integer32.com)
+* [Rust Playground](https://play.rust-lang.org)
 
 
 ### RxJS


### PR DESCRIPTION
## What does this PR do?
Add resources: Rust

## For resources
### Description
Rust books, cheatsheets, interactive tutorials

### Why is this valuable (or not)?
To be a good rustacean

### How do we know it's really free?
All of these are open source

### For book lists, is it a book? For course lists, is it a course? etc.
Yes for all

## Checklist:

- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Followup

- Check the output of Travis-CI for linter errors!
