### PR TITLE
Fix wrong author of Rails Guides in Japanese

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -607,7 +607,7 @@
 
 ### Ruby
 
-* [Ruby on Rails ガイド](https://railsguides.jp) - Michael Hartl, 八田 昌三(翻訳), 安川 要平(翻訳)
+* [Ruby on Rails ガイド](https://railsguides.jp) - Rails community, 八田 昌三(翻訳), 安川 要平(翻訳)
 * [Ruby on Rails チュートリアル](https://railstutorial.jp) - Michael Hartl, 八田 昌三(翻訳), 安川 要平(翻訳)
 * [Ruby ソースコード完全解説](https://i.loveruby.net/ja/rhg/book) - 青木峰郎
 * [Ruby リファレンスマニュアル](https://www.ruby-lang.org/ja/documentation) - まつもとゆきひろ


### PR DESCRIPTION
## What does this PR do?
Correct author info.

## For resources
### Description
I have found and correct wrong author of [Rails Guides in Japanese](https://railsguides.jp/), which seems added by me. 😓💦

### Why is this valuable (or not)?
To show correct author of the resources.

### How do we know it's really free?
The website ( https://railsguides.jp/ ) is published under the following repo!
https://github.com/yasslab/railsguides.jp

### For book lists, is it a book? For course lists, is it a course? etc.
The website is a project that translates the [official Rails guides](https://edgeapi.rubyonrails.org/) into Japanese, and it is listed [here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#translating-rails-guides). 

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
