### PR TITLE
fix: Use Markdown instead of HTML markup for H3 & H4 headings

### DIFF
--- a/books/free-programming-books-ar.md
+++ b/books/free-programming-books-ar.md
@@ -2,7 +2,7 @@
 
 * [Arduino](#arduino)
 * [Artificial Intelligence](#artificial-intelligence)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [HTML/CSS](#htmlcss)
 * [Introduction to Programming in Arabic](#introduction-to-programming-in-arabic)
 * [JavaScript](#javascript)
@@ -34,7 +34,7 @@
 * [مدخل إلى الذكاء الاصطناعي وتعلم الآلة](https://academy.hsoub.com/files/17-%D9%85%D8%AF%D8%AE%D9%84-%D8%A5%D9%84%D9%89-%D8%A7%D9%84%D8%B0%D9%83%D8%A7%D8%A1-%D8%A7%D9%84%D8%A7%D8%B5%D8%B7%D9%86%D8%A7%D8%B9%D9%8A-%D9%88%D8%AA%D8%B9%D9%84%D9%85-%D8%A7%D9%84%D8%A2%D9%84%D8%A9/) - Mohamed Lahlah (PDF)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [سبيلك المختصر لتعلم لغة c# - برمجة الواجهات](https://www.mobarmijoun.com/2014/04/c_19.html) - Khaled Al-Saadani (Arab Coders Academy) (PDF)
 

--- a/books/free-programming-books-bg.md
+++ b/books/free-programming-books-bg.md
@@ -23,7 +23,7 @@
 * [Програмиране за .NET Framework](https://www.devbg.org/dotnetbook) - Светлин Наков и колектив
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Основи на програмирането със C++](https://cpp-book.softuni.bg) - Светлин Наков и колектив
 

--- a/books/free-programming-books-bg.md
+++ b/books/free-programming-books-bg.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -16,7 +16,7 @@
 * [ANSI C - Пълен справочник](https://progstarter.com/index.php?option=com_content&view=article&id=9&Itemid=122&lang=bg) - Димо Петков
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Основи на програмирането със C#](https://csharp-book.softuni.bg) - Светлин Наков и колектив
 * [Принципи на програмирането със C#](https://introprogramming.info/intro-csharp-book) - Светлин Наков, Веселин Колев и колектив

--- a/books/free-programming-books-cs.md
+++ b/books/free-programming-books-cs.md
@@ -38,7 +38,7 @@
 * [Systémové programování v jazyce C#](https://phoenix.inf.upol.cz/esf/ucebni/sysprog.pdf) (PDF)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Moderní programování objektových aplikací v C++](https://akela.mendelu.cz/~xvencal2/CPP/opora.pdf) (PDF)
 * [Objektové programování v C++](http://media1.jex.cz/files/media1:49e6b94e79262.pdf.upl/07.%20Objektov%C3%A9%20programov%C3%A1n%C3%AD%20v%20C%2B%2B.pdf) (PDF)

--- a/books/free-programming-books-cs.md
+++ b/books/free-programming-books-cs.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [Bash](#bash)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Git](#git)
 * [HTML](#html)
@@ -32,7 +32,7 @@
 * [Bash očima Bohdana Milara](http://i.iinfo.cz/files/root/k/bash_ocima_bohdana_milara.pdf) (PDF)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Programovací jazyk C#](http://www.cs.vsb.cz/behalek/vyuka/pcsharp/text.pdf) - Marek Běhálek (PDF)
 * [Systémové programování v jazyce C#](https://phoenix.inf.upol.cz/esf/ucebni/sysprog.pdf) (PDF)

--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -73,7 +73,7 @@ Dirk Loser, Clemens Tamme, Philipp Schweinzer (PDF)
 * [Visual C# 2012](http://openbook.rheinwerk-verlag.de/visual_csharp_2012) - Andreas Kühnel (Online)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Die Boost C++ Bibliotheken](http://dieboostcppbibliotheken.de) - Boris Schäling (Online)
 * [Lean Testing für C++-Programmierer (2018)](https://www.assets.dpunkt.de/openbooks/Openbook_Lean_Testing.pdf) - Andreas Spillner, Ulrich Breymann (PDF)

--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -5,7 +5,7 @@
 * [Android](#android)
 * [Assembly Language](#assembly-language)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Component Pascal](#component-pascal)
 * [Git](#git)
@@ -67,7 +67,7 @@ Dirk Loser, Clemens Tamme, Philipp Schweinzer (PDF)
 * [Softwareentwicklung in C](https://web.archive.org/web/20190214185910/http://www.asc.tuwien.ac.at/~eprog/download/schmaranz.pdf) - Klaus Schmaranz (PDF)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Programmieren in C#: Einführung](http://www.highscore.de/csharp/einfuehrung)
 * [Visual C# 2012](http://openbook.rheinwerk-verlag.de/visual_csharp_2012) - Andreas Kühnel (Online)

--- a/books/free-programming-books-dk.md
+++ b/books/free-programming-books-dk.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Java](#java)
 * [Pascal](#pascal)
@@ -12,7 +12,7 @@
 * [Programmering i C](http://people.cs.aau.dk/~normark/c-prog-06/pdf/all.pdf) - Kurt Nørmark (PDF)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Object-oriented Programming in C#](http://people.cs.aau.dk/~normark/oop-csharp/pdf/all.pdf) - Kurt Nørmark (PDF)
 

--- a/books/free-programming-books-dk.md
+++ b/books/free-programming-books-dk.md
@@ -17,7 +17,7 @@
 * [Object-oriented Programming in C#](http://people.cs.aau.dk/~normark/oop-csharp/pdf/all.pdf) - Kurt Nørmark (PDF)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Notes about C++](http://people.cs.aau.dk/~normark/ap/index.html) - Kurt Nørmark (HTML)
 

--- a/books/free-programming-books-el.md
+++ b/books/free-programming-books-el.md
@@ -14,7 +14,7 @@
 * [Διαδικαστικός προγραμματισμός](https://repository.kallipos.gr/bitstream/11419/1346/1/00_master%20document_KOY.pdf) - Μαστοροκώστας Πάρις (PDF)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Εισαγωγή στη C++](http://www.ebooks4greeks.gr/2011.Download_free-ebooks/Pliroforikis/glossa_programmatismoy_C++__eBooks4Greeks.gr.pdf) (PDF)
 * [Προγραμματισμός με τη γλώσσα C++](https://repository.kallipos.gr/bitstream/11419/6443/1/00_master_document-KOY.pdf) - Θεόδωρος Αλεβίζος (PDF)
@@ -49,5 +49,3 @@
 ### SQL
 
 * [Εισαγωγή στην SQL: Εργαστηριακές Ασκήσεις σε MySQL5.7](https://www.ebooks4greeks.gr/eisagwgh-sthn-sql-ergasthriakes-askhseis-se-mysql5-7)
-
-

--- a/books/free-programming-books-et.md
+++ b/books/free-programming-books-et.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C Sharp](#c-sharp)
+* [C#](#csharp)
 * [Java](#java)
 * [JavaScript](#javascript)
     * [AngularJS](#angularjs)
@@ -18,7 +18,7 @@
 * [Programmeerimiskeel C](https://et.wikibooks.org/wiki/Programmeerimiskeel_C) - Wikiõpikud
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Microsoft Visual Studio Code ja C#](https://digiarhiiv.ut.ee/Ained/Doc/VFailid/CSharp_ja_VS.pdf) - Kalle Remm (PDF)
 

--- a/books/free-programming-books-fi.md
+++ b/books/free-programming-books-fi.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C Sharp](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [JavaScript](#javascript)
 * [MySQL](#mysql)
@@ -29,7 +29,7 @@
 * [Ohjelmoinnin perusteet ja C-kieli](http://cs.stadia.fi/~silas/ohjelmointi/c_opas) - Simo Silander
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Ohjelmointi 1: C#](https://jyx.jyu.fi/bitstream/handle/123456789/47417/978-951-39-4859-7.pdf) - Martti Hyvönen, Vesa Lappalainen, Antti-Jussi Lakanen (PDF)
 

--- a/books/free-programming-books-fi.md
+++ b/books/free-programming-books-fi.md
@@ -34,7 +34,7 @@
 * [Ohjelmointi 1: C#](https://jyx.jyu.fi/bitstream/handle/123456789/47417/978-951-39-4859-7.pdf) - Martti Hyvönen, Vesa Lappalainen, Antti-Jussi Lakanen (PDF)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [C++](https://fi.wikibooks.org/wiki/C%2B%2B) - Wikikirjasto
 * [C++-ohjelmointi](https://www.ohjelmointiputka.net/oppaat/opas.php?tunnus=cpp_ohj_01)

--- a/books/free-programming-books-he.md
+++ b/books/free-programming-books-he.md
@@ -4,7 +4,7 @@
   * [מערכות הפעלה](#מערכות-הפעלה)
   * [רשתות](#רשתות)
 * [Assembly](#assembly)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [Java](#java)
 * [Python](#python)
 
@@ -26,7 +26,7 @@
 * [ארגון המחשב ושפת סף](https://data.cyber.org.il/python/python_book.pdf) – ברק גונן, המרכז לחינוך סייבר (PDF)
 
 
-### <a name="c-sharp"></a>C#
+### <a name="csharp"></a>C\#
 
 * [מבוא לתכנות בסביבת האינטרנט בשפת C#](https://meyda.education.gov.il/files/free%20books/%D7%9E%D7%91%D7%95%D7%90%20%D7%9C%D7%AA%D7%9B%D7%A0%D7%95%D7%AA%20%D7%91%D7%A1%D7%91%D7%99%D7%91%D7%AA%20%D7%94%D7%90%D7%99%D7%A0%D7%98%D7%A8%D7%A0%D7%98%20090216.pdf) – מט״ח (PDF)
 

--- a/books/free-programming-books-hu.md
+++ b/books/free-programming-books-hu.md
@@ -37,7 +37,7 @@
 * [Arduino programozási kézikönyv](http://avr.tavir.hu) - Brian W. Evans írása alapján fordította, kiegészítette és frissítette Cseh Róbert (PDF - regisztráció szükséges)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Fejlett programozási technikák](http://www.ms.sapientia.ro/~manyi/teaching/c++/cpp.pdf) - Antal Margit (PDF)
 

--- a/books/free-programming-books-id.md
+++ b/books/free-programming-books-id.md
@@ -2,7 +2,7 @@
 
 * [Android](#android)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [CodeIgniter](#codeigniter)
 * [Emacs](#emacs)
@@ -37,7 +37,7 @@
 * [Belajar Pemrograman C untuk Pemula](https://www.petanikode.com/tutorial/c/) - Ahmad Muhardian (:construction: *in process*)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Menguasai Pemrograman Berorientasi Objek Dengan Bahasa C#](https://mahirkoding.id/ebook-pemrograman-berorientasi-objek-c-pdf/)
 

--- a/books/free-programming-books-id.md
+++ b/books/free-programming-books-id.md
@@ -42,7 +42,7 @@
 * [Menguasai Pemrograman Berorientasi Objek Dengan Bahasa C#](https://mahirkoding.id/ebook-pemrograman-berorientasi-objek-c-pdf/)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Belajar C++ Dasar Bahasa Indonesia](https://github.com/kelasterbuka/CPP_dasar-dasar-programming) - Kelas Terbuka
 * [Koding C++ Dengan Qt](https://leanpub.com/koding-cpp-qt) *(Membutuhkan akun Leanpub atau email yang valid)*

--- a/books/free-programming-books-it.md
+++ b/books/free-programming-books-it.md
@@ -102,7 +102,7 @@
 * [ABC# - Guida alla programmazione](http://antoniopelleriti.it/wp-content/uploads/2019/04/ABCsharp-guida-alla-programmazione-in-csharp.pdf) - A. Pelleriti (PDF)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Corso C++ standard](http://didatticait.altervista.org/programmazione/CPP/CPP-dispense/CORSO_C.pdf) - (PDF)
 * [Il linguaggio C++](https://hpc-forge.cineca.it/files/CoursesDev/public/2012%20Autumn/Introduzione%20alla%20programmazioni%20a%20oggetti%20in%20C++/corsocpp.pdf) - (PDF)

--- a/books/free-programming-books-it.md
+++ b/books/free-programming-books-it.md
@@ -10,7 +10,7 @@
 * [Assembly Language](#assembly-language)
 * [BASH](#bash)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [CSS](#css)
 * [Database](#database)
@@ -97,7 +97,7 @@
 * [Tricky C](http://www.dmi.unict.it/diraimondo/web/wp-content/uploads/classes/so/mirror-stuff/Tricky_C.pdf) (PDF)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [ABC# - Guida alla programmazione](http://antoniopelleriti.it/wp-content/uploads/2019/04/ABCsharp-guida-alla-programmazione-in-csharp.pdf) - A. Pelleriti (PDF)
 

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -271,7 +271,7 @@
 * [猫でもわかるプログラミング](http://kumei.ne.jp/c_lang) - 粂井康孝
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [C++11の文法と機能(C++11: Syntax and Feature)](https://ezoeryou.github.io/cpp-book/C++11-Syntax-and-Feature.xhtml) - 江添亮
 * [C++入門](https://www.asahi-net.or.jp/~yf8k-kbys/newcpp0.html) - 小林健一郎

--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -57,7 +57,7 @@
 * [BeeJ's Guide to Network Programming - 인터넷 소켓 활용](https://blogofscience.com/Socket_Programming-KLDP.html)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [씹어먹는 C++](https://github.com/kev0960/ModooCode/raw/master/book/cpp/main.pdf) - 이재범 (PDF)
 
@@ -225,4 +225,3 @@
 ### Unicode
 
 * [번역 Unicode 이모티콘에 얽힌 이것저것 (이모티콘 표준과 프로그래밍 핸들링)](http://pluu.github.io/blog/android/2020/01/11/unicode-emoji/)
-

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -28,7 +28,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [BeanShell](#beanshell)
 * [BETA](#beta)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Chapel](#chapel)
 * [Cilk](#cilk)
@@ -462,7 +462,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [TONC GBA Programming - Game Boy Advance Development](http://www.coranac.com/tonc/text/toc.htm)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [C# Notes for Professionals](http://goalkicker.com/CSharpBook/) - Compiled from StackOverflow documentation (PDF)
 * [C# Programming](https://en.wikibooks.org/wiki/C_Sharp_Programming) - Wikibooks

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -485,7 +485,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Xamarin.Forms Succinctly](https://www.syncfusion.com/ebooks/xamarin-forms-succinctly) - Alessandro Del Sole
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [C++ Annotations](https://fbb-git.gitlab.io/cppannotations/) - Frank B. Brokken (HTML, PDF)
 * [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md) - Editors: Bjarne Stroustrup, Herb Sutter

--- a/books/free-programming-books-nl.md
+++ b/books/free-programming-books-nl.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [COBOL](#cobol)
 * [Java](#java)
 * [PHP](#php)
@@ -15,7 +15,7 @@
 * [Programmeren in C](https://nl.wikibooks.org/wiki/Programmeren_in_C) - Wikibooks
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Programmeren in C Sharp](https://nl.wikibooks.org/wiki/Programmeren_in_C_Sharp) - Wikibooks
 

--- a/books/free-programming-books-pl.md
+++ b/books/free-programming-books-pl.md
@@ -5,7 +5,7 @@
 * [Assembly](#assembly)
 * [Bash](#bash)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Common Lisp](#common-lisp)
 * [Coq](#coq)
@@ -69,7 +69,7 @@
 * [Wgłąb języka C](http://helion.pl/online/wglab/wglab.zip) (ZIP)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Darmowy kurs C#](http://kurs.aspnetmvc.pl/Csharp)
 * [Kurs C#](http://zajacmarek.com/kurs-c-sharp/) - Marek Zając

--- a/books/free-programming-books-pl.md
+++ b/books/free-programming-books-pl.md
@@ -78,7 +78,7 @@
 * [Wstęp do programowania w C#](http://c-sharp.ue.katowice.pl/ksiazka/c_sharp_wer2_0.pdf) - Anna Kempa, Tomasz Staś (PDF)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [C++](https://pl.wikibooks.org/wiki/C++) - Wikibooks
 * [Język C++ – podstawy programowania](http://www.dz5.pl/ti/cpp/zz_dodatki/kurs_cpp_szczegolowy2.pdf) - Paweł Mikołajczak (PDF)

--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -106,7 +106,7 @@
 * [C# e Orientação a Objetos](https://www.caelum.com.br/apostila-csharp-orientacao-objetos/) - Caelum
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Apostila Linguagem C++](http://www.ime.usp.br/~slago/slago-C++.pdf) - Silvio Lago (PDF)
 * [Estrutura de Dados](http://calhau.dca.fee.unicamp.br/wiki/images/0/01/EstruturasDados.pdf) (PDF)

--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -7,7 +7,7 @@
 * [Android](#android)
 * [Assembly](#assembly)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Dart](#dart)
 * [Docker](#docker)
@@ -101,7 +101,7 @@
 * [Projeto de Algoritmos em C](http://www.ime.usp.br/~pf/algoritmos/)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [C# e Orientação a Objetos](https://www.caelum.com.br/apostila-csharp-orientacao-objetos/) - Caelum
 

--- a/books/free-programming-books-ru.md
+++ b/books/free-programming-books-ru.md
@@ -9,7 +9,7 @@
 * [Assembly](#assembly)
 * [Bash](#bash)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Clojure](#clojure)
 * [CoffeeScript](#coffeescript)
@@ -143,7 +143,7 @@
 * [Язык Си в примерах](https://ru.wikibooks.org/wiki/Язык_Си_в_примерах) - Викиучебник
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Паттерны проектирования в C# и .NET](https://metanit.com/sharp/patterns) - Евгений Попов
 * [Полное руководство по языку программирования С# 7.0 и платформе .NET 4.7](https://metanit.com/sharp/tutorial) - Евгений Попов

--- a/books/free-programming-books-ru.md
+++ b/books/free-programming-books-ru.md
@@ -151,7 +151,7 @@
 * [Design Patterns via C#](http://itvdn.com/ru/patterns) - Александр Шевчук, Дмитрий Охрименко, Андрей Касьянов (PDF) *(Требуется аккаунт)*
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Введение в язык программирования С++](http://lib.ru/CPPHB/cpptut.txt_with-big-pictures.html) - Бьерн Страуструп
 * [Введение в язык Си++](http://stolyarov.info/books/cppintro) - Андрей Столяров (PDF)

--- a/books/free-programming-books-sv.md
+++ b/books/free-programming-books-sv.md
@@ -10,7 +10,7 @@
 * [C-programmering](https://sv.wikibooks.org/wiki/C-programmering) - Wikibooks
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Programmera spel i C++ för nybörjare](https://sv.wikibooks.org/wiki/Programmera_spel_i_C%2B%2B_f%C3%B6r_nyb%C3%B6rjare) - Wikibooks
 
@@ -23,4 +23,3 @@
 ### PHP
 
 * [Programmera i PHP](https://sv.wikibooks.org/wiki/Programmera_i_PHP) - Wikibooks
-

--- a/books/free-programming-books-tr.md
+++ b/books/free-programming-books-tr.md
@@ -47,7 +47,7 @@
 * [GNU C Kütüphanesi Basvuru Klavuzu](http://www.belgeler.org/glibc/glibc.html)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [C++ Dersleri](https://www.yusufsezer.com.tr/cpp-dersleri/) - Yusuf Sezer
 

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -28,7 +28,7 @@
   * [Assembly](#assembly)
   * [AWK](#awk)
   * [C](#c)
-  * [C#](#c-sharp)
+  * [C#](#csharp)
   * [C++](#cpp)
   * [CoffeeScript](#coffeescript)
   * [Dart](#dart)
@@ -334,7 +334,7 @@
 * [Linux C 编程一站式学习](http://docs.linuxtone.org/ebooks/C&CPP/c/)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [精通C#(第6版)](http://book.douban.com/subject/24827879/)
 

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -339,7 +339,7 @@
 * [精通C#(第6版)](http://book.douban.com/subject/24827879/)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [100个gcc小技巧](https://github.com/hellogcc/100-gcc-tips/blob/master/src/index.md)
 * [100个gdb小技巧](https://github.com/hellogcc/100-gdb-tips/blob/master/src/index.md)

--- a/courses/free-courses-ar.md
+++ b/courses/free-courses-ar.md
@@ -4,7 +4,7 @@
 * [Assembly](#assembly)
 * [Bootstrap](#bootstrap)
 * [C](#c)
-* [C Sharp](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Computer Architecture](#computer-architecture)
 * [Dart](#dart)
@@ -66,7 +66,7 @@
 * [Introduction to Programming ( C Language - مقدمة في البرمجة ( لغة السي](https://www.youtube.com/playlist?list=PLMm8EjqH1EFXI8wByY0umF_DQON2S9uws) - Ahmed Sallam
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [C#](https://www.youtube.com/playlist?list=PLltZRmsFXWnIfLM0BKgJNZYVnvCDZNAh_) - 6wrni
 * [C# Programming Course Level 1 Basics By Arabic](https://www.youtube.com/playlist?list=PLnzqK5HvcpwQLsXXXxx_mX3WvUEgGM0iA) - محمد شوشان

--- a/courses/free-courses-ar.md
+++ b/courses/free-courses-ar.md
@@ -74,7 +74,7 @@
 * [Unit Testing in C# [Arabic]](https://www.youtube.com/playlist?list=PLwj1YcMhLRN28xijrXMO255JHsO3csus-) - خالد السعداني
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Arabic C++ For kids & beginners (برمجة لصغار السن والمبتدئيين)](https://www.youtube.com/playlist?list=PLPt2dINI2MIbwnEoeHZnUHeUHjTd8x4F3) - Arabic Competitive Programming
 * [C++ Intensive - برمجة الحاسوب](https://www.youtube.com/playlist?list=PLPt2dINI2MIZPFq6HyUB1Uhxdh1UDnZMS) - Arabic Competitive Programming

--- a/courses/free-courses-bn.md
+++ b/courses/free-courses-bn.md
@@ -41,7 +41,7 @@
 * [Pattern Printing in C](https://www.youtube.com/playlist?list=PLgH5QX0i9K3oTxQhx2kejYmQn6qtRULCD) - Anisul Islam
 
 
-### <a name="csharp"></a>C#
+### <a name="csharp"></a>C\#
 
 * [C# and ASP.NET MVC Full Bangla Tutorial BITM](https://www.youtube.com/playlist?list=PL_g-DE60bXDBpjMPUWGbmCLHnQDIIcw-6) - Learn With Nirash
 * [C# bangla tutorial | Basic to advance in depth bangla course](https://www.youtube.com/playlist?list=PLbC4KRSNcMnqQakB2xlZPoaV6uau4wTIt) - Learn Hunter

--- a/courses/free-courses-de.md
+++ b/courses/free-courses-de.md
@@ -12,7 +12,7 @@
 * [TypeScript](#typescript)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [C++ Grundlagen Tutorials von Pilzschaf](https://www.youtube.com/playlist?list=PLStQc0GqppuVs05kWvLBoHcWCULX3ueIM) - Pilzschaf
 

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -10,7 +10,7 @@
 * [Bash / Shell](#bash--shell)
 * [Bootstrap](#bootstrap)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Clojure](#clojure)
 * [Cloud Computing](#cloud-computing)
@@ -241,7 +241,7 @@
 * [The Arduino Platform and C Programming](https://www.coursera.org/learn/arduino-platform)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [C# 101](https://channel9.msdn.com/Series/CSharp-101) - Scott Hanselman, Kendra Havens Microsoft.
 * [C# Programming All-in-One Tutorial Series (6 HOURS!)](https://www.youtube.com/watch?v=qOruiBrXlAw) - Caleb Curry (YouTube)
@@ -746,7 +746,7 @@
 
 ### .NET
 
-> :information_source: See also &#8230; [C#](#c-sharp)
+> :information_source: See also &#8230; [C#](#csharp)
 
 
 ### Objective-C

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -250,7 +250,7 @@
 * [Learn how to program: C# and .NET](https://www.learnhowtoprogram.com/c-and-net) - Epicodus Inc.
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [C++ For Programmers](https://www.udacity.com/course/c-for-programmers--ud210) - Catherine Gamboa (Udacity)
 * [C++ Programming Tutorial for Beginners (For Absolute Beginners)](https://www.youtube.com/playlist?list=PLS1QulWo1RIYSyC6w2-rDssprPrEsgtVK) - ProgrammingKnowledge

--- a/courses/free-courses-fi.md
+++ b/courses/free-courses-fi.md
@@ -1,12 +1,12 @@
 ### Index
 
-* [C#](#C#)
+* [C#](#csharp)
 * [Other](#other)
 * [Python](#python)
 * [Web Development](#web-development)
 
 
-### C#
+### <a name="csharp"></a>C\#
 
 * [Jyväskylän yliopiston C#-kieli ohjelmointikurssi](https://tim.jyu.fi/view/kurssit/tie/ohj1/moniste/Ohjelmointi-1) - Ilmainen verkkokurssi
 

--- a/courses/free-courses-fr.md
+++ b/courses/free-courses-fr.md
@@ -4,7 +4,7 @@
 * [APL](#apl)
 * [Bash / Shell](#bash--shell)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Git](#git)
 * [HTML / CSS](#html--css)
@@ -46,14 +46,14 @@
 * [TUTOS C](https://www.youtube.com/playlist?list=PLEagTQfI6nPOWS4JPnxW5pRVgeyLuS5oC) - PrimFX
 
 
+### <a name="csharp"></a>C\#
+
+* [C# - Cours](https://www.youtube.com/playlist?list=PLrSOXFDHBtfGBHAMEg9Om9nF_7R7h5mO7) - Formation Video
+
+
 ### <a name="cpp"></a>C++
 
 * [La programmation en C++ moderne](https://zestedesavoir.com/tutoriels/822/la-programmation-en-c-moderne/) - Zeste de savoir informaticienzero mehdidou99
-
-
-### C Sharp
-
-* [C# - Cours](https://www.youtube.com/playlist?list=PLrSOXFDHBtfGBHAMEg9Om9nF_7R7h5mO7) - Formation Video
 
 
 ### Git

--- a/courses/free-courses-hi.md
+++ b/courses/free-courses-hi.md
@@ -121,7 +121,7 @@
 * [Web Development Course](https://www.youtube.com/playlist?list=PLfqMhTWNBTe3H6c9OGXb5_6wcc1Mca52n) - Apna College
 
 
-<h4 id="nextjs">Next.js</h4>
+#### Next.js
 
 * [NextJS Tutorial In Hindi](https://www.youtube.com/playlist?list=PLwGdqUZWnOp2rDbpfKAeUi9f8qZMS7_cv) - Vinod Bahadur Thapa (Thapa Technical)
 

--- a/courses/free-courses-id.md
+++ b/courses/free-courses-id.md
@@ -4,7 +4,7 @@
 * [Apache Kafka](#apache-kafka)
 * [AR / VR](#ar--vr)
 * [C / C++](#c--c)
-* [C#](#c)
+* [C#](#csharp)
 * [Construct](#construct)
 * [Dart](#dart)
 * [Desain dan Arsitektur](#desain-dan-arsitektur)
@@ -72,7 +72,7 @@
 * [Memulai Pemrograman dengan C](https://www.dicoding.com/academies/120) - Dicoding, membutuhkan registrasi
 
 
-### C#
+### <a name="csharp"></a>C\#
 
 * [Belajar Pemrograman C#](https://www.youtube.com/playlist?list=PLuGFxya63u253zhOzhxanaSBNJ_UiIhUb) - Galih Pratama
 

--- a/courses/free-courses-it.md
+++ b/courses/free-courses-it.md
@@ -71,7 +71,7 @@
 * [Programmazione ad oggetti in C#](https://www.youtube.com/watch?v=aSgikNnGEKM&list=PLktbfd3yXeH8yQpHM3O468k8l-aTC6Hl6) - G. Pellegrini Parisi
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [C++ 11](https://www.youtube.com/playlist?list=PL0qAPtx8YtJfZpJD7uFxAXglkiHSEhktG) (F. Camuso)
 * [C++ libreria QT - playlist 1](https://www.youtube.com/playlist?list=PL0qAPtx8YtJdH4GVwL_3QeJjPcz3DHE2t) (F. Camuso)

--- a/courses/free-courses-it.md
+++ b/courses/free-courses-it.md
@@ -5,7 +5,7 @@
 * [Architettura degli Elaboratori](#architettura-degli-elaboratori)
 * [Assembly](#assembly)
 * [C](#c)
-* [C Sharp](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Database](#database)
   * [SQL](#sql)
@@ -66,7 +66,7 @@
 * [Linguaggio C - Corso completo](https://www.youtube.com/playlist?list=PL83Ordjpzm5oUl7tFEjc4iirkPBiv7FxR) - Programmazione Time
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Programmazione ad oggetti in C#](https://www.youtube.com/watch?v=aSgikNnGEKM&list=PLktbfd3yXeH8yQpHM3O468k8l-aTC6Hl6) - G. Pellegrini Parisi
 

--- a/courses/free-courses-ko.md
+++ b/courses/free-courses-ko.md
@@ -5,7 +5,7 @@
 * [Arduino](#arduino)
 * [ASP.NET](#asp.net)
 * [C/C++](#c/c++)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [Circuit](#circuit)
 * [Deep Learning](#deep-learning)
 * [Flutter](#flutter)
@@ -80,7 +80,7 @@
 * [C언어 코딩도장](https://dojang.io/course/view.php?id=2)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [예제로 배우는 C# 강좌](https://www.youtube.com/playlist?list=PL4PkN2EXiuVF3Xl0HNVMdY-_kMM3oyBds)
 

--- a/courses/free-courses-pl.md
+++ b/courses/free-courses-pl.md
@@ -41,7 +41,7 @@
 * [Podstawy programowania w języku C#](https://www.youtube.com/playlist?list=PLk5dbESAmUZh1cLITav0ZmDEqRujsPa93)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Kurs C++](https://www.youtube.com/playlist?list=PLE84826ABF088F7E8)
 * [Podejście obiektowe dla znających już podstawy C++ (VIDEO)](https://www.youtube.com/playlist?list=PLOYHgt8dIdozvOVheSRb_qPVU-4ZJA7uB) - Mirosław Zelent, Damian Stelmach

--- a/courses/free-courses-pl.md
+++ b/courses/free-courses-pl.md
@@ -4,7 +4,7 @@
 * [Bash](#bash)
 * [Brainfuck](#brainfuck)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [CSS](#css)
 * [HTML](#html)
@@ -36,7 +36,7 @@
 * [Kurs Programowania w C](https://www.youtube.com/playlist?list=PLgeFsJ0yZyikV_e8YDl5rixXu-H6wFIIZ)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [Podstawy programowania w języku C#](https://www.youtube.com/playlist?list=PLk5dbESAmUZh1cLITav0ZmDEqRujsPa93)
 

--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -2,7 +2,7 @@
 
 * [Android](#android)
 * [C](#c)
-* [C Sharp](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [CSS](#css)
 * [Dart](#dart)
@@ -55,7 +55,7 @@
 * [Programação Moderna em C](https://www.youtube.com/playlist?list=PLIfZMtpPYFP5qaS2RFQxcNVkmJLGQwyKE) - Papo Binário (Youtube)
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [C# e Windows Forms: Consultar CEP no WebService dos Correios](https://www.udemy.com/webservice-correios/) - Gilseone Moraes, Training4All Cursos (Udemy)
 * [C# e Windows Forms: Encurtando URLs com a API do Bitly](https://www.udemy.com/bitly-api/) - Gilseone Moraes, Training4All Cursos (Udemy)

--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -65,7 +65,7 @@
 * [Manipulando Listas Genéricas em C#](https://www.udemy.com/listas-genericas-em-csharp/) - Gilseone Moraes, Training4All Cursos (Udemy)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Curso de C++ - A linguagem de programação fundamental para quem quer ser um programador](https://www.youtube.com/playlist?list=PLx4x_zx8csUjczg1qPHavU1vw1IkBcm40) - Canal Fessor Bruno (CFBCursos)
 

--- a/courses/free-courses-ru.md
+++ b/courses/free-courses-ru.md
@@ -34,7 +34,7 @@ ADV - Продвинутый. Тонкости.
 * [Туториал по SOLID](https://ota-solid.now.sh) - Саша Беспоясов и Артём Самофалов (INT)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Введение в программирование (C++)](https://stepik.org/course/363) - Stepik (BEG)
 * [Основы разработки на С++: белый пояс](https://www.coursera.org/learn/c-plus-plus-white) - Шишков Илья Иванович, Парамонов Евгений Анатольевич, Полднев Антон Вячеславович, Лежанкин Иван Андреевич (Coursera) (INT)
@@ -172,5 +172,3 @@ ADV - Продвинутый. Тонкости.
 * [Введение в Ruby](https://ru.hexlet.io/courses/ruby) - Hexlet (BEG)
 * [Путь Rubyrush](https://rubyrush.ru/steps) (BEG)
 * [Ruby - первое знакомство](https://stepik.org/course/87996) - Stepik (BEG)
-
-

--- a/courses/free-courses-ru.md
+++ b/courses/free-courses-ru.md
@@ -29,7 +29,7 @@ INT - Cредний. Расширенные возможности.
 ADV - Продвинутый. Тонкости.
 
 
-<h3 id="design-architecture">Дизайн и Aрхитектура</h3>
+### <a name="design-architecture"></a>Дизайн и Aрхитектура
 
 * [Туториал по SOLID](https://ota-solid.now.sh) - Саша Беспоясов и Артём Самофалов (INT)
 

--- a/courses/free-courses-th.md
+++ b/courses/free-courses-th.md
@@ -24,7 +24,7 @@
 * [ภาษา C#](http://marcuscode.com/lang/csharp) - MarcusCode
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [ภาษา C++](http://marcuscode.com/lang/cpp) - MarcusCode
 

--- a/courses/free-courses-th.md
+++ b/courses/free-courses-th.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Git](#git)
 * [JavaScript](#javascript)
@@ -19,7 +19,7 @@
 * [ภาษา C](http://marcuscode.com/lang/c) - MarcusCode
 
 
-### C-Sharp
+### <a name="csharp"></a>C\#
 
 * [ภาษา C#](http://marcuscode.com/lang/csharp) - MarcusCode
 

--- a/courses/free-courses-uk.md
+++ b/courses/free-courses-uk.md
@@ -5,7 +5,7 @@
 * [Python](#python)
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [Мова програмування C++](https://stepik.org/course/67114) - Stepik
 

--- a/courses/free-courses-vi.md
+++ b/courses/free-courses-vi.md
@@ -6,7 +6,7 @@
 * [Bash](#bash)
 * [Bootstrap](#bootstrap)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [CSS](#css)
 * [Git](#git)
 * [Go](#go)
@@ -81,7 +81,7 @@
 * [Series Con trỏ trong C](http://diendan.congdongcviet.com/threads/t42977::tim-hieu-ban-chat-cua-con-tro-tu-co-ban-den-nang-cao.cpp) - Cộng đồng C Việt
 
 
-### C-Sharp
+### <a name="csharp"></a>C\#
 
 * [C# Căn Bản](https://www.youtube.com/playlist?list=PL33lvabfss1wUj15ea6W0A-TtDOrWWSRK)
 * [C# Căn Bản](https://www.youtube.com/playlist?list=PLRhlTlpDUWsyOEc-S8ovGVG5L92mZEjVu) - TEDU

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -4,7 +4,7 @@
 * [Artificial Intelligence](#artificial-intelligence)
 * [Bash](#bash)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Clojure](#clojure)
 * [Data Science](#data-science)
@@ -63,7 +63,7 @@
 * [The C Cheat Sheet: An Introduction to Programming in C](https://sites.ualberta.ca/~ygu/courses/geoph624/codes/C.CheatSheet.pdf) - Andrew Sterian (PDF)
 
 
-### <a name="c-sharp"></a>C#
+### <a name="csharp"></a>C\#
 
 * [C# Cheat Sheet](https://simplecheatsheet.com/tag/c-cheat-sheet-1/) - Simple Cheat Sheet (HTML)
 

--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -4,7 +4,7 @@
 * [Android](#android)
 * [Bash](#bash)
 * [C](#c)
-* [C#](#c-sharp)
+* [C#](#csharp)
 * [C++](#cpp)
 * [Clojure](#clojure)
 * [Cloud Computing](#cloud-computing)
@@ -70,7 +70,7 @@
 * [Learn C](http://www.learn-c.org) - Learn-C
 
 
-### C Sharp
+### <a name="csharp"></a>C\#
 
 * [C# Tutorial](https://www.tutlane.com/tutorial/csharp) - tutlane
 * [C# Tutorial](https://www.w3schools.com/cs) - W3Schools

--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -79,7 +79,7 @@
 * [Learn C#](https://www.codecademy.com/learn/learn-c-sharp) - Codecademy
 
 
-<h3 id="cpp">C++</h3>
+### <a name="cpp"></a>C++
 
 * [C++ Tutorial](https://www.w3schools.com/cpp) - W3Schools
 * [CppKoans](https://github.com/torbjoernk/CppKoans)

--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -61,7 +61,7 @@
 * [SoloLearn](https://code.sololearn.com/c)
 
 
-### <a name="csharp"></a>C#
+### <a name="csharp"></a>C\#
 
 * [SoloLearn](https://code.sololearn.com/csharp)
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

- Fixes #6688 

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Put lists in alphabetical order, correct spacing.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
