### PR TITLE
Add Korean Rust Guidebook `Rust by Example`

### DIFF
--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -180,6 +180,7 @@
 ### Rust
 
 * [러스트 프로그래밍 언어](https://rinthel.github.io/rust-lang-book-ko/) - 스티브 클라브닉, 캐롤 니콜스 (HTML) (:construction: *in process*)
+* [Rust by Example](https://hanbum.gitbooks.io/rustbyexample/content/) (:construction: *in process*)
 
 
 ### Scratch


### PR DESCRIPTION
## What does this PR do?
Add resource(s) 

## For resources
### Description

### Why is this valuable (or not)?
`Rust by example` is maybe the second most loved Rust book for rustaceans.
This now has a Korean translation, yet not completed.
Still worth to add on the list.

### How do we know it's really free?
It's public, deployed on gitbooks.

### For book lists, is it a book? For course lists, is it a course? etc.
It's a book.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
