### PR TITLE
Update Emacs entries links

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -642,10 +642,10 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 ### Emacs
 
-* [An Introduction to Programming in Emacs Lisp, 3rd Edition](https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html)
+* [An Introduction to Programming in Emacs Lisp](https://www.gnu.org/software/emacs/manual/eintr.html)
 * [Emacs for the Modern World](https://www.finseth.com/craft/) (HTML)
 * [GNU Emacs Lisp Reference Manual](http://www.gnu.org/software/emacs/manual/elisp.html)
-* [GNU Emacs Manual](https://www.gnu.org/software/emacs/manual/pdf/emacs.pdf) (PDF)
+* [GNU Emacs Manual](https://www.gnu.org/software/emacs/manual/emacs.html)
 
 
 ### Embedded Systems


### PR DESCRIPTION
Changed from HTML/PDF links to their respective landing page so reader can choose their preferred reading format (HTML node, HTML single page, PDF, etc.).

## What does this PR do?
Improve repo

## For resources
### Description
Update GNU Emacs manuals links.

### Why is this valuable (or not)?
The current links redirect reader to either HTML or PDF. This commit change those links with their respective landing page. The landing page provides many formats to choose, so the reader can freely read the manuals with their preferred formats.

### How do we know it's really free?
The pages are licensed under Creative Commons Attribution-NoDerivatives 4.0 International License.

### For book lists, is it a book? For course lists, is it a course? etc.
It is collection of books. More of the collection can be found [here](https://www.gnu.org/software/emacs/manual/)

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
