### PR TITLE
Update link for CONTRIBUTING(ko)

### DIFF
--- a/HOWTO-ko.md
+++ b/HOWTO-ko.md
@@ -14,4 +14,4 @@ Free-Programming-Books 에 오신 것을 환영합니다! 우리는 Github 에 �
 
 경험 많은 오픈 소스 기여자라 할지라도, 여러분을 곤란하게 만들 수 있는 것들이 있습니다. 일단 PR을 제출하면 GitHub Actions는 띄어쓰기나 알파벳 순으로 작은 문제를 발견하는 작업을 실행합니다. 녹색 단추가 나타나면 모든 항목을 검토할 준비가 되어 있지만 그렇지 않으면 검사에서 "상세 정보"를 클릭합니다. 문제를 해결하고 PR에 커밋을 추가합니다.
 
-마지막으로 추가하려는 리소스가 Free-Programming-Books에 적합한지 확실하지 않은 경우 [CONTRIBUTING](CONTRIBUTING.md)의 지침을 확인십시오.
+마지막으로 추가하려는 리소스가 Free-Programming-Books에 적합한지 확실하지 않은 경우 [CONTRIBUTING](CONTRIBUTING-ko.md)의 지침을 확인십시오.


### PR DESCRIPTION
* Update CONTRIBUTING link on HOWTO-ko.md from CONTRIBUTING.md to CONTRIBUTING-ko.md

## What does this PR do?
Improve repo

## For resources
### Description

### Why is this valuable (or not)?
Easy to read from HOWTO-ko.md to CONTRIBUTING-ko.md.

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
