### PR TITLE
HOWTO in Russian

### DIFF
--- a/HOWTO-es.md
+++ b/HOWTO-es.md
@@ -1,4 +1,4 @@
-Lea esto en otros idiomas: [English](HOWTO.md), [Français](HOWTO-fr.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md)
+Lea esto en otros idiomas: [English](HOWTO.md), [Français](HOWTO-fr.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md), [Русский](HOWTO-ru.md).
 
 Sea bienvenido a *Free-Programming-Books*! Damos una calurosa bienvenida a los nuevos colaboradores; incluso a aquellos que realizan su primera Pull Request (PR) en Github. Si es usted uno de ellos, aquí van algunos recursos que quizás le pueden ayudar:
 

--- a/HOWTO-fa_IR.md
+++ b/HOWTO-fa_IR.md
@@ -1,4 +1,4 @@
-این متن را در زبان‌های دیگر بخوانید: [English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md)
+این متن را در زبان‌های دیگر بخوانید: [English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [Русский](HOWTO-ru.md).
 
 <div dir="rtl">
 به Free-Programming-Books خوش آمدید! ما به مشارکت‌کنندگان جدید خوش‌آمد می‌گوییم. حتی آنهایی که اولین پول‌ریکوئست خود را در گیت‌هاب می‌گذارند. اگر شما هم یکی از آنهایید، منابع زیر می‌توانند به شما کمک کنند.

--- a/HOWTO-fr.md
+++ b/HOWTO-fr.md
@@ -1,4 +1,4 @@
-Lisez ceci dans d'autres langues: [English](HOWTO.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md)
+Lisez ceci dans d'autres langues: [English](HOWTO.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md), [Русский](HOWTO-ru.md).
 
 Bienvenue à Free-Programming-Books! Nous souhaitons la bienvenue aux nouveaux contributeurs; même ceux qui font leur toute première pull request sur Github. Si vous faites partie de ceux-ci, voici quelques ressources qui pourraient vous aider:
 

--- a/HOWTO-hi.md
+++ b/HOWTO-hi.md
@@ -1,4 +1,4 @@
-इस लेख को अन्य भाषाओं में पढ़ें: [English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md)
+इस लेख को अन्य भाषाओं में पढ़ें: [English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md), [Русский](HOWTO-ru.md).
 
 फ्री-प्रोग्रामिंग-पुस्तकों में आपका स्वागत है! हम नए योगदानकर्ताओं का स्वागत करते हैं; यहां तक ​​कि उन लोगों के लिए जो गिथब पर अपना पहला पुल अनुरोध करते हैं। यदि आप उनमें से एक हैं, तो यहां कुछ संसाधन हैं जो मदद कर सकते हैं:
 * [About Pull Requests](https://help.github.com/articles/about-pull-requests/)

--- a/HOWTO-pt_BR.md
+++ b/HOWTO-pt_BR.md
@@ -1,4 +1,4 @@
-Leia em outras linguagens: [English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [فارسی](HOWTO-fa_IR.md)
+Leia em outras linguagens: [English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [فارسی](HOWTO-fa_IR.md), [Русский](HOWTO-ru.md).
 
 
 Seja bem-vindo(a) ao Free-Programming-Books (Livros de Programação Grátis)! Novos contribuidores são bem-vindos para nós; até mesmo aqueles fazendo seu primeiro pull request no Github. Se você é um deles, nós temos alguns recursos que podem ajudar:

--- a/HOWTO-ru.md
+++ b/HOWTO-ru.md
@@ -1,4 +1,4 @@
-Доступно на других языках: [English](HOWTO.md),[Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md)
+Доступно на других языках: [English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md)
 
 Добро пожаловать в Free-Programming-Books! Мы приветствуем новых участников; даже тех, кто делает свой самый первый пулреквест на Github. Если вы один из них, вот несколько ресурсов, которые могут вам помочь:
 

--- a/HOWTO-ru.md
+++ b/HOWTO-ru.md
@@ -1,0 +1,21 @@
+Доступно на других языках: [English](HOWTO.md),[Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md)
+
+Добро пожаловать в Free-Programming-Books! Мы приветствуем новых участников; даже тех, кто делает свой самый первый пулреквест на Github. Если вы один из них, вот несколько ресурсов, которые могут вам помочь:
+
+* [:us: Про пулреквесты](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+* [:us: Создание пулреквеста](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
+* [:us: Github Hello World](https://guides.github.com/activities/hello-world/)
+* [:us: Youtube - обучающий ролик по Github для новичков](https://www.youtube.com/watch?v=0fKg7e37bQE)
+* [:us: Youtube - Как форкнуть GitHub репозиторий и отправить пулл реквест](https://www.youtube.com/watch?v=G1I3HF4YWEw)
+* [:us: Youtube - курс погружения в Markdown](https://www.youtube.com/watch?v=HUBNt18RFbo)
+
+* [:ru: Pull request'ы на GitHub или Как мне внести изменения в чужой проект](https://habr.com/ru/post/125999/)
+* [:ru: Github Hello World](http://bi0morph.github.io/hello-world/)
+* [:ru: Youtube - Изучение GitHub в одном видео уроке за 15 минут](https://www.youtube.com/watch?v=JfpCicDUMKc)
+* [:ru: Youtube - Markdown - пиши README без боли](https://www.youtube.com/watch?v=FFBTGdEMrQ4)
+  
+Не стесняйтесь задавать вопросы; каждый участник начал с первого PR. Вы могли бы стать нашим тысячным! 
+
+Даже если вы опытный участник проекта с открытым исходным кодом, есть вещи, которые могут вас сбить с толку. После того как вы отправите свой PR, GitHub Actions запустит линтер который часто находит небольшие проблемы с пробелами или алфавитным порядком. Если у вас появляется зеленая кнопка, все готово к проверке, а если нет, нажмите "Details" под проверкой, которая не смогла выяснить, что не понравилось линтеру. Устраните проблему и добавьте коммит в свой пулреквест.
+
+Наконец, если вы не уверены, что ресурс, который вы хотите добавить, подходит для Free-Programming-Books, прочтите рекомендации в [CONTRIBUTING](CONTRIBUTING-ru.md).

--- a/HOWTO-zh.md
+++ b/HOWTO-zh.md
@@ -1,4 +1,4 @@
-阅读本文的其他语言版本：[English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md)
+阅读本文的其他语言版本：[English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md), [Русский](HOWTO-ru.md).
 
 欢迎使用 Free-Programming-Books（免费编程书籍）！我们欢迎新的贡献者；即使是在 Github 上首次提出拉取请求的人。如果您是其中之一，那么以下资源可能会有所帮助：
 

--- a/HOWTO-zh_TW.md
+++ b/HOWTO-zh_TW.md
@@ -1,4 +1,4 @@
-閱讀本文的其他語言版本: [English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md)
+閱讀本文的其他語言版本: [English](HOWTO.md), [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md), [Русский](HOWTO-ru.md).
 
 歡迎使用 Free-Programming-Books！我們歡迎新的貢獻者；即使是在Github上首次提出 pull request 的人。如果您是其中之一，那麼以下資源可能會對你有所幫助：
 

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,4 +1,4 @@
-Read this in other languages: [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md)
+Read this in other languages: [Français](HOWTO-fr.md), [Español](HOWTO-es.md), [简体中文](HOWTO-zh.md), [हिन्दी](HOWTO-hi.md), [繁體中文](HOWTO-zh_TW.md), [Português (BR)](HOWTO-pt_BR.md), [فارسی](HOWTO-fa_IR.md), [Русский](HOWTO-ru.md).
 
 Welcome to Free-Programming-Books! We welcome new contributors; even those making their very first pull request on Github. If you're one of those, here are some resources that might help:
 


### PR DESCRIPTION
## What does this PR do?

Add Howto translation to Russian language. I am added links to similar resources in Russian. Because if Russian speaking person can watch/read HOWTO only in Russian, so it's better to give links to resources in Russian language.
 But I am not removed English links and add mark. In case of Russian-speaking person can't use main HOWTO but can use :us: links


## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [X] Search for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction)
