### PR TITLE
fix: ensure crosslinks format

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -837,6 +837,7 @@
 #### Angular
 
 > :information_source: See also &#8230; [AngularJS](#angularjs)
+
 * [Angular 12 Course](https://www.youtube.com/playlist?list=PLjsBk8SIQEi-RqkglLcn19TaeeopcuDXV) - Slobodan Gajic
 * [Angular 6 Tutorials](https://www.youtube.com/playlist?list=PLYxzS__5yYQlqCmHqDyW3yo5V79C7eaTe) - codedamn (YouTube)
 * [Angular Courses](https://www.youtube.com/playlist?list=PLTjRvDozrdlxAhsPP4ZYtt3G8KbJ449oT) - Programming with Mosh (YouTube)


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

In #6017 several resources was added, removing with one of them a blank line part of the Angular crosslink note 

### Why is this valuable (or not)?

This PR ensures the syntax format accorded in #5535 restoring it

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Put lists in alphabetical order, correct spacing.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
