### PR TITLE
fix(docs): Manually set anchors for broken tags

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1,7 +1,7 @@
 ### Index
 
-* [0 - MOOC](#0-45-mooc)
-* [Algorithms & Data Structures](#algorithms-amp-data-structures)
+* [0 - MOOC](#0---mooc)
+* [Algorithms & Data Structures](#algorithms--data-structures)
 * [Android](#android)
 * [APL](#apl)
 * [Artificial Intelligence](#artificial-intelligence)
@@ -80,7 +80,7 @@
 * [Web Development](#web-development)
 
 
-### 0 &#45; MOOC
+<h3 id="0---mooc">0 - MOOC</h3>
 
 * [Codecademy](https://www.codecademy.com)
 * [Coursera](https://www.coursera.org)
@@ -99,7 +99,7 @@
 * [Udacity](https://www.udacity.com)
 
 
-### Algorithms &amp; Data Structures
+<h3 id="algorithms--data-structures">Algorithms & Data Structures</h3>
 
 * [Algorithms](https://www.youtube.com/playlist?list=PLDN4rrl48XKpZkf03iYFl-O29szjTrs_O) - Abdul Bari
 * [Berkeley University CS 61B: Data Structures](http://datastructur.es/sp16/)

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1,7 +1,7 @@
 ### Index
 
-* [0 - MOOC](#0---mooc)
-* [Algorithms & Data Structures](#algorithms--data-structures)
+* [0 - MOOC](#0-45-mooc)
+* [Algorithms & Data Structures](#algorithms-amp-data-structures)
 * [Android](#android)
 * [APL](#apl)
 * [Artificial Intelligence](#artificial-intelligence)
@@ -80,7 +80,7 @@
 * [Web Development](#web-development)
 
 
-### 0 - MOOC
+### 0 &#45; MOOC
 
 * [Codecademy](https://www.codecademy.com)
 * [Coursera](https://www.coursera.org)
@@ -99,7 +99,7 @@
 * [Udacity](https://www.udacity.com)
 
 
-### Algorithms & Data Structures
+### Algorithms &amp; Data Structures
 
 * [Algorithms](https://www.youtube.com/playlist?list=PLDN4rrl48XKpZkf03iYFl-O29szjTrs_O) - Abdul Bari
 * [Berkeley University CS 61B: Data Structures](http://datastructur.es/sp16/)


### PR DESCRIPTION
## What does this PR do?
Related to PR #5810. Fixes issue #6508.
GFM parses anchors differently on Github vs on Github Pages.

Given this markup:
```
* [0 - MOOC](#0---mooc)
* [Algorithms & Data Structures](#algorithms--data-structures)

### 0 - MOOC
### Algorithms & Data Structures
```

Github generates this HTML:
```
<a href="#0---mooc">0 - MOOC</a>
<a href="#algorithms--data-structures">Algorithms &amp; Data Structures</a>

<h3><a id="user-content-0---mooc" href="#0---mooc"></a>0 - MOOC</h3>
<h3><a id="user-content-algorithms--data-structures" href="#algorithms--data-structures"></a>Algorithms &amp; Data Structures</h3>
```

But Github pages generates this, note the different `id` and `href` values:
```
<a href="#0---mooc">0 - MOOC</a>
<a href="#algorithms--data-structures">Algorithms &amp; Data Structures</a>

<h3 id="mooc">0 - MOOC</h3>
<h3 id="algorithms-amp-data-structures">Algorithms &amp; Data Structures</h3>
```

Which results in the links working in Github but not on Github pages.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
