### PR TITLE
Move vim and emacs casts under IDEs

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -8,7 +8,6 @@
 * [CSS](#css)
 * [Data Science](#data-science)
 * [Elixir](#elixir)
-* [Emacs](#emacs)
 * [Erlang](#erlang)
 * [Git](#git)
 * [Golang](#golang)
@@ -30,7 +29,6 @@
 * [Python](#python)
 * [Ruby](#ruby)
 * [Rust](#rust)
-* [Vim](#vim)
 
 
 ### Android


### PR DESCRIPTION
## What does this PR do?
This follows on from https://github.com/EbookFoundation/free-programming-books/pull/6437 and moves screencasts for `emacs` and `vim` under the IDEs / editors heading per request by @davorpa.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [X] Search for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction)

## Follow-up
- Check the status of GitHub Actions and resolve any reported warnings!
