### PR TITLE
Fix spanish podcast links

### DIFF
--- a/casts/free-podcasts-screencasts-es.md
+++ b/casts/free-podcasts-screencasts-es.md
@@ -19,7 +19,7 @@
 
 ### Desarrollo Web
 
-* [Codalot Podcast](https://codalot.dev) (podcast)
+* [Codalot Podcast](https://www.ivoox.com/escuchar-codalot-podcast_nq_747399_1.html) (podcast)
 * [Hablando.js](https://anchor.fm/carlosazaustre) - Carlos Azaustre (podcast)
 * [La Web es la Plataforma](https://anchor.fm/the-web-is-the-platform) (podcast)
 * [República Web](https://republicaweb.es) (podcast)
@@ -64,8 +64,8 @@
 * [Doomling & Chill](https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy8zNGM2ZjE5MC9wb2RjYXN0L3Jzcw==) (podcast)
 * [Educando Geek](https://educandogeek.github.io) (podcast)
 * [Frikismo Puro](https://www.ivoox.com/podcast-frikismo-puro_sq_f1268809_1.html) (podcast)
-* [Hijos de la Web](https://www.hijosdelaweb.com) (podcast) (Última Actualización, Marzo 2020)
-* [iCharlas](http://icharlas.es) (podcast)
+* [Hijos de la Web](https://www.ivoox.com/podcast-hijos-web_sq_f1588708_1.html) (podcast)
+* [iCharlas](https://www.ivoox.com/podcast-icharlas-podcast_sq_f155400_1.html) (podcast)
 * [La Tecnologería](https://tecnologeria.com) (podcast)
 * [Más allá de la innovación](https://masalladelainnovacion.com/todos-los-podcasts/) (podcast)
 * [Mixx.io](https://mixx.io/podcasts) (podcast)


### PR DESCRIPTION
## What does this PR do?
Update links

## For resources
### Description
As stated in the issue [#5740](https://github.com/EbookFoundation/free-programming-books/issues/5470) some links were broken in the list of Spanish podcast, it seems that the podcasts related doesn't maintain their websites anymore so a link to Ivoox as been added.

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
