### PR TITLE
Add Easy Rust in Rust section.

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2150,6 +2150,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 * [A Gentle Introduction To Rust](https://stevedonovan.github.io/rust-gentle-intro) - Steve J Donovan
 * [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book)
+* [Easy Rust](https://dhghomon.github.io/easy_rust/)
 * [Guide to Rustc Development](https://rustc-dev-guide.rust-lang.org)
 * [Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial.github.io/too-many-lists) - Alexis Beingessner
 * [Rust by Example](https://doc.rust-lang.org/stable/rust-by-example)


### PR DESCRIPTION
## What does this PR do?
Add Easy Rust tutorial in Rust section.

## For resources

### Description
Easy Rust is Rust tutorial in easy English especially aimed at non-native English speakers.

### Why is this valuable (or not)?
Rust has a very high learning curve and this tutorial simplifies it by explaining concepts in simple language.

### How do we know it's really free?
It's free and open-sourced on Github.

### For book lists, is it a book? For course lists, is it a course? etc.
It's a github.io site based on Easy Rust Github repo. 

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
