### PR TITLE
fix: archive past KDD cups and update main resource link to current year

### DIFF
--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -68,7 +68,10 @@
 * [CrowdANALYTIX](https://www.crowdanalytix.com/community)
 * [DrivenData](https://www.drivendata.org)
 * [Kaggle](https://www.kaggle.com)
-* [KDD Cup](https://www.kdd.org/kdd2019/kdd-cup)
+* [KDD Cup 2022](https://kdd.org/kdd2022/) - Aidong Zhang, Huzefa Rangwala, et al.
+    * [KDD Cup 2019](https://web.archive.org/web/20210118021527/https://www.kdd.org/kdd2019/kdd-cup) - Vipin Kumar, Ankur Teredesai, et al. *(:card_file_box: archived)*
+    * [KDD Cup 2020](https://web.archive.org/web/20210617000028/https://www.kdd.org/kdd2020/kdd-cup) - Jie Tang, Jieping Ye, Claudia Perlich, Iryna Skrypnyk, et al. *(:card_file_box: archived)*
+    * [KDD Cup 2021](https://kdd.org/kdd2021) - Feida Zhu, Beng Chin Ooi, Chunyan Miao, et al.
 
 
 ### Information security

--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -68,10 +68,6 @@
 * [CrowdANALYTIX](https://www.crowdanalytix.com/community)
 * [DrivenData](https://www.drivendata.org)
 * [Kaggle](https://www.kaggle.com)
-* [KDD Cup 2022](https://kdd.org/kdd2022/) - Aidong Zhang, Huzefa Rangwala, et al.
-    * [KDD Cup 2019](https://web.archive.org/web/20210118021527/https://www.kdd.org/kdd2019/kdd-cup) - Vipin Kumar, Ankur Teredesai, et al. *(:card_file_box: archived)*
-    * [KDD Cup 2020](https://web.archive.org/web/20210617000028/https://www.kdd.org/kdd2020/kdd-cup) - Jie Tang, Jieping Ye, Claudia Perlich, Iryna Skrypnyk, et al. *(:card_file_box: archived)*
-    * [KDD Cup 2021](https://kdd.org/kdd2021) - Feida Zhu, Beng Chin Ooi, Chunyan Miao, et al.
 
 
 ### Information security


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

### Why is this valuable (or not)?

Solves urlchecker fault about this resource first time added at #4346. Related with #5470

  https://github.com/EbookFoundation/free-programming-books/runs/3835571930?check_suite_focus=true#step:6:102
  ```http
  Issues :-(
  > Links 
  3. [L069] 404 https://www.kdd.org/kdd2019/kdd-cup  
  ```   

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
