### PR TITLE
Add RCS resources

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -178,6 +178,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Racket](#racket)
 * [Raku](#raku)
 * [Raspberry Pi](#raspberry-pi)
+* [RCS](#rcs)
 * [REBOL](#rebol)
 * [Ruby](#ruby)
   * [RSpec](#rspec)
@@ -2072,6 +2073,12 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Raspberry Pi: Measure, Record, Explore](https://leanpub.com/RPiMRE/read) - Malcolm Maclean (HTML)
 * [Raspberry Pi Users Guide - (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)
 * [The Official Raspberry Pi Project Book 1 (2015)](https://magpi.raspberrypi.com/books/projects-1) (PDF)
+
+
+### RCS
+
+* [RCS — A System for Version Control](https://www.cs.purdue.edu/homes/trinkle/RCShome/rcs.ps) - Walter F. Tichy (PS)
+* [RCS Handbook](https://www.cs.purdue.edu/homes/trinkle/RCShome/contrib/odonavan/RCS_Book.tar.Z) - Brian O’Donovan
 
 
 ### REBOL


### PR DESCRIPTION
## What does this PR do?
Add [Revision Control System (RCS)](https://en.wikipedia.org/wiki/Revision_Control_System) resources.

## For resources
### Description

Add two resources:
* *RCS — A System for Version Control* — The paper where the original author of RCS describes RCS.
* *RCS Handbook* — A book that shows how to use RCS.

### Why is this valuable (or not)?

*RCS Handbook* is particularly valuable because it goes far beyond the man pages and the short tutorials found on various websites. For example, the book teaches about branching, merging, and managing software projects.

### How do we know it's really free?

These texts are made available on the [Purdue RCS Homepage](https://www.cs.purdue.edu/homes/trinkle/RCShome/#DOC).

### For book lists, is it a book? For course lists, is it a course? etc.

One paper and one book.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)
