### PR TITLE
Add Japanese books (Scratch, C++)

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -660,6 +660,7 @@
 
 ### Scratch
 
+* [Scratch for CS First でプログラミングをはじめよう](https://csfirst.withgoogle.com/c/cs-first/ja/welcome-to-cs-first/overview.html) - Grow with Google プログラム
 * [炎の型 With Scratch (ゲームプログラム入門)](https://kyorohiro.gitbooks.io/doc_scratch) - kyorohiro
 
 

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -276,6 +276,7 @@
 
 * [C++11の文法と機能(C++11: Syntax and Feature)](https://ezoeryou.github.io/cpp-book/C++11-Syntax-and-Feature.xhtml) - 江添亮
 * [C++入門](https://www.asahi-net.or.jp/~yf8k-kbys/newcpp0.html) - 小林健一郎
+* [C++入門 AtCoder Programming Guide for beginners (APG4b)](https://atcoder.jp/contests/APG4b) - 齋藤主裕, 石黒淳
 * [cpprefjp - C++ Reference Site in Japanese](https://cpprefjp.github.io)
 * [Google C++ スタイルガイド 日本語全訳](https://ttsuki.github.io/styleguide/cppguide.ja.html) - Benjy Weinberger, Craig Silverstein, Gregory Eitzmann, Mark Mentovai, Tashana Landray, ttsuki(翻訳)
 * [Standard Template Library プログラミング](https://web.archive.org/web/20170607163002/http://episteme.wankuma.com/stlprog) - επιστημη


### PR DESCRIPTION
## What does this PR do?
Add resources

## For resources
### Description
Add links to Scratch and C++ books.

### Why is this valuable (or not)?
* **Scratch for CS First でプログラミングをはじめよう**
This programming material is published by Google.

* **C++入門 AtCoder Programming Guide for beginners (APG4b)**
It is published by AtCoder, a company that operates programming contest site.
Learn the fundamentals of general-purpose programming.

### How do we know it's really free?
* **Scratch for CS First でプログラミングをはじめよう**
This website is published under the Creative Commons License BY-SA 4.0.

* **C++入門 AtCoder Programming Guide for beginners (APG4b)**
It is offered free of charge by AtCoder as an introduction to competitive programming.

### For book lists, is it a book? For course lists, is it a course? etc.
Yes, these are all books.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
