### PR TITLE
Remove `The Vim Blog` podcast

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -147,7 +147,6 @@
 * [Emacs Rocks!](http://emacsrocks.com) (screencast)
 * [Free screencasts about the text editor Vim](http://vimcasts.org) (screencast)
 * [PHPStorm Tips & Tricks](https://www.youtube.com/playlist?list=PLk9WlAgeZoTfHdJUv75-5grVQf4ijIrzw) - Christoph Rumpel (screencast)
-* [The Vim Blog](https://soundcloud.com/thevimcast) (podcast)
 * [vim Hacking](https://www.youtube.com/playlist?list=PL-p5XmQHB_JSTaEPygu1DZjuFfb704Uv7) (screencast)
 
 


### PR DESCRIPTION
## What does this PR do?
Remove resource(s)

## For resources
The Vim Blog
### Description
Linked podcast is a politics podcast
### Why is this valuable (or not)?
Not related to free programming books
### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
