### PR TITLE
Udemy PHP Pagos  retirados

### DIFF
--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -214,7 +214,6 @@
 
 ### PHP
 
-* [Boas práticas em PHP](https://www.udemy.com/boas-praticas-em-php/) - Diego Mariano (Udemy)
 * [Curso Básico de Bootstrap 4 , PHP e MySQL](https://www.udemy.com/curso-basico-de-bootstrap-4-php-e-mysql-gratis/) - Ricardo Milbrath Gonçalves (Udemy)
 * [Curso de CodeIgniter para iniciantes](https://www.youtube.com/playlist?list=PLInBAd9OZCzz2vtRFDwum0OyUmJg8UqDV) - RBtech
 * [Curso de PHP para Iniciantes](https://www.youtube.com/playlist?list=PLHz_AreHm4dm4beCCCmW4xwpmLf6EHY9k) - Gustavo Guanabara (Curso em Video)
@@ -223,10 +222,6 @@
 * [Introdução ao PHP orientado a objetos](https://www.udemy.com/php-orientado-a-objetos/) - Diego Mariano (Udemy)
 * [Laravel 8 - Primeiros Passos](https://www.udemy.com/course/laravel-8/) - Nanderson Castro (Udemy)
 * [Lógica de Programação com PHP](https://www.youtube.com/playlist?list=PLhTDLccA9vgHHwGZArcUqIZ5AUGwrbZ_A) - Curso Zend Framework (YouTube)
-* [Login com validação e flash messages (PHP)](https://www.udemy.com/login-com-validacao-e-flash-messages-php/) - Alexandre Cardoso (Udemy)
-* [PDO para quem não sabe PDO](https://www.udemy.com/pdo-para-quem-nao-sabe-pdo/) - Alexandre Cardoso (Udemy)
-* [PHP 7 do Básico ao Intermediário](https://www.udemy.com/php-do-basico-ao-intermediario/) - Gunnar Correa (Udemy)
-* [PHP para quem entende PHP](https://www.udemy.com/php-para-quem-entende-php/) - Alexandre Cardoso (Udemy)
 
 
 ### Python


### PR DESCRIPTION
Foram retirados alguns links da Udemy para cursos pagos.

Precisa checar os cursos das demais linguagens, não pude fazer isso.
Provavelmente os demais cursos Udemy que ainda são gratuitos se tornarão pagos no futuro, e deverão ser removidos da lista quando isso acontecer.

Provavelmente este repositório está sendo usado para SEO e SEM. Portanto, sugiro que seja discutida a inserção de links para empresas que alteram a visibilidade de cursos que, no início são gratuitos e, posteriormente são alterados para pagos, fazendo com que esse repositório sirva para publicidade gratuita.

## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
