### PR TITLE
docs(contributing): RIPtutorial creator guidelines ES

### DIFF
--- a/CONTRIBUTING-es.md
+++ b/CONTRIBUTING-es.md
@@ -165,7 +165,7 @@ Nuestros listados proporcionan un conjunto mínimo de metadatos: títulos, URL, 
 - Queremos dar crédito a los creadores de recursos gratuitos cuando sea apropiado, ¡incluso traductores!
 - En el caso de obras traducidas, se debe acreditar también al autor original.
 - No permitimos enlaces directos al creador.
-- En el caso de recopilaciones u obras remezcladas, el "creador" puede necesitar una descripción. Por ejemplo, los libros de "GoalKicker" se acreditan como "Creado a partir de la documentación de StackOverflow".
+- En el caso de recopilaciones u obras remezcladas, el "creador" puede necesitar una descripción. Por ejemplo, los libros de "GoalKicker" o "RIP Tutorial" se acreditan como "`Creado a partir de la documentación de StackOverflow`" (en inglés: "`Compiled from StackOverflow documentation`").
 
 <a name="platforms-and-access-notes"></a>
 ##### Plataformas y Notas de Acceso


### PR DESCRIPTION
## What does this PR do?
Add info | Improve repo

## For resources
### Description

Append `RIP tutorial` to the `Goalkicker` creator notes in `CONTRIBUTING-es.md`.

### Why is this valuable (or not)?

Improves / synchronize repository documentation with the spanish translation of feature EbookFoundation/free-programming-books#6153 

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
