### PR TITLE
Remove "The Art of Computer Programming - Donald Knuth (fascicles, mostly volume 4)"

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -114,7 +114,6 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [Sequential and parallel sorting algorithms](http://www.inf.fh-flensburg.de/lang/algorithmen/sortieren/algoen.htm)
 * [Text Algorithms](http://igm.univ-mlv.fr/~mac/REC/text-algorithms.pdf) (PDF)
 * [The Algorithm Design Manual](http://www8.cs.umu.se/kurser/TDBAfl/VT06/algorithms/BOOK/BOOK/BOOK.HTM)
-* [The Art of Computer Programming](http://www.cs.utsa.edu/~wagner/knuth/) - Donald Knuth (fascicles, mostly volume 4)
 * [The Design of Approximation Algorithms](http://www.designofapproxalgs.com/book.pdf) (PDF)
 * [The Great Tree List Recursion Problem](http://cslibrary.stanford.edu/109/TreeListRecursion.pdf) (PDF)
 * [The Kademlia Protocol Succinctly](https://www.syncfusion.com/ebooks/kademlia_protocol_succinctly) - Marc Clifton


### PR DESCRIPTION
## What does this PR do?
Removes "The Art of Computer Programming - Donald Knuth (fascicles, mostly volume 4)" as it is no longer free. Resolves #5401

[Author's website](https://cs.stanford.edu/~knuth/taocp.html) states:
> The authorized PDF versions can be purchased at www.informit.com/taocp. If you have purchased a different version of the eBook, and can provide proof of purchase of that eBook, you can obtain a gratis PDF verson by sending email and proof of purchase to taocp@pearson.com.

and

> Volumes 1--4A are available from the publisher, Addison-Wesley Publishing Company.

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
