### PR TITLE
added php book list on en books file

### DIFF
--- a/books/free-programming-books-en.md
+++ b/books/free-programming-books-en.md
@@ -1,6 +1,7 @@
 ### Index
 
 * [All](#all)
+* [PHP](#php)
 
 
 ### All
@@ -8,3 +9,7 @@
 * [English, By Programming Language](free-programming-books-langs.md)
   [English, By Subject](free-programming-books-subjects.md)
   (The list of books in English is here for historical reasons.)
+
+### PHP
+
+* [PHP](https://books.goalkicker.com/PHPBook/)


### PR DESCRIPTION
## What does this PR do?
Added https://books.goalkicker.com/PHPBook/ for php en books file

## For resources
### Description
Followed template of md file modified

### Why is this valuable (or not)?
This focuses on php tutorials, coding, etc

### How do we know it's really free?
I tried downloading the pdf from the site and it's free with all php notes

### For book lists, is it a book? For course lists, is it a course? etc.
This is a PDF and based on readme.md this is categorized under books

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
