### PR TITLE
config: update `.editorconfig` parameters according to current format of files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,7 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
 # editorconfig.org
+
 root = true
 
 [*]

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ trim_trailing_whitespace = false
 
 [*.{yaml,yml}]
 indent_size = 2
+
+[*.{json,jsonc}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,9 @@ end_of_line = crlf
 [*.{json,jsonc}]
 indent_size = 2
 
+[Makefile]
+indent_style = tab
+
 [*.{md,mkd,mkdn,mdwn,mdown,markdown}]
 trim_trailing_whitespace = false
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,15 +13,15 @@ trim_trailing_whitespace = true
 indent_size = 4
 end_of_line = crlf
 
-[*.{md,mkd,mkdn,mdwn,mdown,markdown}]
-trim_trailing_whitespace = false
-
-[*.{yaml,yml}]
-indent_size = 2
-
 [*.{json,jsonc}]
 indent_size = 2
+
+[*.{md,mkd,mkdn,mdwn,mdown,markdown}]
+trim_trailing_whitespace = false
 
 [*.py]
 indent_size = 4
 indent_style = space
+
+[*.{yaml,yml}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,8 +2,10 @@
 # coding styles between different editors and IDEs
 # editorconfig.org
 
+; top-most EditorConfig file
 root = true
 
+; define basic and global for any file
 [*]
 charset = utf-8
 end_of_line = lf
@@ -12,16 +14,20 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+; DOS scripts - force CRLF eof
 [*.{bat,cmd}]
 indent_size = 4
 end_of_line = crlf
 
+; JSON files - compress a little more
 [*.{json,jsonc}]
 indent_size = 2
 
+; Make tasks - match defaults according it own syntax
 [Makefile]
 indent_style = tab
 
+; Markdown files - preserve whitespaces
 [*.{md,mkd,mkdn,mdwn,mdown,markdown}]
 trim_trailing_whitespace = false
 
@@ -30,9 +36,11 @@ trim_trailing_whitespace = false
 indent_size = 4
 charset = utf-8-bom
 
+; Python sources - match defaults according it own syntax
 [*.py]
 indent_size = 4
 indent_style = space
 
+; YML config files - match defaults according it own syntax
 [*.{yaml,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,10 +19,9 @@ spaces_around_operators = true
 
 ; DOS/Windows batch scripts - 
 [*.{bat,cmd}]
-indent_size = 4
 end_of_line = crlf
 
-; JavaScript/TypeScript files - 
+; JavaScript files - 
 [*.{js,ts}]
 curly_bracket_next_line = true
 quote_type = single
@@ -44,16 +43,6 @@ trim_trailing_whitespace = false
 [*.{ps1,psd1,psm1}]
 charset = utf-8-bom
 end_of_line = crlf
-indent_size = 4
-
-; Python sources - match it own default syntax
-[*.py]
-indent_size = 4
-indent_style = space
-
-; Tab separated values - preserve separator 
-[*.tsv]
-indent_style = tab
 
 ; YML config files - match it own default syntax
 [*.{yaml,yml}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_size = 2
 
 [*.{json,jsonc}]
 indent_size = 2
+
+[*.py]
+indent_size = 4
+indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{markdown,md}]
+[*.{md,mkd,mkdn,mdwn,mdown,markdown}]
 trim_trailing_whitespace = false
 
 [*.{yaml,yml}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
+max_line_length = off
 trim_trailing_whitespace = true
 
 ; DOS scripts - force CRLF eof

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,10 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.{bat,cmd}]
+indent_size = 4
+end_of_line = crlf
+
 [*.{md,mkd,mkdn,mdwn,mdown,markdown}]
 trim_trailing_whitespace = false
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -25,6 +25,11 @@ indent_style = tab
 [*.{md,mkd,mkdn,mdwn,mdown,markdown}]
 trim_trailing_whitespace = false
 
+; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+charset = utf-8-bom
+
 [*.py]
 indent_size = 4
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,34 +14,47 @@ indent_style = space
 insert_final_newline = true
 max_line_length = off
 trim_trailing_whitespace = true
+curly_bracket_next_line = false
+spaces_around_operators = true
 
-; DOS scripts - force CRLF eof
+; DOS/Windows batch scripts - 
 [*.{bat,cmd}]
 indent_size = 4
 end_of_line = crlf
 
-; JSON files - compress a little more
+; JavaScript/TypeScript files - 
+[*.{js,ts}]
+curly_bracket_next_line = true
+quote_type = single
+
+; JSON files (normal and commented version) - 
 [*.{json,jsonc}]
 indent_size = 2
+quote_type = double
 
-; Make tasks - match defaults according it own syntax
+; Make - match it own default syntax
 [Makefile]
 indent_style = tab
 
-; Markdown files - preserve whitespaces
-[*.{md,mkd,mkdn,mdwn,mdown,markdown}]
+; Markdown files - preserve trail spaces that means break line
+[*.{md,markdown}]
 trim_trailing_whitespace = false
 
 ; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
 [*.{ps1,psd1,psm1}]
-indent_size = 4
 charset = utf-8-bom
+end_of_line = crlf
+indent_size = 4
 
-; Python sources - match defaults according it own syntax
+; Python sources - match it own default syntax
 [*.py]
 indent_size = 4
 indent_style = space
 
-; YML config files - match defaults according it own syntax
+; Tab separated values - preserve separator 
+[*.tsv]
+indent_style = tab
+
+; YML config files - match it own default syntax
 [*.{yaml,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.md]
+[*.{markdown,md}]
 trim_trailing_whitespace = false
+
+[*.{yaml,yml}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,12 +2,12 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 4
-end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
+end_of_line = lf
+indent_size = 4
+indent_style = space
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.{md,mkd,mkdn,mdwn,mdown,markdown}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Update `.editorconfig` parameters according to values provided by @SethFalco in #5564 (commit e9f7dff3be87e640a72f97bd4eec1be79ec2b43a) and extend it.

- 2 spaces indent for `yaml` or `yml` files
- 2 spaces indent for `json` & `jsonc` (commented) files
- avoid strip trailing spaces in [any kind of markdown files](https://superuser.com/questions/249436/file-extension-for-markdown-files)

Moreabout editorconfig syntax at: https://editorconfig.org/

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
