### PR TITLE
Add GNU Emacs refcard to more/free-programming-cheatsheets.md file un…

### DIFF
--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -80,10 +80,10 @@
 ### <a name="ide--editores"></a>IDE / Editors
 
 * [Editor VI - Guia de Referência](https://aurelio.net/curso/material/vim-ref.html) - Aurelio Marinho Jargas
+* [GNU Emacs Refcard](https://www.gnu.org/software/emacs/refcards/pdf/refcard.pdf) - Official PDF from [GNU.org](https://www.gnu.org/home.en.html)
 * [Vim Avançado](https://aurelio.net/vim/vim-avancado.txt) - Aurelio Marinho Jargas
 * [Vim Básico](https://aurelio.net/vim/vim-basico.txt) - Aurelio Marinho Jargas
 * [Vim Médio](https://aurelio.net/vim/vim-medio.txt) - Aurelio Marinho Jargas
-* [GNU Emacs Refcard](https://www.gnu.org/software/emacs/refcards/pdf/refcard.pdf) - Official [GNU.org](https://www.gnu.org/home.en.html)
 
 
 ### Java

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -80,7 +80,7 @@
 ### <a name="ide--editores"></a>IDE / Editors
 
 * [Editor VI - Guia de Referência](https://aurelio.net/curso/material/vim-ref.html) - Aurelio Marinho Jargas
-* [GNU Emacs Refcard](https://www.gnu.org/software/emacs/refcards/pdf/refcard.pdf) - Official PDF from [GNU.org](https://www.gnu.org/home.en.html)
+* [GNU Emacs Reference Card](https://www.gnu.org/software/emacs/refcards/pdf/refcard.pdf) - GNU.org (PDF)
 * [Vim Avançado](https://aurelio.net/vim/vim-avancado.txt) - Aurelio Marinho Jargas
 * [Vim Básico](https://aurelio.net/vim/vim-basico.txt) - Aurelio Marinho Jargas
 * [Vim Médio](https://aurelio.net/vim/vim-medio.txt) - Aurelio Marinho Jargas

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -83,6 +83,7 @@
 * [Vim Avançado](https://aurelio.net/vim/vim-avancado.txt) - Aurelio Marinho Jargas
 * [Vim Básico](https://aurelio.net/vim/vim-basico.txt) - Aurelio Marinho Jargas
 * [Vim Médio](https://aurelio.net/vim/vim-medio.txt) - Aurelio Marinho Jargas
+* [GNU Emacs Refcard](https://www.gnu.org/software/emacs/refcards/pdf/refcard.pdf) - Official [GNU.org](https://www.gnu.org/home.en.html)
 
 
 ### Java


### PR DESCRIPTION
…der ide/editors category

## What does this PR do?
Add resource(s)

## For resources
### Description
Added GNU Emacs refcard/cheatsheet from the official site.

### Why is this valuable (or not)?
Great reference card for Emacs users.

### How do we know it's really free?
Official reference card from GNU.org is available for free to download as PDF.

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
