### PR TITLE
Add index for Rust lang, and two free courses in `free-courses-ko.md`

### DIFF
--- a/courses/free-courses-ko.md
+++ b/courses/free-courses-ko.md
@@ -220,8 +220,8 @@
 
 ### Rust
 
-* [Team Jupeter - Rust by Examples](https://www.youtube.com/playlist?list=PLlSZlNj22M7SywLz61Wseh6iVGWRrtH76) (유튜브 채널: Team Jupeter)
-* [Team Jupeter - The Rust Programming Language](https://www.youtube.com/playlist?list=PLlSZlNj22M7TBqclhEMkXFabaDCmds0mg) (유튜브 채널: Team Jupeter)
+* [Team Jupeter - Rust by Examples](https://www.youtube.com/playlist?list=PLlSZlNj22M7SywLz61Wseh6iVGWRrtH76) - Team Jupeter (유튜브 채널) 
+* [Team Jupeter - The Rust Programming Language](https://www.youtube.com/playlist?list=PLlSZlNj22M7TBqclhEMkXFabaDCmds0mg) - Team Jupeter (유튜브 채널) 
 
 
 ### Security


### PR DESCRIPTION
## What does this PR do?
Add resource(s) 

## For resources
### Description
I've added Rust lang section for Korean free courses.
And also added two courses which references two famous Rust lang book
1. The Rust Programming Language
2. Rust by Examples

### Why is this valuable (or not)?
Rust language is blooming. And I am pretty sure there should be increasing number of developers and students who want to learn the language but struggling by finding Korean based material.
I hope this PR would help them.

### How do we know it's really free?
The links lead to youtube playlist. It's totally free.

### For book lists, is it a book? For course lists, is it a course? etc.
It's a course lists

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
