### PR TITLE
Remove Rust courses from suspicious source 

### DIFF
--- a/courses/free-courses-ko.md
+++ b/courses/free-courses-ko.md
@@ -31,7 +31,6 @@
 * [Raspberry Pi](#raspberry-pi)
 * [Reinforced Learning](#reinforced-learning)
 * [Ruby](#ruby)
-* [Rust](#rust)
 * [Security](#security)
 * [Spring](#spring)
 * [Swift](#swift)
@@ -233,9 +232,6 @@
 
 * [Python & Ruby](https://www.opentutorials.org/course/1750) (생활코딩)
 * [Ruby coin](https://www.youtube.com/playlist?list=PLEBQPmkNcLCIE9ERi4k_nUkGgJoBizx6s)
-
-
-### Rust
 
 
 ### Security


### PR DESCRIPTION
## What does this PR do?
Remove resource(s)

## For resources
### Description
I removed two Korean Rust lang courses.
### Why is this valuable (or not)?
After I've added those links, I lately found that the creators of those courses are kinda ... weird.
The courses are fine, but in their main website they described some of their suspicious ambitions about changing the world. So I thought removing those course links should be done to prevent people to be led to them.

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.
Course list (removing)

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
