### PR TITLE
Add Let's Data Podcast on Podcasts pt_BR

### DIFF
--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -35,6 +35,7 @@
 * [Data Science Academy](http://datascienceacademy.com.br/blog/podcast-dsa/) (podcast)
 * [Pizza de Dados](https://pizzadedados.com) (podcast)
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)
+* [Let's Data](https://www.youtube.com/channel/UCS58303Tmd0wIKTddmRskdQ) (podcast)
 
 
 ### Game development

--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -34,7 +34,7 @@
 * [Data Hackers](https://datahackers.com.br/podcast) (podcast)
 * [Data Science Academy](http://datascienceacademy.com.br/blog/podcast-dsa/) (podcast)
 * [Let's Data](https://www.youtube.com/channel/UCS58303Tmd0wIKTddmRskdQ) (podcast)
-* [Teste de Turing] (https://castbox.fm/channel/Teste-de-Turing-id2546538) (podcast)
+* [Teste de Turing](https://castbox.fm/channel/Teste-de-Turing-id2546538) (podcast)
 * [Pizza de Dados](https://pizzadedados.com) (podcast)
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)
 

--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -39,7 +39,6 @@
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)
 
 
-
 ### Game development
 
 * [Podquest](http://www.podquest.com.br) (podcast)

--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -34,10 +34,9 @@
 * [Data Hackers](https://datahackers.com.br/podcast) (podcast)
 * [Data Science Academy](http://datascienceacademy.com.br/blog/podcast-dsa/) (podcast)
 * [Let's Data](https://www.youtube.com/channel/UCS58303Tmd0wIKTddmRskdQ) (podcast)
-* [Teste de Turing](https://castbox.fm/channel/Teste-de-Turing-id2546538) (podcast)
 * [Pizza de Dados](https://pizzadedados.com) (podcast)
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)
-
+* [Teste de Turing](https://castbox.fm/channel/Teste-de-Turing-id2546538) (podcast)
 
 ### Game development
 

--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -36,7 +36,7 @@
 * [Let's Data](https://www.youtube.com/channel/UCS58303Tmd0wIKTddmRskdQ) (podcast)
 * [Pizza de Dados](https://pizzadedados.com) (podcast)
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)
-* [Teste de Turing](https://castbox.fm/channel/Teste-de-Turing-id2546538) (podcast)
+* [Teste de Turing](https://anchor.fm/testedeturing) - Erick Fonseca (podcast)
 
 
 ### Game development

--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -33,7 +33,7 @@
 
 * [Data Hackers](https://datahackers.com.br/podcast) (podcast)
 * [Data Science Academy](http://datascienceacademy.com.br/blog/podcast-dsa/) (podcast)
-* [Let's Data](https://www.youtube.com/channel/UCS58303Tmd0wIKTddmRskdQ) (podcast)
+* [Let's Data](https://www.youtube.com/playlist?list=PLn_z5E4dh_Lj5eogejMxfOiNX3nOhmhmM) - Bernardo Lago, Felipe Schiavon, Leon Silva (screencast)
 * [Pizza de Dados](https://pizzadedados.com) (podcast)
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)
 * [Teste de Turing](https://anchor.fm/testedeturing) - Erick Fonseca (podcast)

--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -33,9 +33,10 @@
 
 * [Data Hackers](https://datahackers.com.br/podcast) (podcast)
 * [Data Science Academy](http://datascienceacademy.com.br/blog/podcast-dsa/) (podcast)
+* [Let's Data](https://www.youtube.com/channel/UCS58303Tmd0wIKTddmRskdQ) (podcast)
 * [Pizza de Dados](https://pizzadedados.com) (podcast)
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)
-* [Let's Data](https://www.youtube.com/channel/UCS58303Tmd0wIKTddmRskdQ) (podcast)
+
 
 
 ### Game development

--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -34,6 +34,7 @@
 * [Data Hackers](https://datahackers.com.br/podcast) (podcast)
 * [Data Science Academy](http://datascienceacademy.com.br/blog/podcast-dsa/) (podcast)
 * [Let's Data](https://www.youtube.com/channel/UCS58303Tmd0wIKTddmRskdQ) (podcast)
+* [Teste de Turing] (https://castbox.fm/channel/Teste-de-Turing-id2546538) (podcast)
 * [Pizza de Dados](https://pizzadedados.com) (podcast)
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)
 

--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -38,6 +38,7 @@
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)
 * [Teste de Turing](https://castbox.fm/channel/Teste-de-Turing-id2546538) (podcast)
 
+
 ### Game development
 
 * [Podquest](http://www.podquest.com.br) (podcast)


### PR DESCRIPTION
Add Let's Data Podcast on Podcasts pt_BR

## What does this PR do?
Add Let's Data Podcast on Podcasts pt_BR

## For resources
### Description
O Let's Data Podcast traz pessoas interessantes para conversar sobre ciência de dados e inteligência articificial e outras aleatoriedades da vida. Criado e apresentado por Bernardo Lago, Felipe Schiavon e Leon Silva, com o objetivo de divulgar conhecimento aliando dois enfoques: técnico e humano. Os episódios são transmitidos ao vivo pelo canal no YouTube. Junte-se a nós e venha aprender mais sobre ciência de dados e IA!


### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
