### PR TITLE
Add vlang documentation

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2447,7 +2447,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 ### V
 
-* [V Documentation](https://github.com/vlang/v/blob/HEAD/doc/docs.md) - Alex Medveniko, vlang.io, et al. (Markdown)
+* [V Documentation](https://github.com/vlang/v/blob/HEAD/doc/docs.md) - vlang.io (Markdown)
 
 
 ### Verilog

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -214,6 +214,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
   * [Angular](#angular)
   * [Deno](#deno)
 * [Unix](#unix)
+* [V](#v)
 * [Verilog](#verilog)
 * [VHDL](#vhdl)
 * [Vim](#vim)
@@ -2442,6 +2443,10 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Unix for Poets](http://web.stanford.edu/class/cs124/kwc-unix-for-poets.pdf) - Kenneth Ward Church (PDF)
 * [Unix Toolbox](https://web.archive.org/web/20210912091852/https://cb.vu/unixtoolbox.xhtml) - Colin Barschel *(:card_file_box: archived)*
 * [UNIX Tutorial for Beginners](http://www.ee.surrey.ac.uk/Teaching/Unix/)
+
+
+### V
+* [V Documentation](https://github.com/vlang/v/blob/master/doc/docs.md) (Markdown)
 
 
 ### Verilog

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2447,7 +2447,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 ### V
 
-* [V Documentation](https://github.com/vlang/v/blob/master/doc/docs.md) (Markdown)
+* [V Documentation](https://github.com/vlang/v/blob/HEAD/doc/docs.md) - Alex Medveniko, vlang.io, et al. (Markdown)
 
 
 ### Verilog

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2446,6 +2446,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 
 ### V
+
 * [V Documentation](https://github.com/vlang/v/blob/master/doc/docs.md) (Markdown)
 
 


### PR DESCRIPTION
## What does this PR do?
It adds the official vlang documentation. I am unsure if the markdown file format needs to be specified, so I just added it for now

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)
