### PR TITLE
Add grain docs

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -66,6 +66,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [FreeBSD](#freebsd)
 * [Git](#git)
 * [Go](#go)
+* [Grain](#grain)
 * [GraphQL](#graphql)
 * [Groovy](#groovy)
   * [Gradle](#gradle)
@@ -844,6 +845,11 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [The Go Tutorial](http://tour.golang.org)
 * [The Little Go Book](https://github.com/karlseguin/the-little-go-book) - Karl Seguin ([PDF](https://www.openmymind.net/assets/go/go.pdf), [ePUB](https://www.openmymind.net/assets/go/go.epub))
 * [Web apps in Go, the anti textbook](https://github.com/thewhitetulip/web-dev-golang-anti-textbook/)
+
+
+## Grain
+
+* [The Grain Docs](https://grain-lang.org/docs/)
 
 
 ### GraphQL

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -66,7 +66,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [FreeBSD](#freebsd)
 * [Git](#git)
 * [Go](#go)
-* [Grain](#grain)
 * [GraphQL](#graphql)
 * [Groovy](#groovy)
   * [Gradle](#gradle)
@@ -340,6 +339,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [x86 Assembly](https://en.wikibooks.org/wiki/X86_Assembly) - Wikibooks
 * [x86 Disassembly](https://en.wikibooks.org/wiki/X86_Disassembly) - Wikibooks
 * [Zen of Assembly Language: Volume I, Knowledge (1990)](http://www.jagregory.com/abrash-zen-of-asm/) - Michael Abrash
+* [The Grain Docs](https://grain-lang.org/docs/)
 
 
 #### Non-X86
@@ -845,11 +845,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [The Go Tutorial](http://tour.golang.org)
 * [The Little Go Book](https://github.com/karlseguin/the-little-go-book) - Karl Seguin ([PDF](https://www.openmymind.net/assets/go/go.pdf), [ePUB](https://www.openmymind.net/assets/go/go.epub))
 * [Web apps in Go, the anti textbook](https://github.com/thewhitetulip/web-dev-golang-anti-textbook/)
-
-
-## Grain
-
-* [The Grain Docs](https://grain-lang.org/docs/)
 
 
 ### GraphQL

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -327,13 +327,13 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [ARM Assembly Language Programming](http://www.rigwit.co.uk/ARMBook/ARMBook.pdf) - Peter Knaggs (PDF) (:construction: *in process*)
 * [Assemblers And Loaders (1993)](http://www.davidsalomon.name/assem.advertis/asl.pdf) - David Salomon (PDF)
 * [Assembly Language Succinctly](https://www.syncfusion.com/succinctly-free-ebooks/assemblylanguage) - Christopher Rose, Syncfusion Inc. (HTML, PDF, EPUB, Kindle)
-* [The Grain Docs](https://grain-lang.org/docs/)
 * [PC Assembly Language](http://pacman128.github.io/pcasm/) - P. A. Carter
 * [Programming from the Ground Up](https://download-mirror.savannah.gnu.org/releases/pgubook/ProgrammingGroundUp-1-0-booksize.pdf) - Jonathan Bartlett (PDF)
 * [Ralf Brown's Interrupt List](http://www.ctyme.com/rbrown.htm)
 * [Run Down On x86 Intel Assembly Course](https://github.com/Ret2LC/x86-assembly) - Ret2LC
 * [Software optimization resources](http://www.agner.org/optimize/) - A. Fog
 * [The Art of Assembly Language (2003)](https://web.archive.org/web/20120525102637/http://maven.smith.edu/~thiebaut/ArtOfAssembly/artofasm.html) - Randall Hyde (PDF)
+* [The Grain Docs](https://grain-lang.org/docs/)
 * [WebAssembly friendly programming with C/C++](https://github.com/3dgen/cppwasm-book/tree/master/en) - Ending, Chai Shushan, Yushih (HTML, [:package: examples](https://github.com/3dgen/cppwasm-book/tree/master/examples))
 * [Wizard Code, A View on Low-Level Programming](https://web.archive.org/web/20170712195930/http://vendu.twodots.nl/files/wizardcode4.pdf) - Tuomo Tuomo Venäläinen (PDF)
 * [x86-64 Assembly Language Programming with Ubuntu](http://www.egr.unlv.edu/~ed/x86.html) - Ed Jorgensen (PDF)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -327,6 +327,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [ARM Assembly Language Programming](http://www.rigwit.co.uk/ARMBook/ARMBook.pdf) - Peter Knaggs (PDF) (:construction: *in process*)
 * [Assemblers And Loaders (1993)](http://www.davidsalomon.name/assem.advertis/asl.pdf) - David Salomon (PDF)
 * [Assembly Language Succinctly](https://www.syncfusion.com/succinctly-free-ebooks/assemblylanguage) - Christopher Rose, Syncfusion Inc. (HTML, PDF, EPUB, Kindle)
+* [The Grain Docs](https://grain-lang.org/docs/)
 * [PC Assembly Language](http://pacman128.github.io/pcasm/) - P. A. Carter
 * [Programming from the Ground Up](https://download-mirror.savannah.gnu.org/releases/pgubook/ProgrammingGroundUp-1-0-booksize.pdf) - Jonathan Bartlett (PDF)
 * [Ralf Brown's Interrupt List](http://www.ctyme.com/rbrown.htm)
@@ -339,7 +340,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [x86 Assembly](https://en.wikibooks.org/wiki/X86_Assembly) - Wikibooks
 * [x86 Disassembly](https://en.wikibooks.org/wiki/X86_Disassembly) - Wikibooks
 * [Zen of Assembly Language: Volume I, Knowledge (1990)](http://www.jagregory.com/abrash-zen-of-asm/) - Michael Abrash
-* [The Grain Docs](https://grain-lang.org/docs/)
 
 
 #### Non-X86


### PR DESCRIPTION
I added a reference to the Grain documentation, I used the name appearing in the sidebar. The name of the webpage is different (`Welcome to Grain! - Grain Docs`), I can change it to this name if necessary. 

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)