### PR TITLE
Changed the URL for C for Python Programmers by Carl Burch 

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -427,7 +427,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Beej's Guide to the GNU Debugger (GDB)](http://beej.us/guide/bggdb/) - B. Hall (HTML)
 * [Build Your Own Lisp](http://www.buildyourownlisp.com) - Daniel Holden
 * [C Elements of Style](http://www.oualline.com/books.free/style/) - Steve Oualline
-* [C for Python Programmers - Carl Burch](http://www.toves.org/books/cpy/)
+* [C for Python Programmers - Carl Burch](http://www.cburch.com/books/cpy/index.html)
 * [C Notes for Professionals](https://goalkicker.com/CBook) - Compiled from StackOverflow Documentation (PDF)
 * [C Programming](https://en.wikibooks.org/wiki/Programming%3AC) - Wikibooks
 * [C Programming Boot Camp - Paul Gribble](https://gribblelab.org/teaching/CBootCamp/)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -427,7 +427,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Beej's Guide to the GNU Debugger (GDB)](http://beej.us/guide/bggdb/) - B. Hall (HTML)
 * [Build Your Own Lisp](http://www.buildyourownlisp.com) - Daniel Holden
 * [C Elements of Style](http://www.oualline.com/books.free/style/) - Steve Oualline
-* [C for Python Programmers - Carl Burch](http://www.cburch.com/books/cpy/index.html)
+* [C for Python Programmers - Carl Burch](http://www.cburch.com/books/cpy/)
 * [C Notes for Professionals](https://goalkicker.com/CBook) - Compiled from StackOverflow Documentation (PDF)
 * [C Programming](https://en.wikibooks.org/wiki/Programming%3AC) - Wikibooks
 * [C Programming Boot Camp - Paul Gribble](https://gribblelab.org/teaching/CBootCamp/)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -427,7 +427,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Beej's Guide to the GNU Debugger (GDB)](http://beej.us/guide/bggdb/) - B. Hall (HTML)
 * [Build Your Own Lisp](http://www.buildyourownlisp.com) - Daniel Holden
 * [C Elements of Style](http://www.oualline.com/books.free/style/) - Steve Oualline
-* [C for Python Programmers - Carl Burch](http://www.cburch.com/books/cpy/)
+* [C for Python Programmers](http://www.cburch.com/books/cpy/) - Carl Burch
 * [C Notes for Professionals](https://goalkicker.com/CBook) - Compiled from StackOverflow Documentation (PDF)
 * [C Programming](https://en.wikibooks.org/wiki/Programming%3AC) - Wikibooks
 * [C Programming Boot Camp - Paul Gribble](https://gribblelab.org/teaching/CBootCamp/)


### PR DESCRIPTION
## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo
Improves Repo
## For resources
### Description
Updated the link for C for Python Programmers by Carl Burch by removing the old link and updating it with the new link.
### Why is this valuable (or not)?
Valuable, because it helps us to directly navigate to Carl Burch's free book on C for Python Programmers without going through the broken link.
### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.
I have made changes to the book list for the book named "C for Python Programmers" By Carl Burch.
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
