### PR TITLE
chore(books): recover syncfusion succinctly assembly

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -320,7 +320,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 * [ARM Assembly Language Programming](http://www.rigwit.co.uk/ARMBook/ARMBook.pdf) - Peter Knaggs (PDF) (:construction: *in process*)
 * [Assemblers And Loaders (1993)](http://www.davidsalomon.name/assem.advertis/asl.pdf) - David Salomon (PDF)
-* [Assembly Language Succinctly](https://www.syncfusion.com/succinctly-free-ebooks/assemblylanguage) - Christopher Rose, Syncfusion Inc. (HTML, [PDF, EPUB, Kindle](https://www.syncfusion.com/succinctly-free-ebooks/confirmation/assemblylanguage))
+* [Assembly Language Succinctly](https://www.syncfusion.com/succinctly-free-ebooks/assemblylanguage) - Christopher Rose, Syncfusion Inc. (HTML, PDF, EPUB, Kindle)
 * [PC Assembly Language](http://pacman128.github.io/pcasm/) - P. A. Carter
 * [Professional Assembly Language](https://web.archive.org/web/20170329045538/http://blog.hit.edu.cn:80/jsx/upload/AT%EF%BC%86TAssemblyLanguage.pdf) (PDF)
 * [Programming from the Ground Up](https://download-mirror.savannah.gnu.org/releases/pgubook/ProgrammingGroundUp-1-0-booksize.pdf) - Jonathan Bartlett (PDF)


### PR DESCRIPTION
Reverts EbookFoundation/free-programming-books#6253 and apply book moving

Improves #5470 

Book was moved to https://www.syncfusion.com/succinctly-free-ebooks/assemblylanguage without set a redirection (bad SEO practices)

In practice.... all Syncfusion books was moved due to website redesign

_Originally posted by @davorpa in https://github.com/EbookFoundation/free-programming-books/pull/6253#discussion_r729471826