### PR TITLE
fix: use new Google CodeJam practice archive website

### DIFF
--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -100,7 +100,7 @@
 * [Edabit](https://edabit.com)
 * [Exercism](http://exercism.io)
 * [Geeks For Geeks](https://practice.geeksforgeeks.org)
-* [Google Code Jam - Practise](https://code.google.com/codejam/contests.html)
+* [Google Code Jam - Practise](https://codingcompetitions.withgoogle.com/codejam/archive)
 * [Hacker.org](http://www.hacker.org)
 * [HackerEarth](https://www.hackerearth.com)
 * [HDU Online Judge](http://acm.hdu.edu.cn)


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

### Why is this valuable (or not)?

Solves urlchecker fault about this resource first time added at #1197. Related with #5470

  https://github.com/EbookFoundation/free-programming-books/runs/3835571930?check_suite_focus=true#step:6:102
  ```http
  Issues :-(
  > Links 
  5. [L098] 404 https://code.google.com/codejam/contests.html  
  ```   

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
