### PR TITLE
Moved Solidity tutorial from tutorials to courses

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -818,6 +818,7 @@
 
 * [Learn Solidity](https://youtube.com/playlist?list=PL16WqdAj66SCOdL6XIFbke-XQg2GW_Avg) - Will it Scale (Youtube)
 * [MASTER Solidity for Blockchain](https://youtube.com/playlist?list=PLS5SEs8ZftgVnWHv2_mkvJjn5HBOkde3g) - Dapp University (Youtube)
+* [Solidity Tutorial - A Full Course on Ethereum, Blockchain Development, Smart Contracts, and the EVM](https://www.youtube.com/watch?v=ipwxYa-F1uY) - Gregory McCubbin @ freeCodeCamp.org & Dapp University (YouTube)
 
 
 ### Swift


### PR DESCRIPTION
## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo
Moved [Solidity Tutorial - A Full Course on Ethereum, Blockchain Development, Smart Contracts, and the EVM](https://www.youtube.com/watch?v=ipwxYa-F1uY) - Gregory McCubbin @ freeCodeCamp.org & Dapp University (YouTube)
to courses from tutorials
## For resources 
### Description
A free YouTube course on Ethereum, Blockchain Development, Smart Contracts, and the EVM
### Why is this valuable (or not)?
The course takes 1, 5 hours and includes 6 chapters hence in course is a lot of useful information.
### How do we know it's free?
It's on YouTube, the account is not required and it's available for everyone.
### For book lists, is it a book? For course lists, is it a course? etc.
Course
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
