### PR TITLE
Added Datastax Academy

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -284,7 +284,7 @@
 
 #### NoSQL
 
-* [Datastax Academy (Apache Cassandra)](https://academy.datastax.com) - Datastax Inc. *(email address required)*
+* [Datastax Academy (Apache Cassandra)](https://www.datastax.com/dev/academy) - Datastax Inc. *(email address required)*
 * [MongoDB University](https://university.mongodb.com) - MongoDB, Inc. (email address *required*)
 * [Neo4j Graph Database Tutorial](https://www.youtube.com/playlist?list=PLqfPEK2RTgChcOZ6qHgSfwiBPCz2Bzdjh) - Satish C J (YouTube)
 * [Redis University](https://university.redis.com) - Redis Inc. *(email address required)*


### PR DESCRIPTION
Added Datastax Academy to the list of NoSQL courses.

## What does this PR do?
Add resource(s)

## For resources
### Description
Datastax Academy has many free high-quality online courses concentrating on Apache Cassandra. 

### Why is this valuable (or not)?
I did these courses prior to Cassandra certification and they cover all the topics.

### How do we know it's really free?
After registration, all courses can be watched for free. The website also provides progress tracking.

### For book lists, is it a book? For course lists, is it a course? etc.
It's a video course divided by topic.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
