### PR TITLE
chore(readme): Apply markdownlint fix for `MD004/ul-style` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ Free Podcasts and Screencasts:
 
 Volunteers have translated many of our Contributing, How-to, and Code of Conduct documents into languages covered by our lists.
 
-- English
-  - [Code of Conduct](docs/CODE_OF_CONDUCT.md)
-  - [Contributing](docs/CONTRIBUTING.md)
-  - [How-to](docs/HOWTO.md)
-- ... *[More languages](docs/README.md#translations)* ...
++ English
+  + [Code of Conduct](docs/CODE_OF_CONDUCT.md)
+  + [Contributing](docs/CONTRIBUTING.md)
+  + [How-to](docs/HOWTO.md)
++ ... *[More languages](docs/README.md#translations)* ...
 
 You might notice that there are [some missing translations here](docs/README.md#translations) - perhaps you would like to help out by [contributing a translation](docs/CONTRIBUTING.md#help-out-by-contributing-a-translation)?
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Apply markdownlint fix for `MD004/ul-style` consistent rule (https://github.com/markdownlint/markdownlint/blob/HEAD/docs/RULES.md#md004---unordered-list-style)

> Unordered list style [Expected: plus; Actual: dash]

Small bug introduced by #6700

### Why is this valuable (or not)?

Keep markdown syntax homogenized acording to markdownlint rules

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Put lists in alphabetical order, correct spacing.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
