### PR TITLE
fix: #5831 HOWTO Dutch. flag emoji code `en` > `us`

### DIFF
--- a/HOWTO-nl.md
+++ b/HOWTO-nl.md
@@ -5,9 +5,9 @@ Welkom bij Free-Programming-Books! We verwelkomen nieuwe bijdragers; zelfs degen
 * [:us: Over pull-verzoeken](https://help.github.com/articles/about-pull-requests/) *(in engels)*
 * [:us: Een pull-verzoek maken](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) *(in engels)*
 * [:us: Github Hallo Wereld](https://guides.github.com/activities/hello-world/) *(in engels)*
-* [:en: Youtube - Github-zelfstudie voor beginners](https://www.youtube.com/watch?v=0fKg7e37bQE) *(in engels)*
-* [:en: Youtube - Hoe een GitHub-repo te forken en een pull-verzoek in te dienen](https://www.youtube.com/watch?v=G1I3HF4YWEw) *(in engels)*
-* [:en: Youtube - Markdown Crash Course](https://www.youtube.com/watch?v=HUBNt18RFbo) *(in engels)*
+* [:us: Youtube - Github-zelfstudie voor beginners](https://www.youtube.com/watch?v=0fKg7e37bQE) *(in engels)*
+* [:us: Youtube - Hoe een GitHub-repo te forken en een pull-verzoek in te dienen](https://www.youtube.com/watch?v=G1I3HF4YWEw) *(in engels)*
+* [:us: Youtube - Markdown Crash Course](https://www.youtube.com/watch?v=HUBNt18RFbo) *(in engels)*
 
 
 Aarzel niet om vragen te stellen; elke bijdrager begon met een eerste PR. Je zou onze duizendste kunnen zijn!


### PR DESCRIPTION
# What does this PR do?
Improve repo

## For resources
### Description

Hotfix to resolve https://github.com/EbookFoundation/free-programming-books/commit/d775cb34fbf5eadbdaa465bf46510cc4974151f8#commitcomment-59537594

`:en:` emoji flag markup doesn't work. Use `:us:` :us: or `:gb:` :gb:

Source PR: #5831.

https://github.com/EbookFoundation/free-programming-books/commit/d775cb34fbf5eadbdaa465bf46510cc4974151f8#diff-b35eb40c148657d4ea1361c44496e11c5625f484a4c6040c022770e88cbcfdccR8-R10

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates. #5831
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
