### PR TITLE
Fix link in books/free-programming-books-ja.md

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -679,7 +679,7 @@
 
 ### Swift
 
-* [逆引きSwift](http://docs.fabo.io/swift/) - FaBo
+* [逆引きSwift](http://faboplatform.github.io/SwiftDocs/) - FaBo
 
 
 ### Tcl/Tk


### PR DESCRIPTION
Issues #6092
## What does this PR do?
Fix resource
## For resources
### Description
逆引きSwift - FaBo(http://docs.fabo.io/swift/) is moved to http://faboplatform.github.io/SwiftDocs/

### Why is this valuable (or not)?
know about Swift.
### How do we know it's really free?
free
### For book lists, is it a book? For course lists, is it a course? etc.
book
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
