### PR TITLE
Add Japanese books (TypeScript, Rust)

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -629,7 +629,7 @@
 ### Rust
 
 * [Rust by Example 日本語版](https://doc.rust-jp.rs/rust-by-example-ja) - Rustコミュニティ(翻訳)
-* [The Rust Programming Language 日本語版](https://doc.rust-jp.rs/book-ja) - Steve Klabnik, Carol Nichols, Rustコミュニティ(翻訳)
+* [The Rust Programming Language 日本語版](https://doc.rust-jp.rs/book-ja) - Steve Klabnik, Carol Nichols, Rustコミュニティ(翻訳) ([PDF](https://doc.rust-jp.rs/book-ja-pdf/book.pdf))
 
 
 ### Sather


### PR DESCRIPTION
## What does this PR do?
Add resources

## For resources
### Description
Add links to TypeScript, Rust books
I also add a section on Rust.

### Why is this valuable (or not)?
* **仕事ですぐに使えるTypeScript**
This is a book where we can learn practical web front-end.

* **The Rust Programming Language 日本語版**
This is a translation of the official guide into Japanese.

* **Rust by Example 日本語版**
This is the Japanese translation of the "Rust By Example" posted on the official website.

### How do we know it's really free?
* **仕事ですぐに使えるTypeScript**
It is available for free under CC BY-SA 4.0.
This book is also available on GitHub.

* **The Rust Programming Language 日本語版**
It can be found on the official Rust website in Japanese.

* **Rust by Example 日本語版**
This book has been translated and published by the same community as the above book.

### For book lists, is it a book? For course lists, is it a course? etc.
Yes, these are all books

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
