### PR TITLE
docs(contributing): Add playground definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Free Podcasts and Screencasts:
 
 ### Programming Playgrounds
 
+Whether you're a beginner programmer or an expert developer, code/programming playgrounds are useful when sharing and learning with others. A programming playground is an online service where you can write, compile(or run), and share code with others. They also allows you to fork and get your hands dirty by playing around with other's code.
+
 + [Chinese / 中文](more/free-programming-playgrounds-zh.md)
 + [English](more/free-programming-playgrounds.md)
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,6 @@ Free Podcasts and Screencasts:
 
 ### Programming Playgrounds
 
-Whether you're a beginner programmer or an expert developer, code/programming playgrounds are useful when sharing and learning with others. A programming playground is an online service where you can write, compile(or run), and share code with others. They also allows you to fork and get your hands dirty by playing around with other's code.
-
 + [Chinese / 中文](more/free-programming-playgrounds-zh.md)
 + [English](more/free-programming-playgrounds.md)
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,11 +18,12 @@ By contributing you agree to respect the [Code of Conduct](CODE_OF_CONDUCT.md) o
 2. You don't have to know Git: if you found something of interest which is *not already in this repo*, please open an [Issue](https://github.com/EbookFoundation/free-programming-books/issues) with your links propositions.
     - If you know Git, please Fork the repo and send Pull Requests (PR).
 
-3. We have 5 kinds of lists. Choose the right one:
+3. We have 6 kinds of lists. Choose the right one:
 
     - *Books* : PDF, HTML, ePub, a gitbook.io based site, a Git repo, etc.
     - *Courses* : A course is a learning material which is not a book. [This is a course](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-006-introduction-to-algorithms-fall-2011/).
     - *Interactive Tutorials* : An interactive website which lets the user type code or commands and evaluates the result (by "evaluate" we don't mean "grade"). e.g.: [Try Haskell](http://tryhaskell.org), [Try GitHub](http://try.github.io).
+    - *Playgrounds* : are online and interactive websites, games or desktop software useful to learn playing. Therefore, you can write, compile (or run), and share this code snippets with others. They also usually allows you to fork and get your hands dirty by playing around with other's code.
     - *Podcasts and Screencasts* : Podcasts and screencasts.
     - *Problem Sets & Competitive Programming* : A website or software which lets you assess your programming skills by solving simple or complex problems, with or without code review, with or without comparing the results with other users.
 


### PR DESCRIPTION
## What does this PR do?
Add info | Improve repo

## For resources
### Description

Adds in a nutshell section the defition of `playground` category with an adapted text from the original idea made by Summan Roy in #6817 

### Why is this valuable (or not)?

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [ ] Search for duplicates. #6817

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
Added a small definition about programming/coding playgrounds for making it understandable to beginners