### PR TITLE
docs(courses): fix italian course page

### DIFF
--- a/courses/free-courses-it.md
+++ b/courses/free-courses-it.md
@@ -13,12 +13,11 @@
 * [DevOps](#devops)
 * [Embedded](#embedded)
   * [Arduino](#arduino)
-* [Erlang](#erlang)
 * [Generale](#generale)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [Machine Learning](#machine-learning)
-* [Miscellaneous](#miscellaneous)
+* [Misto](#misto)
 * [Mobile](#mobile)
 * [Networking](#networking)
 * [Pascal](#pascal)
@@ -43,15 +42,15 @@
 
 ### Algoritmi e Strutture Dati
 
-* [AlgoMOOC - Algoritmi quotidiani](https://www.youtube.com/watch?v=opHFKVuDiYM&list=PLjTV6y5YWc5HNnLyXkzUe9IlkG2n6guxU) - A. Bogliolo
-* [Algoritmi e Programmazione (C)](https://www.youtube.com/playlist?list=PLUFFnpJdi99nqESTPaxlPMOF7yEEb8_sS) - P. Camurati, Politecnico di Torino
+* [AlgoMOOC - Algoritmi quotidiani](https://www.youtube.com/playlist?list=PLjTV6y5YWc5HNnLyXkzUe9IlkG2n6guxU) - A. Bogliolo
+* [Algoritmi e Programmazione (C)](https://www.youtube.com/playlist?list=PLUFFnpJdi99nqESTPaxlPMOF7yEEb8_sS) - P. Camurati e G. Cabodi, Politecnico di Torino
 * [Algoritmi e Strutture Dati](https://www.youtube.com/playlist?list=PLO4y9a8lTpK2TViOKbk-NjDBvL4RXDwYY) - R. Grossi, Università di Pisa
 
 
 ### Architettura degli Elaboratori
 
-* [Architettura degli Elaboratori](https://www.youtube.com/playlist?list=PLjTV6y5YWc5H2fefaz78qCeSKWj-k_-pY) - A. Bogliolo, Università di Urbino
 * [Architettura degli Elaboratori](https://www.youtube.com/playlist?list=PLhEwqlL10MqMYYiR5NqMblyyQr1ss-b8q) - A. Sperduti, Università di Padova
+* [CArcMOOC - Computer Architecture UniurbIT](https://www.youtube.com/playlist?list=PLjTV6y5YWc5H2fefaz78qCeSKWj-k_-pY) - A. Bogliolo, Università di Urbino
 
 
 ### Assembly
@@ -62,13 +61,12 @@
 ### C
 
 * [Corso di programmazione in C](https://www.youtube.com/playlist?list=PLO4y9a8lTpK2ugwPRLN_1oOrlzX9Zc9It) - R. Rizzi, Università di Verona
-* [Corso di programmazione in C (Standard C89/C90)](https://staff.polito.it/claudio.fornaro/CorsoC/) - C. Fornaro, Politecnico di Torino
 * [Linguaggio C - Corso completo](https://www.youtube.com/playlist?list=PL83Ordjpzm5oUl7tFEjc4iirkPBiv7FxR) - Programmazione Time
 
 
 ### <a id="csharp"></a>C\#
 
-* [Programmazione ad oggetti in C#](https://www.youtube.com/watch?v=aSgikNnGEKM&list=PLktbfd3yXeH8yQpHM3O468k8l-aTC6Hl6) - G. Pellegrini Parisi
+* [Programmazione ad oggetti in C#](https://www.youtube.com/playlist?list=PLktbfd3yXeH8yQpHM3O468k8l-aTC6Hl6) - G. Pellegrini Parisi
 
 
 ### <a id="cpp"></a>C++
@@ -79,7 +77,7 @@
 
 ### Database
 
-* [Basi di Dati](https://www.youtube.com/playlist?list=PLAQopGWlIcyZ7CN1sefdnCusfoodLP931) - T. Catarci
+* [Basi di Dati](https://www.youtube.com/playlist?list=PLAQopGWlIcyZ7CN1sefdnCusfoodLP931) - T. Catarci, Università La Sapienza di Roma
 
 
 #### SQL
@@ -94,20 +92,15 @@
 
 ### DevOps
 
-* [Docker - EmmeCiLab](https://www.youtube.com/playlist?list=PLCbSCJEIR6CpDJw4MawjHlgbsP3IG376e) - M. Cicolella
+* [Docker - EmmeCiLab](https://www.youtube.com/playlist?list=PLCbSCJEIR6CpDJw4MawjHlgbsP3IG376e) - Mauro Cicolella
 
 
 ### Embedded
 
 #### Arduino
 
-* [Arduino Cookbook - Corso di Arduino in 150 video](https://www.youtube.com/playlist?list=PL9_01HM23dGEDNNfR6BtlDWD8DDoAcLOT) - P. Aliverti
-* [Corso Arduino 2014](https://www.youtube.com/playlist?list=PLA27EZBY5vePO9T6YP3rH8LTTdylz69VE) - POuL, Politecnico di Milano
-
-
-### Erlang
-
-* [Iniziare con Erlang Language](https://riptutorial.com/it/erlang)
+* [Arduino Cookbook - Corso di Arduino (400+ video)](https://www.youtube.com/playlist?list=PL9_01HM23dGEDNNfR6BtlDWD8DDoAcLOT) - P. Aliverti
+* [Corso Arduino 2014](https://www.youtube.com/playlist?list=PLA27EZBY5vePO9T6YP3rH8LTTdylz69VE) - POuL Politecnico di Milano
 
 
 ### Generale
@@ -116,28 +109,25 @@
 * [Fondamenti di Informatica](https://www.youtube.com/playlist?list=PLUL1bzfXcbX3g2cIcTFdmvj5yawQtUOxJ) - C. De Stefano, Università di Cassino e del Lazio Meridionale
 * [Informatica](https://didattica.polito.it/pls/portal30/sviluppo.videolezioni.vis?cor=232) - M. Mezzalama, Politecnico di Torino
 * [Informatica di Base - Corso intensivo](https://www.youtube.com/playlist?list=PLG31HS6yEI8dv6TUmv9w0W6YmEAQm0P2q) - G. Pellegrini Parisi
-* [Informatica I - Modelli dell'Informatica](https://www.youtube.com/playlist?list=PLAQopGWlIcyalkb2baN9mnotsdBm5Vbkc) - A. Marchetti Spaccamela, Università La Sapienza Università di Roma
+* [Informatica I - Modelli dell'Informatica](https://www.youtube.com/playlist?list=PLAQopGWlIcyalkb2baN9mnotsdBm5Vbkc) - A. Marchetti Spaccamela, Università La Sapienza di Roma
 * [Sistemi di Calcolo](https://www.youtube.com/playlist?list=PLAQopGWlIcybT12h7fjVvlGAeSqOKDnTA) - C. Demetrescu, Università La Sapienza di Roma
 * [Teoria dell'informazione](https://www.youtube.com/playlist?list=PL0qAPtx8YtJeGo5g4Esi7tm6kHPRivkvb) - F. Camuso
 
 
 ### Java
 
-* [Algoritmi e Strutture Dati Java](http://www.vitoantoniobevilacqua.it/wiki/index.php?title=Pagina_principale#Dispense_di_Algoritmi_e_Strutture_Dati_in_Java) - V. Bevilacqua, Politecnico di Bari
-* [Api Rest vs GraphQL: La mini-serie per gli impazienti](https://www.youtube.com/playlist?list=PL2zaZp2LZxlv2XxmLm4dGP1tHfMjj7-kN) - D. Balinzo
 * [Corso di Java Spring Framework](https://www.youtube.com/playlist?list=PLCbSCJEIR6CqgCLyVzqp49xOm8A5YDTKA) - Mauro Cicolella
 * [Design Patterns in Java](https://www.youtube.com/playlist?list=PLCbSCJEIR6Cq-ac90TGvJ8Wo8TtyZ4nhu) - Mauro Cicolella
 * [Esercitazioni di Spring Boot](https://www.youtube.com/playlist?list=PLCbSCJEIR6CpGchit9OCI6fX_qVYs78d_) - Mauro Cicolella
-* [Java EE](https://www.youtube.com/playlist?list=PLjGYWJ4Dcy-erfReHXB9Ush0cREGSmyIe) - S. Zorba
-* [Programmazione a Oggetti (Java)](https://www.youtube.com/playlist?list=PLUFFnpJdi99kewGZIHpCDgarZER_-J1am) - M. Torchiano
+* [Java EE](https://www.youtube.com/playlist?list=PLjGYWJ4Dcy-erfReHXB9Ush0cREGSmyIe) - Sonia Zorba
+* [Programmazione a Oggetti (Java)](https://www.youtube.com/playlist?list=PLUFFnpJdi99kewGZIHpCDgarZER_-J1am) - M. Torchiano, Politecnico di Torino
 
 
 ### JavaScript
 
 * [Corso base di Javascript](https://www.youtube.com/playlist?list=PLFLSwyN4GsWmcBvMr5tzsJy9TI8DbfWC5) - S. Tocci
-* [Corso di JavaScript (base)](https://www.youtube.com/watch?v=JUBhi8O3wn0&list=PLG5caACNVwzpIhlLACNZd6BvABWv_Ti4I) - Lacerba
-* [Corso Javascript (ES6)](https://www.youtube.com/watch?v=dDekOIgzxPA&list=PL0qAPtx8YtJceyk5_NpNvLbbkrmfX9kkw) - F. Camuso
-* [Introduzione a NodeJS](https://www.nodeacademy.it) - Alberto Olla (email address *requested*, not required)
+* [Corso di JavaScript](https://www.youtube.com/playlist?list=PLG5caACNVwzpIhlLACNZd6BvABWv_Ti4I) - Lacerba
+* [Corso Javascript (ES6)](https://www.youtube.com/playlist?list=PL0qAPtx8YtJceyk5_NpNvLbbkrmfX9kkw) - F. Camuso
 
 
 ### Machine Learning
@@ -145,9 +135,10 @@
 * [Machine Learning in italiano col Pollo Watzlawick](https://www.youtube.com/playlist?list=PLa-sizbCyh93c0nSPAb8k5ZZeOq4SBIl9) - P. Savastano
 
 
-### Miscellaneous
+### Misto
 
-* [Programmazione Basic Commodore 64](https://www.youtube.com/playlist?list=PLCbSCJEIR6CrVT003ytijkO6kUrCT9VIT) - M. Cicolella
+* [Api Rest vs GraphQL: La mini-serie per gli impazienti](https://www.youtube.com/playlist?list=PL2zaZp2LZxlv2XxmLm4dGP1tHfMjj7-kN) - D. Balinzo
+* [Programmazione Basic Commodore 64](https://www.youtube.com/playlist?list=PLCbSCJEIR6CrVT003ytijkO6kUrCT9VIT) - Mauro Cicolella
 
 
 ### Mobile
@@ -162,8 +153,8 @@
 
 ### Pascal
 
-* [Corso di programmazione in Pascal](https://www.youtube.com/watch?v=DYy2IbteC2U&list=PLO4y9a8lTpK1DS45Wljy0l5rMtVNIesRJ) - R. Rizzi, Università di Verona
-* [Videocorso Pascal (Turbo e FPC)](https://www.youtube.com/watch?v=C1ttJju1RKc&list=PLC98ABC853EAEFD7F) - F. Camuso
+* [Corso di programmazione in Pascal](https://www.youtube.com/playlist?list=PLO4y9a8lTpK1DS45Wljy0l5rMtVNIesRJ) - R. Rizzi, Università di Verona
+* [Videocorso Pascal (Turbo e FPC)](https://www.youtube.com/playlist?list=PLC98ABC853EAEFD7F) - F. Camuso
 
 
 ### Python
@@ -176,13 +167,12 @@
 
 * [Corso di C per sistemi Embedded](https://www.youtube.com/playlist?list=PLFPNVUgYSJN3szCCDYzDoai2ueDxZpCcb) - Davide Ferrero, Deid Lab
 * [Programmazione](https://www.youtube.com/playlist?list=PLhEwqlL10MqN2eB3b4avX_DU3FK0EOYFa) - G. Filè, Università di Padova
-* [Programmazione 2 (Java/C++)](http://latemar.science.unitn.it/segue/index.php?&amp;site=2008Programmazione2&amp;section=86&amp;action=site) - M. Ronchetti, Università di Trento
-* [Tecniche di Programmazione (C/C++)](https://www.youtube.com/playlist?list=PLAQopGWlIcybv3YLRHGS4yZR00X3RvSBm) - L. Iocchi D. Nardi e A. Pretto, Università La Sapienza di Roma
+* [Tecniche di Programmazione (C/C++)](https://www.youtube.com/playlist?list=PLAQopGWlIcybv3YLRHGS4yZR00X3RvSBm) - L. Iocchi, D. Nardi e A. Pretto, Università La Sapienza di Roma
 
 
 ### Ruby
 
-* [Corso Ruby 2013](https://www.youtube.com/watch?v=IQFY6HaXkfM&list=PLA27EZBY5veNwghiX1buwSBziKV765N2t) - POuL Politecnico di Milano
+* [Corso Ruby 2013](https://www.youtube.com/playlist?list=PLA27EZBY5veNwghiX1buwSBziKV765N2t) - POuL Politecnico di Milano
 
 
 ### Sistemi Informativi
@@ -194,9 +184,8 @@
 
 #### Linux
 
-* [Certificazione Linux LPI](https://www.youtube.com/playlist?list=PL4L8OWDC99_d46jXlR02dCWzTwNISywwU)
-* [Corsi GNU/Linux Avanzati 2017](https://www.youtube.com/watch?v=lRbkk_NT6nk&list=PLA27EZBY5veMZYKkqS2sQNPJSCGI1QniD) - POuL Politecnico di Milano
-* [Corsi GNU/Linux Base 2017](https://www.youtube.com/watch?v=SsNiFtDRxRM&list=PLA27EZBY5veNNqkeuFwjJFWserz6QLzS_) - POuL Politecnico di Milano
+* [Corsi GNU/Linux Avanzati 2017](https://www.youtube.com/playlist?list=PLA27EZBY5veMZYKkqS2sQNPJSCGI1QniD) - POuL Politecnico di Milano
+* [Corsi GNU/Linux Base 2017](https://www.youtube.com/playlist?list=PLA27EZBY5veNNqkeuFwjJFWserz6QLzS_) - POuL Politecnico di Milano
 
 
 ### Strumenti di sviluppo
@@ -211,12 +200,12 @@
 
 #### Maven
 
-* [Tutorial su Maven](https://www.youtube.com/playlist?list=PLjGYWJ4Dcy-f71M9YyNSk4RpLE5jobe7y) - S. Zorba
+* [Tutorial su Maven](https://www.youtube.com/playlist?list=PLjGYWJ4Dcy-f71M9YyNSk4RpLE5jobe7y) - Sonia Zorba
 
 
 ### Web
 
-* [Interfacce grafiche (HTML/CSS/Bootstrap)](https://www.youtube.com/playlist?list=PLUFFnpJdi99kXjntQ0LNPnLbRLjKzmQaC) - A. Bottino, Politecnico di Torino
+* [Computer grafica 2017/2018](https://www.youtube.com/playlist?list=PLUFFnpJdi99kXjntQ0LNPnLbRLjKzmQaC) - A. Bottino, Politecnico di Torino
 * [Progettazione di applicazioni Web](https://www.youtube.com/playlist?list=PLE0AA1735F10543A6) - F. Corno e S. Di Carlo, Politecnico di Torino
 
 
@@ -227,6 +216,6 @@
 
 ### Workshop
 
-* [Workshop 3D Printing 2015](https://www.youtube.com/watch?v=7AJzR94ACZs&list=PLA27EZBY5veNgfDUNft5kju0QAvLPPw2j) - POuL Politecnico di Milano
-* [Workshop Calcolo Numerico 2014](https://www.youtube.com/watch?v=FVzt6TX0CiY&list=PLA27EZBY5veNyyBiZxkjFE2KwAIKLkITL) - POuL Politecnico di Milano
-* [Workshop Python 2014](https://www.youtube.com/watch?v=lz6uKGmrQoU&list=PLA27EZBY5veOFh1PdRdf7dc3DdBg-XctF) - POuL Politecnico di Milano
+* [3D Printing Workshop 2015](https://www.youtube.com/playlist?list=PLA27EZBY5veNgfDUNft5kju0QAvLPPw2j) - POuL Politecnico di Milano
+* [Workshop Calcolo Numerico 2014](https://www.youtube.com/playlist?list=PLA27EZBY5veNyyBiZxkjFE2KwAIKLkITL) - Alessandro Barenghi, POuL Politecnico di Milano
+* [Workshop Python 2014](https://www.youtube.com/playlist?list=PLA27EZBY5veOFh1PdRdf7dc3DdBg-XctF) - Stefano Sanfilippo, POuL Politecnico di Milano

--- a/courses/free-courses-it.md
+++ b/courses/free-courses-it.md
@@ -15,7 +15,7 @@
   * [Arduino](#arduino)
 * [Erlang](#erlang)
 * [Generale](#generale)
-* [Java](#Java)
+* [Java](#java)
 * [JavaScript](#javascript)
 * [Machine Learning](#machine-learning)
 * [Miscellaneous](#miscellaneous)
@@ -44,14 +44,14 @@
 ### Algoritmi e Strutture Dati
 
 * [AlgoMOOC - Algoritmi quotidiani](https://www.youtube.com/watch?v=opHFKVuDiYM&list=PLjTV6y5YWc5HNnLyXkzUe9IlkG2n6guxU) - A. Bogliolo
-* [Algoritmi e Programmazione (C)](https://www.youtube.com/playlist?list=PLUFFnpJdi99nqESTPaxlPMOF7yEEb8_sS) - P. Camurati (Politecnico di Torino)
-* [Algoritmi e Strutture Dati](https://www.youtube.com/playlist?list=PLO4y9a8lTpK2TViOKbk-NjDBvL4RXDwYY) - R. Grossi (Università di Pisa)
+* [Algoritmi e Programmazione (C)](https://www.youtube.com/playlist?list=PLUFFnpJdi99nqESTPaxlPMOF7yEEb8_sS) - P. Camurati, Politecnico di Torino
+* [Algoritmi e Strutture Dati](https://www.youtube.com/playlist?list=PLO4y9a8lTpK2TViOKbk-NjDBvL4RXDwYY) - R. Grossi, Università di Pisa
 
 
 ### Architettura degli Elaboratori
 
-* [Architettura degli Elaboratori](https://www.youtube.com/playlist?list=PLjTV6y5YWc5H2fefaz78qCeSKWj-k_-pY) - A. Bogliolo (Università di Urbino)
-* [Architettura degli Elaboratori](https://www.youtube.com/playlist?list=PLhEwqlL10MqMYYiR5NqMblyyQr1ss-b8q) - A. Sperduti (Università di Padova)
+* [Architettura degli Elaboratori](https://www.youtube.com/playlist?list=PLjTV6y5YWc5H2fefaz78qCeSKWj-k_-pY) - A. Bogliolo, Università di Urbino
+* [Architettura degli Elaboratori](https://www.youtube.com/playlist?list=PLhEwqlL10MqMYYiR5NqMblyyQr1ss-b8q) - A. Sperduti, Università di Padova
 
 
 ### Assembly
@@ -61,8 +61,8 @@
 
 ### C
 
-* [Corso di programmazione in C](https://www.youtube.com/playlist?list=PLO4y9a8lTpK2ugwPRLN_1oOrlzX9Zc9It) - R. Rizzi (Università di Verona)
-* [Corso di programmazione in C (Standard C89/C90)](https://staff.polito.it/claudio.fornaro/CorsoC/) - C. Fornaro (Politecnico di Torino)
+* [Corso di programmazione in C](https://www.youtube.com/playlist?list=PLO4y9a8lTpK2ugwPRLN_1oOrlzX9Zc9It) - R. Rizzi, Università di Verona
+* [Corso di programmazione in C (Standard C89/C90)](https://staff.polito.it/claudio.fornaro/CorsoC/) - C. Fornaro, Politecnico di Torino
 * [Linguaggio C - Corso completo](https://www.youtube.com/playlist?list=PL83Ordjpzm5oUl7tFEjc4iirkPBiv7FxR) - Programmazione Time
 
 
@@ -73,77 +73,76 @@
 
 ### <a id="cpp"></a>C++
 
-* [C++ 11](https://www.youtube.com/playlist?list=PL0qAPtx8YtJfZpJD7uFxAXglkiHSEhktG) (F. Camuso)
-* [C++ libreria QT - playlist 1](https://www.youtube.com/playlist?list=PL0qAPtx8YtJdH4GVwL_3QeJjPcz3DHE2t) (F. Camuso)
+* [C++ 11](https://www.youtube.com/playlist?list=PL0qAPtx8YtJfZpJD7uFxAXglkiHSEhktG) - F. Camuso
+* [C++ libreria QT - playlist 1](https://www.youtube.com/playlist?list=PL0qAPtx8YtJdH4GVwL_3QeJjPcz3DHE2t) - F. Camuso
 
 
 ### Database
 
-* [Basi di Dati](https://www.youtube.com/playlist?list=PLAQopGWlIcyZ7CN1sefdnCusfoodLP931) (T. Catarci)
+* [Basi di Dati](https://www.youtube.com/playlist?list=PLAQopGWlIcyZ7CN1sefdnCusfoodLP931) - T. Catarci
 
 
 #### SQL
 
-* [Corso SQL](https://www.youtube.com/playlist?list=PLE555DB6188C967AC) (F. Camuso)
+* [Corso SQL](https://www.youtube.com/playlist?list=PLE555DB6188C967AC) - F. Camuso
 
 
 ### Delphi
 
-* [Videocorso Delphi/Lazarus](https://www.youtube.com/watch?v=JxE1nUqriV0&list=PLF75FB30719A09FA2) (F. Camuso)
+* [Videocorso Delphi/Lazarus](https://www.youtube.com/playlist?list=PLF75FB30719A09FA2) - F. Camuso
 
 
 ### DevOps
 
-* [Docker - EmmeCiLab](https://www.youtube.com/playlist?list=PLCbSCJEIR6CpDJw4MawjHlgbsP3IG376e) (M. Cicolella)
+* [Docker - EmmeCiLab](https://www.youtube.com/playlist?list=PLCbSCJEIR6CpDJw4MawjHlgbsP3IG376e) - M. Cicolella
 
 
 ### Embedded
 
 #### Arduino
 
-* [Arduino Cookbook - Corso di Arduino in 150 video](https://www.youtube.com/playlist?list=PL9_01HM23dGEDNNfR6BtlDWD8DDoAcLOT) (P. Aliverti)
-* [Corso Arduino 2014](https://www.youtube.com/watch?v=WuqS4C4u42E&list=PLA27EZBY5vePO9T6YP3rH8LTTdylz69VE) (POuLpolimi Politecnico di Milano)
+* [Arduino Cookbook - Corso di Arduino in 150 video](https://www.youtube.com/playlist?list=PL9_01HM23dGEDNNfR6BtlDWD8DDoAcLOT) - P. Aliverti
+* [Corso Arduino 2014](https://www.youtube.com/playlist?list=PLA27EZBY5vePO9T6YP3rH8LTTdylz69VE) - POuL, Politecnico di Milano
 
 
 ### Erlang
 
-* [Erlang/OTP](http://www.khaldi.it/art/erlang/erl01/E01.html) - Jilani KHALDI
 * [Iniziare con Erlang Language](https://riptutorial.com/it/erlang)
 
 
 ### Generale
 
-* [Automi e Linguaggi Formali](https://www.youtube.com/playlist?list=PLhEwqlL10MqNz1pA7R5jnB_gsMIhDOe5X) - Bresolin e Filè (Università di Padova)
-* [Fondamenti di Informatica](https://www.youtube.com/playlist?list=PLUL1bzfXcbX3g2cIcTFdmvj5yawQtUOxJ) - C. De Stefano (Università di Cassino e del Lazio Meridionale)
-* [Informatica](https://didattica.polito.it/pls/portal30/sviluppo.videolezioni.vis?cor=232) - M. Mezzalama (Politecnico di Torino)
+* [Automi e Linguaggi Formali](https://www.youtube.com/playlist?list=PLhEwqlL10MqNz1pA7R5jnB_gsMIhDOe5X) - Bresolin e Filè, Università di Padova
+* [Fondamenti di Informatica](https://www.youtube.com/playlist?list=PLUL1bzfXcbX3g2cIcTFdmvj5yawQtUOxJ) - C. De Stefano, Università di Cassino e del Lazio Meridionale
+* [Informatica](https://didattica.polito.it/pls/portal30/sviluppo.videolezioni.vis?cor=232) - M. Mezzalama, Politecnico di Torino
 * [Informatica di Base - Corso intensivo](https://www.youtube.com/playlist?list=PLG31HS6yEI8dv6TUmv9w0W6YmEAQm0P2q) - G. Pellegrini Parisi
-* [Informatica I - Modelli dell'Informatica](https://www.youtube.com/playlist?list=PLAQopGWlIcyalkb2baN9mnotsdBm5Vbkc) - A. Marchetti Spaccamela (Università La Sapienza Università di Roma)
-* [Sistemi di Calcolo](https://www.youtube.com/playlist?list=PLAQopGWlIcybT12h7fjVvlGAeSqOKDnTA) - C. Demetrescu (Università La Sapienza di Roma)
-* [Teoria dell'informazione](https://www.youtube.com/playlist?list=PL0qAPtx8YtJeGo5g4Esi7tm6kHPRivkvb) (F. Camuso)
+* [Informatica I - Modelli dell'Informatica](https://www.youtube.com/playlist?list=PLAQopGWlIcyalkb2baN9mnotsdBm5Vbkc) - A. Marchetti Spaccamela, Università La Sapienza Università di Roma
+* [Sistemi di Calcolo](https://www.youtube.com/playlist?list=PLAQopGWlIcybT12h7fjVvlGAeSqOKDnTA) - C. Demetrescu, Università La Sapienza di Roma
+* [Teoria dell'informazione](https://www.youtube.com/playlist?list=PL0qAPtx8YtJeGo5g4Esi7tm6kHPRivkvb) - F. Camuso
 
 
 ### Java
 
-* [Algoritmi e Strutture Dati Java](http://www.vitoantoniobevilacqua.it/wiki/index.php?title=Pagina_principale#Dispense_di_Algoritmi_e_Strutture_Dati_in_Java) - V. Bevilacqua (Politecnico di Bari) 
-* [Api Rest vs GraphQL: La mini-serie per gli impazienti](https://www.youtube.com/playlist?list=PL2zaZp2LZxlv2XxmLm4dGP1tHfMjj7-kN) - (D. Balinzo) 
+* [Algoritmi e Strutture Dati Java](http://www.vitoantoniobevilacqua.it/wiki/index.php?title=Pagina_principale#Dispense_di_Algoritmi_e_Strutture_Dati_in_Java) - V. Bevilacqua, Politecnico di Bari
+* [Api Rest vs GraphQL: La mini-serie per gli impazienti](https://www.youtube.com/playlist?list=PL2zaZp2LZxlv2XxmLm4dGP1tHfMjj7-kN) - D. Balinzo
 * [Corso di Java Spring Framework](https://www.youtube.com/playlist?list=PLCbSCJEIR6CqgCLyVzqp49xOm8A5YDTKA) - Mauro Cicolella
-* [Design Patterns in Java](https://www.youtube.com/playlist?list=PLCbSCJEIR6Cq-ac90TGvJ8Wo8TtyZ4nhu) (M. Cicolella)
-* [Esercitazioni di Spring Boot](https://www.youtube.com/playlist?list=PLCbSCJEIR6CpGchit9OCI6fX_qVYs78d_) (M. Cicolella)
-* [Java EE](https://www.youtube.com/playlist?list=PLjGYWJ4Dcy-erfReHXB9Ush0cREGSmyIe) (S. Zorba)
-* [Programmazione a Oggetti (Java)](https://www.youtube.com/playlist?list=PLUFFnpJdi99kewGZIHpCDgarZER_-J1am) (M. Torchiano)
+* [Design Patterns in Java](https://www.youtube.com/playlist?list=PLCbSCJEIR6Cq-ac90TGvJ8Wo8TtyZ4nhu) - Mauro Cicolella
+* [Esercitazioni di Spring Boot](https://www.youtube.com/playlist?list=PLCbSCJEIR6CpGchit9OCI6fX_qVYs78d_) - Mauro Cicolella
+* [Java EE](https://www.youtube.com/playlist?list=PLjGYWJ4Dcy-erfReHXB9Ush0cREGSmyIe) - S. Zorba
+* [Programmazione a Oggetti (Java)](https://www.youtube.com/playlist?list=PLUFFnpJdi99kewGZIHpCDgarZER_-J1am) - M. Torchiano
 
 
 ### JavaScript
 
-* [Corso base di Javascript](https://www.youtube.com/playlist?list=PLFLSwyN4GsWmcBvMr5tzsJy9TI8DbfWC5) (S. Tocci)
-* [Corso di JavaScript (base)](https://www.youtube.com/watch?v=JUBhi8O3wn0&list=PLG5caACNVwzpIhlLACNZd6BvABWv_Ti4I) [(Lacerba.io)](https://lacerba.io)
-* [Corso Javascript (ES6)](https://www.youtube.com/watch?v=dDekOIgzxPA&list=PL0qAPtx8YtJceyk5_NpNvLbbkrmfX9kkw) (F. Camuso)
+* [Corso base di Javascript](https://www.youtube.com/playlist?list=PLFLSwyN4GsWmcBvMr5tzsJy9TI8DbfWC5) - S. Tocci
+* [Corso di JavaScript (base)](https://www.youtube.com/watch?v=JUBhi8O3wn0&list=PLG5caACNVwzpIhlLACNZd6BvABWv_Ti4I) - Lacerba
+* [Corso Javascript (ES6)](https://www.youtube.com/watch?v=dDekOIgzxPA&list=PL0qAPtx8YtJceyk5_NpNvLbbkrmfX9kkw) - F. Camuso
 * [Introduzione a NodeJS](https://www.nodeacademy.it) - Alberto Olla (email address *requested*, not required)
 
 
 ### Machine Learning
 
-* [Machine Learning in italiano col Pollo Watzlawick](https://www.youtube.com/playlist?list=PLa-sizbCyh93c0nSPAb8k5ZZeOq4SBIl9) (P. Savastano)
+* [Machine Learning in italiano col Pollo Watzlawick](https://www.youtube.com/playlist?list=PLa-sizbCyh93c0nSPAb8k5ZZeOq4SBIl9) - P. Savastano
 
 
 ### Miscellaneous
@@ -153,42 +152,42 @@
 
 ### Mobile
 
-* [DART & FLUTTER (per il mobile)](https://www.youtube.com/playlist?list=PL0qAPtx8YtJftaLnIroe7q9udsc9_qg6x) (F. Camuso)
+* [DART & FLUTTER (per il mobile)](https://www.youtube.com/playlist?list=PL0qAPtx8YtJftaLnIroe7q9udsc9_qg6x) - F. Camuso
 
 
 ### Networking
 
-* [Advanced Networking 2016](https://www.youtube.com/playlist?list=PLkbnRIR2azkIXO-ndOz7qBvVC38_wbOW8) (Hacklab Cosenza)
+* [Advanced Networking 2016](https://www.youtube.com/playlist?list=PLkbnRIR2azkIXO-ndOz7qBvVC38_wbOW8) - Hacklab Cosenza
 
 
 ### Pascal
 
-* [Corso di programmazione in Pascal](https://www.youtube.com/watch?v=DYy2IbteC2U&list=PLO4y9a8lTpK1DS45Wljy0l5rMtVNIesRJ) - R. Rizzi (Università di Verona)
-* [Videocorso Pascal (Turbo e FPC)](https://www.youtube.com/watch?v=C1ttJju1RKc&list=PLC98ABC853EAEFD7F) (F. Camuso)
+* [Corso di programmazione in Pascal](https://www.youtube.com/watch?v=DYy2IbteC2U&list=PLO4y9a8lTpK1DS45Wljy0l5rMtVNIesRJ) - R. Rizzi, Università di Verona
+* [Videocorso Pascal (Turbo e FPC)](https://www.youtube.com/watch?v=C1ttJju1RKc&list=PLC98ABC853EAEFD7F) - F. Camuso
 
 
 ### Python
 
-* [Corso Python 2016](https://www.youtube.com/playlist?list=PLA27EZBY5veOa-dbNIetJvyrAuoVy4zDD) (POuLpolimi Politecnico di Milano)
-* [Corso rapido Python per principianti e per esempi](https://www.youtube.com/playlist?list=PL0qAPtx8YtJdbiBCoj4j6x_Ai6Vu9j5r9) (F. Camuso)
+* [Corso Python 2016](https://www.youtube.com/playlist?list=PLA27EZBY5veOa-dbNIetJvyrAuoVy4zDD) - POuL Politecnico di Milano
+* [Corso rapido Python per principianti e per esempi](https://www.youtube.com/playlist?list=PL0qAPtx8YtJdbiBCoj4j6x_Ai6Vu9j5r9) - F. Camuso
 
 
 ### Programmazione
 
-* [Corso di C per sistemi Embedded](https://www.youtube.com/playlist?list=PLFPNVUgYSJN3szCCDYzDoai2ueDxZpCcb) - Davide Ferrero (Deid Lab)
-* [Programmazione](https://www.youtube.com/playlist?list=PLhEwqlL10MqN2eB3b4avX_DU3FK0EOYFa) - G. Filè (Università di Padova)
-* [Programmazione 2 (Java/C++)](http://latemar.science.unitn.it/segue/index.php?&amp;site=2008Programmazione2&amp;section=86&amp;action=site) - M. Ronchetti (Università di Trento)
-* [Tecniche di Programmazione (C/C++)](https://www.youtube.com/playlist?list=PLAQopGWlIcybv3YLRHGS4yZR00X3RvSBm) - L. Iocchi D. Nardi e A. Pretto (Università La Sapienza di Roma)
+* [Corso di C per sistemi Embedded](https://www.youtube.com/playlist?list=PLFPNVUgYSJN3szCCDYzDoai2ueDxZpCcb) - Davide Ferrero, Deid Lab
+* [Programmazione](https://www.youtube.com/playlist?list=PLhEwqlL10MqN2eB3b4avX_DU3FK0EOYFa) - G. Filè, Università di Padova
+* [Programmazione 2 (Java/C++)](http://latemar.science.unitn.it/segue/index.php?&amp;site=2008Programmazione2&amp;section=86&amp;action=site) - M. Ronchetti, Università di Trento
+* [Tecniche di Programmazione (C/C++)](https://www.youtube.com/playlist?list=PLAQopGWlIcybv3YLRHGS4yZR00X3RvSBm) - L. Iocchi D. Nardi e A. Pretto, Università La Sapienza di Roma
 
 
 ### Ruby
 
-* [Corso Ruby 2013](https://www.youtube.com/watch?v=IQFY6HaXkfM&list=PLA27EZBY5veNwghiX1buwSBziKV765N2t) (POuLpolimi Politecnico di Milano)
+* [Corso Ruby 2013](https://www.youtube.com/watch?v=IQFY6HaXkfM&list=PLA27EZBY5veNwghiX1buwSBziKV765N2t) - POuL Politecnico di Milano
 
 
 ### Sistemi Informativi
 
-* [Sistemi Informativi Aziendali](https://didattica.polito.it/pls/portal30/sviluppo.videolezioni.vis?cor=233) - F. Corno (Politecnico di Torino)
+* [Sistemi Informativi Aziendali](https://didattica.polito.it/pls/portal30/sviluppo.videolezioni.vis?cor=233) - F. Corno, Politecnico di Torino
 
 
 ### Sistemi Operativi
@@ -196,38 +195,38 @@
 #### Linux
 
 * [Certificazione Linux LPI](https://www.youtube.com/playlist?list=PL4L8OWDC99_d46jXlR02dCWzTwNISywwU)
-* [Corsi GNU/Linux Avanzati 2017](https://www.youtube.com/watch?v=lRbkk_NT6nk&list=PLA27EZBY5veMZYKkqS2sQNPJSCGI1QniD) (POuLpolimi Politecnico di Milano)
-* [Corsi GNU/Linux Base 2017](https://www.youtube.com/watch?v=SsNiFtDRxRM&list=PLA27EZBY5veNNqkeuFwjJFWserz6QLzS_) (POuLpolimi Politecnico di Milano)
+* [Corsi GNU/Linux Avanzati 2017](https://www.youtube.com/watch?v=lRbkk_NT6nk&list=PLA27EZBY5veMZYKkqS2sQNPJSCGI1QniD) - POuL Politecnico di Milano
+* [Corsi GNU/Linux Base 2017](https://www.youtube.com/watch?v=SsNiFtDRxRM&list=PLA27EZBY5veNNqkeuFwjJFWserz6QLzS_) - POuL Politecnico di Milano
 
 
 ### Strumenti di sviluppo
 
-* [Visual Studio 2019](https://www.youtube.com/playlist?list=PLgaOrAQwrg9J04dWnY-FF4SXUFt-TEQkE) (Mario De Ghetto)
+* [Visual Studio 2019](https://www.youtube.com/playlist?list=PLgaOrAQwrg9J04dWnY-FF4SXUFt-TEQkE) - Mario De Ghetto
 
 
 #### Git
 
-* [Corso Git 2017](https://www.youtube.com/playlist?list=PLA27EZBY5veN02RzEr6Ecm7KcjWadthBh) (POuLpolimi Politecnico di Milano)
+* [Corso Git 2017](https://www.youtube.com/playlist?list=PLA27EZBY5veN02RzEr6Ecm7KcjWadthBh) - POuL Politecnico di Milano
 
 
 #### Maven
 
-* [Tutorial su Maven](https://www.youtube.com/playlist?list=PLjGYWJ4Dcy-f71M9YyNSk4RpLE5jobe7y) (S. Zorba)
+* [Tutorial su Maven](https://www.youtube.com/playlist?list=PLjGYWJ4Dcy-f71M9YyNSk4RpLE5jobe7y) - S. Zorba
 
 
 ### Web
 
-* [Interfacce grafiche (HTML/CSS/Bootstrap)](https://www.youtube.com/playlist?list=PLUFFnpJdi99kXjntQ0LNPnLbRLjKzmQaC) - A. Bottino (Politecnico di Torino)
-* [Progettazione di applicazioni Web](https://www.youtube.com/playlist?list=PLE0AA1735F10543A6) - F. Corno e S. Di Carlo (Politecnico di Torino)
+* [Interfacce grafiche (HTML/CSS/Bootstrap)](https://www.youtube.com/playlist?list=PLUFFnpJdi99kXjntQ0LNPnLbRLjKzmQaC) - A. Bottino, Politecnico di Torino
+* [Progettazione di applicazioni Web](https://www.youtube.com/playlist?list=PLE0AA1735F10543A6) - F. Corno e S. Di Carlo, Politecnico di Torino
 
 
 #### Vue
 
-* [Vue 2.x (corso base)](https://www.youtube.com/playlist?list=PL0qAPtx8YtJdUH44fvkzVxy9waP23I_bE) (F. Camuso)
+* [Vue 2.x (corso base)](https://www.youtube.com/playlist?list=PL0qAPtx8YtJdUH44fvkzVxy9waP23I_bE) - F. Camuso
 
 
 ### Workshop
 
-* [Workshop 3D Printing 2015](https://www.youtube.com/watch?v=7AJzR94ACZs&list=PLA27EZBY5veNgfDUNft5kju0QAvLPPw2j) (POuLpolimi Politecnico di Milano)
-* [Workshop Calcolo Numerico 2014](https://www.youtube.com/watch?v=FVzt6TX0CiY&list=PLA27EZBY5veNyyBiZxkjFE2KwAIKLkITL) (POuLpolimi Politecnico di Milano)
-* [Workshop Python 2014](https://www.youtube.com/watch?v=lz6uKGmrQoU&list=PLA27EZBY5veOFh1PdRdf7dc3DdBg-XctF) (POuLpolimi Politecnico di Milano)
+* [Workshop 3D Printing 2015](https://www.youtube.com/watch?v=7AJzR94ACZs&list=PLA27EZBY5veNgfDUNft5kju0QAvLPPw2j) - POuL Politecnico di Milano
+* [Workshop Calcolo Numerico 2014](https://www.youtube.com/watch?v=FVzt6TX0CiY&list=PLA27EZBY5veNyyBiZxkjFE2KwAIKLkITL) - POuL Politecnico di Milano
+* [Workshop Python 2014](https://www.youtube.com/watch?v=lz6uKGmrQoU&list=PLA27EZBY5veOFh1PdRdf7dc3DdBg-XctF) - POuL Politecnico di Milano


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

- [X] Formatted the authors' name writed wrong
- [X] Removed the university name from the parenthesis:
 - before `* [Name](url) - F. Corno (Politecnico di Torino)` after `* [Name](url) - F. Corno, Politecnico di Torino`
- [X] Removed/changed broken link: #5470
- [X] Replaced unaccepted links (urls with useless parameters...)
- [X] Moved/deleted resources

#### Notes

- https://staff.polito.it/claudio.fornaro/CorsoC/: move to books
- https://riptutorial.com/it/erlang: move to books (#6153)
- http://www.vitoantoniobevilacqua.it/wiki/index.php?title=Pagina_principale#Dispense_di_Algoritmi_e_Strutture_Dati_in_Java: bad resource
- https://www.nodeacademy.it: blog
- http://latemar.science.unitn.it/segue/index.php?&amp;site=2008Programmazione2&amp;section=86&amp;action=site: it isn't a course
- https://www.youtube.com/playlist?list=PL4L8OWDC99_d46jXlR02dCWzTwNISywwU): 64 videos are hidden


## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
