### PR TITLE
Fix links for English casts

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -178,7 +178,7 @@
 #### Elm
 
 * [Elm Radio](https://elm-radio.com) - Dillon Kearns and Jeroen Engels (podcast)
-* [Elm Town](https://elmtown.simplecast.com/) (podcast)
+* [Elm Town](https://elmtown.simplecast.com) (podcast)
 
 
 #### Ember.js
@@ -236,7 +236,7 @@
 * [Frontside the Podcast](https://frontside.io/podcast/) (podcast)
 * [Full Stack Radio](http://www.fullstackradio.com) (podcast)
 * [Functional Geekery](https://www.functionalgeekery.com) (podcast)
-* [Garbage](https://garbage.jcs.org/) (podcast)
+* [Garbage](https://garbage.jcs.org) (podcast)
 * [Hacker Culture](https://anchor.fm/hackerculture) (podcast)
 * [IEEE Software's "On Computing" with Grady Booch](http://www.computer.org/web/computingnow/oncomputing) (podcast)
 * [Ladybug Podcast](https://www.ladybug.dev) (podcast)


### PR DESCRIPTION
## What does this PR do?
Fix broken links for English casts.

## For resources
### Description
As stated in the issue [#5740](https://github.com/EbookFoundation/free-programming-books/issues/5470) some links were broken in the list of Engllish podcast. It seems that some casts are no longer reachable on internet, others just moved to other address/platform.

### Why is this valuable (or not)?
It fix broken links 

### How do we know it's really free?
I have check that the new links are free and not broken

### For book lists, is it a book? For course lists, is it a course? etc.
Podcasts

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
