### PR TITLE
Update free-programming-books-subjects.md

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -231,7 +231,7 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [Docker Jumpstart](http://odewahn.github.io/docker-jumpstart/) - Andrew Odewahn
 * [Docker Tutorial](https://www.tutorialspoint.com/docker/) - Tutorials Point (HTML, PDF)
 * [Kubernetes Deployment & Security Patterns](https://resources.linuxfoundation.org/LF+Projects/CNCF/TheNewStack_Book2_KubernetesDeploymentAndSecurityPatterns.pdf) - Alex Williams (PDF)
-* [Kubernetes for Full-Stack Developers](https://www.digitalocean.com/community/curriculums/kubernetes-for-full-stack-developers) - Jamon Camisso, Hanif Jetha, Katherine Juell (PDF, EPUB)
+* [Kubernetes for Full-Stack Developers](https://www.digitalocean.com/community/books/digitalocean-ebook-kubernetes-for-full-stack-developers) - Jamon Camisso, Hanif Jetha, Katherine Juell (PDF, EPUB)
 * [Uncomplicating Kubernetes](https://livro.descomplicandokubernetes.com.br/en/) - Jeferson Fernando
 
 


### PR DESCRIPTION
## What does this PR do?

It's changing the URL of **Kubernetes for Full-Stack Developers** to the new URL.

### Before

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/7970174/165600076-e142712b-bd73-4283-8c86-9d42089eca9c.png">

### Current change

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/7970174/165600121-02dc3d98-8399-4fb9-85c2-614193e7054f.png">

_As you can see, right at the bottom it shows this cute box_

<img width="617" alt="image" src="https://user-images.githubusercontent.com/7970174/165600189-49aafb1f-7c34-470b-a939-907398c87cf7.png">


## For resources
### Description

### Why is this valuable (or not)?

N/A

### How do we know it's really free?

N/A

### For book lists, is it a book? For course lists, is it a course? etc.

N/A

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [X] Search for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
