### PR TITLE
Adds "Networking" category and IPv6 course

### DIFF
--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -206,9 +206,11 @@
 
 * [Aprenda Markdown](https://www.udemy.com/aprenda-markdown/) - Roberto Achar (Udemy)
 
+
 ### Networking
 
 * [Curso de IPv6 Básico a Distância](http://saladeaula.nic.br/courses/course-v1:NIC.br+IPV6-001+T001/about) - NIC.br
+
 
 ### Node.js
 


### PR DESCRIPTION
Adds "Networking" category and IPv6 course from NIC.br

## What does this PR do?
Adds a new category for Networking courses and adds a new IPv6 course.

## For resources
### Description
This is a course produced by NIC.br, which is a non-profit association, aimed at teaching basic IPv6 skills to IT professionals.

### Why is this valuable (or not)?
It's a course produced by high-skilled professionals and has already trained more than 2,000 professionals.

### How do we know it's really free?
It's clearly stated on it's page.

### For book lists, is it a book? For course lists, is it a course? etc.
This is a course.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
