### PR TITLE
Add "ANSI Common Lisp Standard"

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1454,6 +1454,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 ### Lisp
 
+* [ANSI Common Lisp Standard (draft version 15.17R, X3J13/94-101R)](https://web.archive.org/web/20190304180600/http://cvberry.com/downloads/cl-ansi-standard-draft-w-sidebar.pdf) (PDF)
 * [Basic Lisp Techniques](http://franz.com/resources/educational_resources/cooper.book.pdf) - David J. Cooper, Jr. (PDF)
 * [Casting Spels in Lisp](http://www.lisperati.com/casting.html)
 * [Common Lisp: A Gentle Introduction to Symbolic Computation](http://www.cs.cmu.edu/~dst/LispBook/) - David S. Touretzky (PDF, PS)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1454,7 +1454,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 ### Lisp
 
-* [ANSI Common Lisp Standard (draft version 15.17R, X3J13/94-101R)](https://web.archive.org/web/20190304180600/http://cvberry.com/downloads/cl-ansi-standard-draft-w-sidebar.pdf) (PDF)
+* [ANSI Common Lisp Standard (draft version 15.17R, X3J13/94-101R)](https://franz.com/support/documentation/cl-ansi-standard-draft-w-sidebar.pdf) (PDF)
 * [Basic Lisp Techniques](http://franz.com/resources/educational_resources/cooper.book.pdf) - David J. Cooper, Jr. (PDF)
 * [Casting Spels in Lisp](http://www.lisperati.com/casting.html)
 * [Common Lisp: A Gentle Introduction to Symbolic Computation](http://www.cs.cmu.edu/~dst/LispBook/) - David S. Touretzky (PDF, PS)


### PR DESCRIPTION
## What does this PR do?
Add a PDF version of the last draft of the ANSI Common Lisp standard.

## For resources
### Description

This PDF comes from https://web.archive.org/web/20190630183107/http://cvberry.com/tech_writings/notes/common_lisp_standard_draft.html

### Why is this valuable (or not)?

This is a PDF version of the last draft of the ANSI Common Lisp standard, which differs minimally from the final standard.

### How do we know it's really free?

The final draft standard is for "free use, copying, distribution" ([source](https://www.cs.cmu.edu/afs/cs/project/ai-repository/ai/lang/lisp/doc/standard/ansi/0.html)). This PDF is also distributed by Franz Inc. https://franz.com/support/documentation/

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)
