### PR TITLE
Add 'Learn you some Erlang for great good!' translation

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -333,6 +333,7 @@
 
 ### Erlang
 
+* [Learn you some Erlang for great good!](https://www.ymotongpoo.com/works/lyse-ja/) - Fred Hebert, Yoshifumi Yamaguchi (HTML)
 * [お気楽 Erlang プログラミング入門](http://www.nct9.ne.jp/m_hiroi/func/erlang.html) - 広井誠
 
 

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -702,7 +702,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Erlang Handbook](https://github.com/esl/erlang-handbook/raw/master/output/ErlangHandbook.pdf) (PDF)
 * [Erlang Programming](https://en.wikibooks.org/wiki/Erlang_Programming) - Wikibooks (HTML)
 * [Getting Started with Erlang User's Guide](http://www.erlang.org/doc/getting_started/users_guide.html) (HTML)
-* [Learn You Some Erlang For Great Good](http://learnyousomeerlang.com) - Frederic Trottier-Hebert
+* [Learn You Some Erlang For Great Good](http://learnyousomeerlang.com) - Fred Hebert
 * [Making reliable distributed systems in the presence of software errors](http://www.erlang.org/download/armstrong_thesis_2003.pdf) - Joe Armstrong (PDF)
 * [Stuff Goes Bad: Erlang in Anger](https://www.erlang-in-anger.com) - Fred Herbert (PDF)
 * [The BEAM Book](https://blog.stenmans.org/theBeamBook) (HTML)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -702,7 +702,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Erlang Handbook](https://github.com/esl/erlang-handbook/raw/master/output/ErlangHandbook.pdf) (PDF)
 * [Erlang Programming](https://en.wikibooks.org/wiki/Erlang_Programming) - Wikibooks (HTML)
 * [Getting Started with Erlang User's Guide](http://www.erlang.org/doc/getting_started/users_guide.html) (HTML)
-* [Learn You Some Erlang For Great Good](http://learnyousomeerlang.com) - Fred Hebert
+* [Learn You Some Erlang For Great Good](http://learnyousomeerlang.com) - Fred Hebert (HTML)
 * [Making reliable distributed systems in the presence of software errors](http://www.erlang.org/download/armstrong_thesis_2003.pdf) - Joe Armstrong (PDF)
 * [Stuff Goes Bad: Erlang in Anger](https://www.erlang-in-anger.com) - Fred Herbert (PDF)
 * [The BEAM Book](https://blog.stenmans.org/theBeamBook) (HTML)


### PR DESCRIPTION
## What does this PR do?
Adds a Japanese-language translation of ['Learn You Some Erlang for Great Good'](https://learnyousomeerlang.com/).

As far as I could tell from a few web searches, this is currently the only complete translation of the book into another language; there are some works-in-progress into:

- Korean: https://github.com/chitacan?tab=repositories&q=lyse
- Chinese: https://github.com/Xorcerer/Learn-You-Some-Erlang-zh_CN/

## For resources
### Description
The book is a free online guide to the Erlang programming language.

### Why is this valuable (or not)?
This complements the [existing entry for the book in English](https://github.com/EbookFoundation/free-programming-books/blob/e5f42084f6ae325071298246f5b9958bf7eb90a7/books/free-programming-books-langs.md?plain=1#L705).

### How do we know it's really free?
The book translation is in HTML format and includes content licensing information.  It is licensed under the [Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported (CC BY-NC-ND 3.0) license](https://creativecommons.org/licenses/by-nc-nd/3.0/).

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- [x] Check the status of GitHub Actions and resolve any reported warnings!