### PR TITLE
fix(books): free-programming-books-ko broken link

### DIFF
--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -120,7 +120,7 @@
 
 ### Linux
 
-* [리눅스 서버를 다루는 기술](https://thebook.io/006718/)
+* [리눅스 서버를 다루는 기술](https://web.archive.org/web/20220107111504/https://thebook.io/006718/) *(:card_file_box: archived)*
 * [GNOME 배우기](https://sites.google.com/site/gnomekr/home/learning_gnome)
 
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Solved a problem of #6942.
This book is similar to https://thebook.io/080277/, the author is the same ([006718](http://www.yes24.com/product/goods/16402357) & [080277](http://www.yes24.com/product/goods/106537368)) but I still think they are two separate books

### For book lists, is it a book? For course lists, is it a course? etc.
It's a book

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Put lists in alphabetical order, correct spacing.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
