### PR TITLE
Adding French book Maitriser Bitcoin

### DIFF
--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -104,19 +104,19 @@
 * [La programmation Shell](https://frederic-lang.developpez.com/tutoriels/linux/prog-shell/) - Frederic Lang, Idriss Neumann
 
 
-### Caml / OCaml
-
-* [Développement d'applications avec Objective Caml](https://www-apr.lip6.fr/~chaillou/Public/DA-OCAML) - Emmanuel Chailloux, Pascal Manoury, Bruno Pagano
-* [Le langage Caml](https://caml.inria.fr/pub/distrib/books/llc.pdf) - Pierre Weis, Xavier Leroy (PDF)
-* [Programmation du système Unix en Objective Caml](https://web.archive.org/web/20211115022546/http://gallium.inria.fr/~remy/camlunix/) - Xavier Leroy, Didier Rémy
-
-
 ### C / C++
 
 * [Cours de C/C++](http://casteyde.christian.free.fr/cpp/cours/online/book1.html) - Christian Casteyde
 * [Guide pour la programmation réseaux de Beej's - Utilisation des sockets Internet](http://vidalc.chez.com/lf/socket.html) - Brian "Beej Jorgensen" Hall (HTML)
 * [Le C en 20 heures](http://framabook.org/le-c-en-20-heures-2/) - Eric Berthomier et Daniel Schang
 * [Programmation en Langage C et Systèmes Informatiques](https://sites.uclouvain.be/SystInfo/notes/Theorie/) - O. Bonaventure, E. Riviere, G. Detal, C. Paasch
+
+
+### Caml / OCaml
+
+* [Développement d'applications avec Objective Caml](https://www-apr.lip6.fr/~chaillou/Public/DA-OCAML) - Emmanuel Chailloux, Pascal Manoury, Bruno Pagano
+* [Le langage Caml](https://caml.inria.fr/pub/distrib/books/llc.pdf) - Pierre Weis, Xavier Leroy (PDF)
+* [Programmation du système Unix en Objective Caml](https://web.archive.org/web/20211115022546/http://gallium.inria.fr/~remy/camlunix/) - Xavier Leroy, Didier Rémy
 
 
 ### Coq

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -12,6 +12,7 @@
 * [Bash / Shell](#bash--shell)
 * [C / C++](#c--c)
 * [Caml / OCaml](#caml--ocaml)
+* [Chaîne de blocs / Blockchain](#chaîne-de-blocs--blockchain)
 * [Coq](#coq)
 * [CSS](#css)
 * [Fortran](#fortran)
@@ -117,6 +118,11 @@
 * [Développement d'applications avec Objective Caml](https://www-apr.lip6.fr/~chaillou/Public/DA-OCAML) - Emmanuel Chailloux, Pascal Manoury, Bruno Pagano
 * [Le langage Caml](https://caml.inria.fr/pub/distrib/books/llc.pdf) - Pierre Weis, Xavier Leroy (PDF)
 * [Programmation du système Unix en Objective Caml](https://web.archive.org/web/20211115022546/http://gallium.inria.fr/~remy/camlunix/) - Xavier Leroy, Didier Rémy
+
+
+### Chaîne de blocs / Blockchain
+
+* [Maîtriser Bitcoin: Programmer la chaîne de blocs publique](https://maitriser-ca.github.io/LivreMaitriserBitcoin/) - Andreas M. Antonopoulos, Serafim Dos Santos (asciidoc, html)
 
 
 ### Coq


### PR DESCRIPTION
## What does this PR do?
Add resource & Improve repo

* Add French book _Maitriser Bitcoin_ by Andreas M. Antonopoulos and translated by Serafim Dos Santos (me)
* C / C++ section was mistakenly misplaced (was after "Caml / OCaml" section, but comes alphabetically before)

## For resources
### Description
The French book _Maîtriser Bitcoin: Programmer la chaîne de blocs publique_ is the translation of the English book _Mastering Bitcoin: Programming the open blockchain_ by Andreas M. Antonopoulos and translated in French (Canada) by Serafim Dos Santos (me).

### Why is this valuable (or not)?
_Mastering Bitcoin_ and its French version _Maîtriser Bitcoin_ is a book for developers, although the first two chapters cover bitcoin at a level that is also approachable to non-programmers. Anyone with a basic understanding of technology can read the first two chapters to get a great understanding of bitcoin.

### How do we know it's really free?
The original English book _Mastering Bitcoin_ is available as an Open Edition translatable by anyone (see [github.com/bitcoinbook/bitcoinbook](https://github.com/bitcoinbook/bitcoinbook) ). The French version of the book is available for free on one of my organizations (see [maitriser-ca.github.io/LivreMaitriserBitcoin/](https://maitriser-ca.github.io/LivreMaitriserBitcoin/) )

### For book lists, is it a book? For course lists, is it a course? etc.
It's a book available in asciidoc and HTML for online reading or PDF generation.


## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)