### PR TITLE
fix(docs): Update markdown processor to use GFM

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,8 @@
 # [Name of visual theme]
 #theme: jekyll-theme-minimal
 remote_theme: pages-themes/minimal@v0.2.0
+
+# [Conversion]
 markdown: GFM
 
 # [Used rubygem plugins]

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # [Name of visual theme]
 #theme: jekyll-theme-minimal
 remote_theme: pages-themes/minimal@v0.2.0
+markdown: GFM
 
 # [Used rubygem plugins]
 plugins:


### PR DESCRIPTION
## What does this PR do?
Improve repo: Update the markdown processor to use GFM instead of the default (kramdown). GFM is the processor Github uses. Resolves #5559.

#### Docs for more information:
https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/setting-a-markdown-processor-for-your-github-pages-site-using-jekyll

#### Examples here:
https://charlottetan.github.io/free-programming-books/CONTRIBUTING-fa_IR.html
<img src="https://user-images.githubusercontent.com/4824630/135745145-9473d4a3-da25-40c8-9481-26d8933e2c3f.png" width="75%">

https://charlottetan.github.io/free-programming-books/HOWTO-fa_IR.html
<img src="https://user-images.githubusercontent.com/4824630/135745219-3453b449-c4bb-4d36-9069-d6810bf0c1ca.png" width="75%">


## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
