### PR TITLE
Add Japanese books (Networking, TypeScript)

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -182,6 +182,7 @@
 * [HTTP/3 explained](https://http3-explained.haxx.se/ja) - Daniel Stenberg
 * [http2 explained](https://http2-explained.haxx.se/ja) - Daniel Stenberg
 * [ネットワークプログラミングの基礎知識](http://x68000.q-e-d.net/~68user/net) - 68user
+* [プロフェッショナルIPv6 第2版](https://dforest.watch.impress.co.jp/library/p/proipv6/11948/ao-ipv6-2-book-20211220.pdf) - 小川晃通 (PDF)
 
 
 #### 機械学習

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -702,6 +702,7 @@
 
 * [TypeScript Deep Dive 日本語版](https://typescript-jp.gitbook.io/deep-dive/) - basarat, yohamta(翻訳)
 * [TypeScriptの為のクリーンコード](https://msakamaki.github.io/clean-code-typescript) - labs42io, 酒巻 瑞穂(翻訳)
+* [サバイバルTypeScript](https://typescriptbook.jp) - YYTypeScript
 * [仕事ですぐに使えるTypeScript](https://future-architect.github.io/typescript-guide) - フューチャー株式会社（Future Corporation） ([PDF](https://future-architect.github.io/typescript-guide/typescript-guide.pdf))
 
 


### PR DESCRIPTION
## What does this PR do?
Add resources

## For resources
### Description
Add links to Networking and TypeScript books.

### Why is this valuable (or not)?
* **プロフェッショナルIPv6 第2版**
This is a book about the whole IPv6 protocol.
This book is also highly reliable as it is sponsored by several companies.

* **サバイバルTypeScript**
This book is an introduction to TypeScript, intended for use at work.

### How do we know it's really free?
* **プロフェッショナルIPv6 第2版**
This book is published under the Creative Commons License BY-NC-SA 4.0.

* **サバイバルTypeScript**
This book is being created as an open source project.

### For book lists, is it a book? For course lists, is it a course? etc.
Yes, these are all books.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
