### PR TITLE
Update .Net Url

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -750,7 +750,7 @@
 
 ### .NET
 
-* [Learn how to program: .NET](https://www.learnhowtoprogram.com/net) - Epicodus Inc.
+* [Learn how to program: C# and .NET](https://www.learnhowtoprogram.com/c-and-net) - Epicodus Inc.
 
 
 ### Objective-C

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -752,6 +752,7 @@
 
 > :information_source: See also &#8230; [C#](#c-sharp)
 
+
 ### Objective-C
 
 * [Objective-C for Swift Developers](https://www.udacity.com/course/objective-c-for-swift-developers--ud1009) - Gabrielle Miller-Messner (Udacity)

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -750,8 +750,6 @@
 
 ### .NET
 
-* [Learn how to program: C# and .NET](https://www.learnhowtoprogram.com/c-and-net) - Epicodus Inc.
-
 > :information_source: See also &#8230; [C#](#c-sharp)
 
 ### Objective-C

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -752,6 +752,7 @@
 
 * [Learn how to program: C# and .NET](https://www.learnhowtoprogram.com/c-and-net) - Epicodus Inc.
 
+> :information_source: See also &#8230; [C#](#c-sharp)
 
 ### Objective-C
 


### PR DESCRIPTION
As the previose was 404 not found

## What does this PR do?
Add resource(s) or just correct it for the same resource

## For resources
### Description
 it's the same resource used for C# and it was already added but the url is wrong

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
