### PR TITLE
Add "Tcl for Web Nerds"

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2381,6 +2381,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 ### Tcl
 
+* [Tcl for Web Nerds](https://philip.greenspun.com/tcl/) - Hal Abelson, Philip Greenspun, and Lydia Sandon (HTML)
 * [Tcl Programming](https://en.wikibooks.org/wiki/Programming%3ATcl) - Richard.Suchenwirth, et. al.
 
 


### PR DESCRIPTION
## What does this PR do?
Add book.

## For resources
### Description
Add book: [Tcl for Web Nerds](https://philip.greenspun.com/tcl/) by Hal Abelson, Philip Greenspun, and Lydia Sandon.

### Why is this valuable (or not)?
Relatively short introduction to Tcl.

### How do we know it's really free?
This is an online book first published in 2002.

### For book lists, is it a book? For course lists, is it a course? etc.
This is a book.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)
