### PR TITLE
official raspberrypi handbook added to the list under Raspberry Pi

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1991,6 +1991,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 ### Raspberry Pi
 
+* [Essentials - GPIO Zero Electronics](https://magpi.raspberrypi.com/books/essentials-gpio-zero-v1) (PDF)
 * [Raspberry Pi: Measure, Record, Explore](https://leanpub.com/RPiMRE/read) - Malcolm Maclean (HTML)
 * [Raspberry Pi Beginner's Guide 4th Edition](https://magpi.raspberrypi.com/books/beginners-guide-4th-ed) (PDF)
 * [Raspberry Pi Camera Guide](https://magpi.raspberrypi.com/books/camera-guide) (PDF)
@@ -1998,7 +1999,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Raspberry Pi Users Guide - (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)
 * [The Official Raspberry Pi Handbook 2022](https://magpi.raspberrypi.com/books/handbook-2022) (PDF)
 * [The Official Raspberry Pi Project Book](https://magpi.raspberrypi.com/books/projects-1) (PDF)
-* [Essentials - GPIO Zero Electronics](https://magpi.raspberrypi.com/books/essentials-gpio-zero-v1) (PDF)
 
 
 ### REBOL


### PR DESCRIPTION
## What does this PR do?
Add official Raspberry Pi Handbook resource.

## For resources
### Description
Latest guide book from the raspberry pi foundation
### Why is this valuable (or not)?
Provides latest information.
### How do we know it's really free?
Magpi book series have always been available for free as pdf. You can check it out by visiting the link all the books they published to date is available as pdf
### For book lists, is it a book? For course lists, is it a course? etc.
It's a book
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
