### PR TITLE
Added a search engine book to subject list

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -649,6 +649,7 @@ Kerridge (PDF) (email address *requested*, not required)
 ### Search Engines
 
 * [Elasticsearch: The Definitive Guide](https://www.elastic.co/guide/en/elasticsearch/guide/current/index.html) ([fork it on GH](https://github.com/elastic/elasticsearch-definitive-guide))
+* [Search Engines: Information Retrieval in Practice](https://ciir.cs.umass.edu/irbook) - W. Bruce Croft, Donald Metzler, Trevor Strohman (PDF)
 * [Solr for newbies workshop (2019)](https://github.com/hectorcorrea/solr-for-newbies) - Hector Correa ([PDF](https://github.com/hectorcorrea/solr-for-newbies/blob/master/tutorial.pdf))
 
 


### PR DESCRIPTION
I added "Search Engines: Information Retrieval in Practice" by W. Bruce Croft, Donald Metzler, Trevor Strohman to the subject list.

## What does this PR do?
Add resource(s)

## For resources
### Description
On page V of the book:
_"This book provides an overview of the important issues in information retrieval,
and how those issues affect the design and implementation of search engines."_

### Why is this valuable (or not)?
Search engines are everywhere.  This book provides an introduction to the working of search engines and the components of information retrieval.

### How do we know it's really free?
On the website and on page VII of the book:
_"This version of the book is being made available for free download."_

### For book lists, is it a book? For course lists, is it a course? etc.
It is a book.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
