### PR TITLE
Solve some 404 errors in books-ES

### DIFF
--- a/books/free-programming-books-es.md
+++ b/books/free-programming-books-es.md
@@ -200,7 +200,7 @@
 * [Desarrollando con Java 8: Poker](https://ia601504.us.archive.org/21/items/DesarrollandoConJava8Poker/DesarrollandoConJava8Poker.pdf) -David Pérez Cabrera (PDF)
 * [Desarrollo de proyectos informáticos con Java](http://www3.uji.es/~belfern/libroJava.pdf) (PDF)
 * [Ejercicios de Programación en Java](https://www.arkaitzgarro.com/java/) - F.M. Pérez Montes (PDF)
-* * [Notas de Introducción al Lenguaje de Programación Java (2004)](https://lya.fciencias.unam.mx/jloa/publicaciones/introduccionJava.pdf) - Jorge L. Ortega Arjona (PDF)
+* [Notas de Introducción al Lenguaje de Programación Java (2004)](https://lya.fciencias.unam.mx/jloa/publicaciones/introduccionJava.pdf) - Jorge L. Ortega Arjona (PDF)
 * [Pensando la computación como un científico (con Java)](http://www.ungs.edu.ar/cm/uploaded_files/publicaciones/476_cid03-Pensar%20la%20computacion.pdf) (PDF)
 * [PlugIn Apache Tapestry: desarrollo de aplicaciones y páginas web](https://picodotdev.github.io/blog-bitix/assets/custom/PlugInTapestry.pdf) (PDF) [(ePub, Mobi, HTML)](https://picodotdev.github.io/blog-bitix/2014/02/libro-sobre-desarrollo-de-aplicaciones-con-apache-tapestry/)
 * [Prácticas de Java (2009)](https://openlibra.com/es/book/download/practicas-de-java) (PDF)


### PR DESCRIPTION
404 Errors 
http://lya.fciencias.unam.mx/jloa/publicaciones/introduccionJava.pdf
http://lya.fciencias.unam.mx/jloa/publicaciones/teoria.pdf
http://lya.fciencias.unam.mx/jloa/publicaciones/automatasyLenguajes.pdf
http://www.bubok.es/libros/205199/POO-y-MVC-en-PHP

## What does this PR do?
Remove resource(s)

## For resources
http://lya.fciencias.unam.mx/jloa/publicaciones/introduccionJava.pdf
http://lya.fciencias.unam.mx/jloa/publicaciones/teoria.pdf
http://lya.fciencias.unam.mx/jloa/publicaciones/automatasyLenguajes.pdf
http://www.bubok.es/libros/205199/POO-y-MVC-en-PHP

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.
4 Books returning 404 errors 

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
