### PR TITLE
fix to mistyping

### DIFF
--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -44,7 +44,7 @@
 
 ### AWK
 
-* [AWS 스크립트](https://mug896.github.io/awk-script)
+* [AWK 스크립트](https://mug896.github.io/awk-script)
 
 
 ### C


### PR DESCRIPTION
AWK guide subject mistyping as AWS

## What does this PR do?
Improve repo

## For resources
### Description
mistyping fixed

### Why is this valuable (or not)?
AWK guide ebook link subject fixed 

### How do we know it's really free?
can do read free

### For book lists, is it a book? For course lists, is it a course? etc.
ebook 

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
