### PR TITLE
chore: merge and homogenize `HTML & CSS` sections across files

### DIFF
--- a/books/free-programming-books-ar.md
+++ b/books/free-programming-books-ar.md
@@ -7,7 +7,7 @@
 * [AWS](#aws)
 * [C#&lrm;](#csharp)
 * [DB & DBMS](#db--dbms)
-* [HTML/CSS](#htmlcss)
+* [HTML and CSS](#html-and-css)
 * [Introduction to Programming in Arabic](#introduction-to-programming-in-arabic)
 * [JavaScript](#javascript)
   * [Vue.js](#vuejs)
@@ -54,7 +54,7 @@
 * [تصميم قواعد البيانات](https://academy.hsoub.com/files/26-تصميم-قواعد-البيانات/) - Adrienne Watt & Nelson Eng، ترجمة أيمن طارق وعلا عباس (PDF)
 
 
-### HTML/CSS
+### HTML and CSS
 
 * [التحريك عبر CSS&rlm;](https://academy.hsoub.com/files/14-التحريك-عبر-css/) - Donovan Hutchinson, Mohamed Beghat&rlm; (PDF)
 * [نحو فهم أعمق لتقنيات HTML5&rlm;](https://academy.hsoub.com/files/13-نحو-فهم-أعمق-لتقنيات-html5/) - Mark Pilgrim, Abdullatif Eymash&rlm; (PDF)

--- a/books/free-programming-books-az.md
+++ b/books/free-programming-books-az.md
@@ -1,8 +1,7 @@
 ### Index
 
 * [C](#c)
-* [CSS](#css)
-* [HTML](#html)
+* [HTML and CSS](#html-and-css)
 * [JavaScript](#javascript)
 * [Linux](#Linux)
 * [PHP](#php)
@@ -13,13 +12,9 @@
 * [C Proqramlaşdırma Dili](http://ilkaddimlar.com/ders/c-proqramlasdirma-dili)
 
 
-### CSS
+### HTML and CSS
 
 * [CSS](http://ilkaddimlar.com/ders/css)
-
-
-### HTML
-
 * [HTML](http://ilkaddimlar.com/ders/html)
 
 

--- a/books/free-programming-books-cs.md
+++ b/books/free-programming-books-cs.md
@@ -4,7 +4,7 @@
 * [C#](#csharp)
 * [C++](#cpp)
 * [Git](#git)
-* [HTML](#html)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [Language Agnostic](#language-agnostic)
   * [Algoritmy a datové struktury](#algoritmy-a-datove-struktury)
@@ -55,7 +55,7 @@
 * [Pro Git](https://knihy.nic.cz/#ProGit) - Scott Chacon (PDF, EPUB, MOBI)
 
 
-### HTML
+### HTML and CSS
 
 * [Ponořme se do HTML5](https://knihy.nic.cz/#HTML5) - Mark Pilgrim (PDF)
 

--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -11,7 +11,7 @@
 * [Git](#git)
 * [Go](#go)
 * [Groovy](#groovy)
-* [HTML & CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [iOS](#ios)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -106,7 +106,7 @@ Dirk Loser, Clemens Tamme, Philipp Schweinzer (PDF)
 * [Groovy für Java-Entwickler](http://examples.oreilly.de/openbooks/pdf_groovyger.pdf) - Jörg Staudemeyer (PDF)
 
 
-### HTML & CSS
+### HTML and CSS
 
 * [CSS](http://www.peterkropff.de/site/css/css.htm) - Peter Kropff (Grundlagen, OOP, MySQLi, PDO) (Online, PDF)
 * [HTML](http://www.peterkropff.de/site/html/html.htm) - Peter Kropff (Online, PDF)

--- a/books/free-programming-books-es.md
+++ b/books/free-programming-books-es.md
@@ -18,7 +18,7 @@
 * [Git](#git)
 * [Go](#go)
 * [Haskell](#haskell)
-* [HTML & CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [AngularJS](#angularjs)
@@ -183,7 +183,7 @@
 * [Piensa en Haskell (ejercicios de programación funcional)](http://www.cs.us.es/~jalonso/publicaciones/Piensa_en_Haskell.pdf) (PDF)
 
 
-### HTML & CSS
+### HTML and CSS
 
 * [99 tips para Web Development](https://fmontes.gumroad.com/l/99tips) - Freddy Montes (PDF) (se solicita email)
 * [CSS avanzado](http://librosweb.es/libro/css_avanzado) Javier Eguíluz (HTML) [(PDF)](https://openlibra.com/es/book/download/css-avanzado)

--- a/books/free-programming-books-fa_IR.md
+++ b/books/free-programming-books-fa_IR.md
@@ -2,7 +2,7 @@
 
 * [رایانش ابری](#%D8%B1%D8%A7%DB%8C%D8%A7%D9%86%D8%B4-%D8%A7%D8%A8%D8%B1%DB%8C)
 * [مهندسی نرم‌افزار](#%D9%85%D9%87%D9%86%D8%AF%D8%B3%DB%8C-%D9%86%D8%B1%D9%85%E2%80%8C%D8%A7%D9%81%D8%B2%D8%A7%D8%B1)
-* [CSS](#css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [LaTeX](#latex)
@@ -30,7 +30,7 @@
 * [ترجمه آزاد کتاب کد تمیز](https://codetamiz.vercel.app) - Robert C. Martin et al.
 
 
-### CSS
+### HTML and CSS
 
 * [یادگیری پیکربندی با CSS](http://fa.learnlayout.com)
 

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -14,10 +14,10 @@
 * [Caml / OCaml](#caml--ocaml)
 * [Chaîne de blocs / Blockchain](#chaîne-de-blocs--blockchain)
 * [Coq](#coq)
-* [CSS](#css)
 * [Fortran](#fortran)
 * [Git](#git)
 * [Haskell](#haskell)
+* [HTML and CSS](#css)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [jQuery](#jquery)
@@ -131,11 +131,6 @@
 * [Le Coq'Art (V8)](http://www.labri.fr/perso/casteran/CoqArt/) - Yves Bertot et Pierre Castéran
 
 
-### CSS
-
-* [Apprendre les mises en page CSS](http://fr.learnlayout.com)
-
-
 ### Fortran
 
 * [IDRIS adaptation of the Fortran 77 manual](http://www.idris.fr/formations/fortran/fortran-77.html) - IDRIS, Hervé Delouis, Patrick Corde (HTML)
@@ -173,6 +168,11 @@
 
 * [A Gentle Introduction to Haskell](http://gorgonite.developpez.com/livres/traductions/haskell/gentle-haskell/) - Paul Hudak, John Peterson et Joseph Fasel
 * [Apprendre Haskell vous fera le plus grand bien !](http://lyah.haskell.fr)
+
+
+### HTML and CSS
+
+* [Apprendre les mises en page CSS](http://fr.learnlayout.com)
 
 
 ### (La)TeX et associés

--- a/books/free-programming-books-hu.md
+++ b/books/free-programming-books-hu.md
@@ -5,7 +5,7 @@
 * [Arduino](#arduino)
 * [C](#c)
 * [C++](#cpp)
-* [HTML / CSS](#html-css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [Lego Mindstorms](#lego-mindstorms)
 * [LISP](#lisp)
@@ -48,7 +48,7 @@
 * [Fejlett programozási technikák](http://www.ms.sapientia.ro/~manyi/teaching/c++/cpp.pdf) - Antal Margit (PDF)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [CSS alapjai](http://weblabor.hu/cikkek/cssalapjai1) - Bártházi András (HTML)
 * [Webes szabványok](http://nagygusztav.hu/webes-szabvanyok) - Chris Mills, Ben Buchanan, Tom Hughes-Croucher, Mark Norman "Norm" Francis, Linda Goin, Paul Haine, Jen Hanen, Benjamin Hawkes-Lewis, Ben Henick, Christian Heilmann, Roger Johansson, Peter-Paul Koch, Jonathan Lane, Tommy Olsson, Nicole Sullivan és Mike West, ford.: Nagy Gusztáv (PDF)

--- a/books/free-programming-books-id.md
+++ b/books/free-programming-books-id.md
@@ -9,7 +9,7 @@
 * [Flutter](#flutter)
 * [Git](#git)
 * [Go](#go)
-* [HTML & CSS](#html-css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [Node.js](#nodejs)
@@ -82,7 +82,7 @@
 * [Mari Belajar Golang](https://www.smashwords.com/books/view/938003) - Risal (PDF)
 
 
-### HTML CSS
+### HTML and CSS
 
 * [Belajar HTML dan CSS](http://www.ariona.net/ebook-belajar-html-dan-css/)
 * [Ebook Belajar HTML Dan CSS Dasar](https://www.malasngoding.com/download-ebook-belajar-html-dan-css-dasar-gratis/)

--- a/books/free-programming-books-it.md
+++ b/books/free-programming-books-it.md
@@ -13,14 +13,13 @@
 * [C](#c)
 * [C#](#csharp)
 * [C++](#cpp)
-* [CSS](#css)
 * [Database](#database)
   * [NoSQL](#nosql)
   * [Relazionali](#relazionali)
   * [SQL](#sql)
 * [Git](#git)
 * [Golang](#golang)
-* [HTML](#html)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [AngularJS](#angularjs)
@@ -117,11 +116,6 @@
 * [Il linguaggio C++](https://hpc-forge.cineca.it/files/CoursesDev/public/2012%20Autumn/Introduzione%20alla%20programmazioni%20a%20oggetti%20in%20C++/corsocpp.pdf) - (PDF)
 
 
-### CSS
-
-* [Guida Completa sviluppo lato Client](http://www.aiutamici.com/PortalWeb/eBook/ebook/Alessandro_Stella-Programmare_per_il_web.pdf) (PDF)
-
-
 ### Database
 
 * [Basi di Dati](http://dbdmg.polito.it/wordpress/teaching/basi-di-dati/) - Apiletti e Cagliero (Politecnico di Torino)
@@ -159,7 +153,7 @@
 * [The Little Go Book](https://github.com/francescomalatesta/the-little-go-book-ita) - Karl Seguin, Francesco Malatesta ([HTML](https://github.com/francescomalatesta/the-little-go-book-ita/blob/master/it/go.md))
 
 
-### HTML
+### HTML and CSS
 
 * [Canoro sito](http://canoro.altervista.org/guide/html/GuidaHTML22.pdf) (PDF)
 * [Guida Completa sviluppo lato Client](http://www.aiutamici.com/PortalWeb/eBook/ebook/Alessandro_Stella-Programmare_per_il_web.pdf) (PDF)

--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -9,7 +9,7 @@
 * [Elastic](#elastic)
 * [GIT](#git)
 * [Go](#go)
-* [HTML5](#html5)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [Node.js](#nodejs)
@@ -87,7 +87,7 @@
 * [The Little Go Book. 리틀 고 책입니다](https://github.com/byounghoonkim/the-little-go-book/) - Karl Seguin, Byounghoon Kim ([HTML](https://github.com/byounghoonkim/the-little-go-book/blob/master/ko/go.md))
 
 
-### HTML5
+### HTML and CSS
 
 * [HTML5, CSS and JavaScript](http://fromyou.tistory.com/581)
 

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -74,7 +74,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Hadoop](#hadoop)
 * [Haskell](#haskell)
 * [Haxe](#haxe)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
   * [Bootstrap](#bootstrap)
   * [Tailwindcss](https://tailwindcss.com/docs) - Adam Wathan
 * [HTTP](#http)
@@ -891,7 +891,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Kha Handbook](https://github.com/KTXSoftware/Kha/wiki/Tutorials)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [A beginner's guide to HTML&CSS](http://learn.shayhowe.com/html-css/)
 * [A free guide to learn HTML and CSS](http://marksheet.io)

--- a/books/free-programming-books-pl.md
+++ b/books/free-programming-books-pl.md
@@ -9,9 +9,8 @@
 * [C++](#cpp)
 * [Common Lisp](#common-lisp)
 * [Coq](#coq)
-* [CSS](#css)
 * [Haskell](#haskell)
-* [HTML](#html)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [LaTeX](#latex)
@@ -92,21 +91,16 @@
 * [Kurs programowania w języku Common Lisp](http://jcubic.pl/lisp_tutorial.php) - Jakub Jankiewicz
 
 
-### CSS
-
-* [Kaskadowe Arkusze Stylów](http://www.kurshtml.edu.pl/css/index.html) - Sławomir Kokłowski
-* [Kurs CSS](https://webref.pl/arena/css/css_index.html) - Arkadiusz Michalski
-* [Moja pierwsza strona internetowa w HTML5 i CSS3](https://ferrante.pl/books/html/) - Damian Wielgosik
-
-
 ### Haskell
 
 * [Haskell](https://pl.wikibooks.org/wiki/Haskell) - Wikibooks
 
 
-### HTML
+### HTML and CSS
 
 * [HTML dla zielonych](http://www.kurshtml.edu.pl/html/zielony.html) - Sławomir Kokłowski
+* [Kaskadowe Arkusze Stylów](http://www.kurshtml.edu.pl/css/index.html) - Sławomir Kokłowski
+* [Kurs CSS](https://webref.pl/arena/css/css_index.html) - Arkadiusz Michalski
 * [KURS HTML](http://www.kurshtml.edu.pl) - Sławomir Kokłowski
 * [Moja pierwsza strona internetowa w HTML5 i CSS3](https://ferrante.pl/books/html/) - Damian Wielgosik
 

--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -20,7 +20,7 @@
 * [Git](#git)
 * [Go](#go)
 * [Haskell](#haskell)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [AngularJS](#angularjs)
@@ -181,7 +181,7 @@
 * [Aprender o Haskell será um grande bem para você (tradução em andamento)](https://github.com/taylorrf/learnhaskell)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [Apostila de HTML](https://www.telecom.uff.br/pet/petws/downloads/apostilas/HTML.pdf) - Robertha Pereira Pedroso (PDF)
 * [Desenvolvimento Web com HTML, CSS e JavaScript](https://www.caelum.com.br/apostila-html-css-javascript/) - Caelum

--- a/books/free-programming-books-pt_PT.md
+++ b/books/free-programming-books-pt_PT.md
@@ -1,8 +1,8 @@
 ### Indice
 
 * [C/C++](#cc)
-* [CSS](#css)
 * [Haskell](#haskell)
+* [HTML and CSS](#html-and-css)
 * [LaTeX](#latex)
 * [Prolog](#prolog)
 * [Python](#python)
@@ -14,14 +14,14 @@
 * [Aprenda a Programar - Uma Breve Introdução (2015)](https://henriquedias.com/downloads/aprenda_a_programar.pdf) - Henrique Dias (PDF)
 
 
-### CSS
-
-* [Aprenda o layout de CSS](http://pt-pt.learnlayout.com)
-
-
 ### Haskell
 
 * [Programação Funcional CC](http://www4.di.uminho.pt/~mjf/pub/PF-Haskell.pdf) - Maria João Frade (PDF)
+
+
+### HTML and CSS
+
+* [Aprenda o layout de CSS](http://pt-pt.learnlayout.com)
 
 
 ### LaTeX

--- a/books/free-programming-books-ro.md
+++ b/books/free-programming-books-ro.md
@@ -2,7 +2,7 @@
 
 * [Ajax](#ajax)
 * [C](#c)
-* [HTML](#html)
+* [HTML and CSS](#html-and-css)
 * [MySQL](#mysql)
 * [PHP](#php)
   * [Symfony](#symfony)
@@ -19,7 +19,7 @@
 * [Ghidul Beej pentru Programarea in Retea - Folosind socket de internet](https://web.archive.org/web/20180710112954/http://weknowyourdreams.com/beej.html) Brian "Beej Jorgensen" Hall, Dragos Moroianu (HTML) *(:card_file_box: archived)*
 
 
-### HTML
+### HTML and CSS
 
 * [HTML](http://tutorialehtml.com/ro/introducere-in-html/)
 

--- a/books/free-programming-books-ru.md
+++ b/books/free-programming-books-ru.md
@@ -19,7 +19,7 @@
 * [Git](#git)
 * [Go](#go)
 * [Haskell](#haskell)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
   * [Bootstrap](#bootstrap)
 * [Java](#java)
   * [Android](#android)
@@ -217,7 +217,7 @@
 * [Haskell: введение в функциональное программирование](https://wiki.nsunc.com/_export/html/haskell) - В.Н. Власов
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [Руководство по HTML5 и CSS3](https://metanit.com/web/html5) - Евгений Попов
 * [Справочник по HTML](http://htmlbook.ru/html) - Влад Мержевич

--- a/books/free-programming-books-ta.md
+++ b/books/free-programming-books-ta.md
@@ -1,9 +1,8 @@
 ## Index
 
 * [Big Data](#BigData)
-* [CSS](#CSS)
 * [Database](#Database)
-* [HTML](#HTML)
+* [HTML and CSS](#html-and-css)
 * [JavaScript](#Javascript)
 * [Machine Learning](#MachineLearning)
 * [MySQL](#MySQL)
@@ -17,18 +16,14 @@
 * [எளிய தமிழில் Big Data](http://www.kaniyam.com/learn-bigdata-in-tamil-ebooks/)
 
 
-### CSS
-
-* [எளிய தமிழில் CSS](http://www.kaniyam.com/download/learn-css-in-tamil.pdf) - Kaniyam Foundation (PDF)
-
-
 ### Database
 
 * [எளிய தமிழில் MySQL ](http://www.kaniyam.com/mysql-book-in-tamil/)
 
 
-### HTML
+### HTML and CSS
 
+* [எளிய தமிழில் CSS](http://www.kaniyam.com/download/learn-css-in-tamil.pdf) - Kaniyam Foundation (PDF)
 * [எளிய தமிழில் CSS](http://www.kaniyam.com/learn-css-in-tamil-ebook/)
 * [எளிய தமிழில் HTML](http://www.kaniyam.com/learn-html-in-tamil/)
 

--- a/books/free-programming-books-tr.md
+++ b/books/free-programming-books-tr.md
@@ -4,13 +4,12 @@
 * [Android](#android)
 * [C](#c)
 * [C++](#cpp)
-* [CSS](#css)
 * [D](#d)
 * [Dart](#dart)
 * [Git](#git)
 * [Go](#go)
 * [Güvenlik ve Gizlilik](#guvenlik-ve-gizlilik)
-* [Html](#html)
+* [HTML and CSS](#html-and-css)
 * [iOS](#ios)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -52,11 +51,6 @@
 * [C++ Dersleri](https://www.yusufsezer.com.tr/cpp-dersleri/) - Yusuf Sezer
 
 
-### CSS
-
-* [CSS Giriş](http://sercaneraslan.com/css/) - Sercan Eraslan
-
-
 ### D
 
 * [D Programlama Dili](https://www.ddili.org/ders/d/D_Programlama_Dili.pdf) - Ali Çehreli (PDF)
@@ -83,10 +77,11 @@
 * [Özgür Yazılım Derneği Güvenlik Rehberi](https://guvenlik.oyd.org.tr) - Filiz Akin et al.
 
 
-### Html
+### HTML and CSS
 
-* [Html'e Giriş](http://www.htmldersleri.org)
-* [Html'e Yolculuk](https://www.github.com/paufsc/journey-to-html)
+* [CSS Giriş](http://sercaneraslan.com/css/) - Sercan Eraslan
+* [HTML'e Giriş](http://www.htmldersleri.org)
+* [HTML'e Yolculuk](https://www.github.com/paufsc/journey-to-html)
 
 
 ### iOS

--- a/books/free-programming-books-uk.md
+++ b/books/free-programming-books-uk.md
@@ -2,7 +2,7 @@
 
 * [ClosureScript](#clojurescript)
 * [Haskell](#haskell)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
   * [Bootstrap](#bootstrap)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -23,7 +23,7 @@
 * [Вивчити собі Хаскель на велике щастя!](http://haskell.trygub.com) - Міран Ліповача
 
 
-### HTML / CSS
+### HTML and CSS
 
 #### Bootstrap
 

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -38,7 +38,7 @@
   * [Fortran](#fortran)
   * [Golang](#golang)
   * [Haskell](#haskell)
-  * [HTML / CSS](#html--css)
+  * [HTML and CSS](#html-and-css)
   * [HTTP](#http)
   * [iOS](#ios)
   * [Java](#java)
@@ -431,7 +431,7 @@
 * [Real World Haskell 中文版](http://cnhaskell.com)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [前端代码规范](http://alloyteam.github.io/CodeGuide/) - 腾讯AlloyTeam团队
 * [通用 CSS 笔记、建议与指导](https://github.com/chadluo/CSS-Guidelines/blob/master/README.md)

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -5,7 +5,6 @@
 * [C++](#cpp)
 * [Clojure](#clojure)
 * [Common Lisp](#common-lisp)
-* [CSS](#css)
 * [Data Science](#data-science)
 * [Elixir](#elixir)
 * [Erlang](#erlang)
@@ -13,6 +12,7 @@
 * [Golang](#golang)
 * [Gulp](#gulp)
 * [Haskell](#haskell)
+* [HTML and CSS](#html-and-css)
 * [IDE and Editors](#ide-and-editors)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -64,13 +64,6 @@
 
 * [Common Lisp for Beginners](https://www.youtube.com/playlist?list=PLCpux10P7KDKPb4eI5b_qSnQaY1ePGKGK) - Neil Munro (screencast)
 * [Little Bits of Lisp](https://www.youtube.com/playlist?list=PL2VAYZE_4wRJi_vgpjsH75kMhN4KsuzR_) - Cecilie Baggers (screencast)
-
-
-### CSS
-
-* [CSS Crash Course For Absolute Beginners](https://www.youtube.com/watch?v=yfoY53QXEnI) - Brad Traversy (screencast)
-* [CSS-Tricks Screencasts](https://css-tricks.com/video-screencasts/) - Chris Coyier (screencast)
-* [The CSS Podcast](https://thecsspodcast.libsyn.com) - Una Kravets, Adam Argyle (podcast)
 
 
 ### Data Science
@@ -140,6 +133,13 @@
 * [Haskell Tutorial](https://www.youtube.com/watch?v=02_H3LjqMr8) - Derek Banas (screencast)
 * [HaskellRank](https://www.youtube.com/playlist?list=PLguYJK7ydFE4aS8fq4D6DqjF6qsysxTnx) - Tsoding, Alexey Kutepov (screencast)
 * [The Haskell Cast](https://www.haskellcast.com) - Chris Forno, Alp Mestanogullari, Rein Henrichs (podcast)
+
+
+### HTML and CSS
+
+* [CSS Crash Course For Absolute Beginners](https://www.youtube.com/watch?v=yfoY53QXEnI) - Brad Traversy (screencast)
+* [CSS-Tricks Screencasts](https://css-tricks.com/video-screencasts/) - Chris Coyier (screencast)
+* [The CSS Podcast](https://thecsspodcast.libsyn.com) - Una Kravets, Adam Argyle (podcast)
 
 
 ### IDE and Editors

--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -5,7 +5,7 @@
 * [DataScience](#datascience)
 * [Game development](#game-development)
 * [Haskell](#haskell)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [iOS](#ios)
 * [Java](#java)
 * [Language Agnostic](#language-agnostic)
@@ -54,7 +54,7 @@
 * [Curso Haskell para Iniciantes](https://www.youtube.com/playlist?list=PL8eBmR3QtPL3pDzQpwPYfWQ4NEPGu6j7z) (screencast)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [Curso em Vídeo - HTML5, CSS3 e JavaScript](https://www.youtube.com/playlist?list=PLHz_AreHm4dlAnJ_jJtV29RFxnPHDuk9o) - Gustavo Guanabara (screencast)
 

--- a/courses/free-courses-ar.md
+++ b/courses/free-courses-ar.md
@@ -16,7 +16,7 @@
 * [Flutter](#flutter)
 * [Game Development](#game-development)
 * [Git](#git)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [Gulp.js](#gulpjs)
@@ -155,7 +155,7 @@
 * [Learn Git in Arabic&rlm;](https://www.youtube.com/playlist?list=PLfDx4cQoUNOYVfQs_NFNyykcqkaJ_plmK) - Algorithm Academy
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [برمجة المواقع \| تعلم لغة الhtml من الصفر](https://www.youtube.com/playlist?list=PLYyqC4bNbCIfMY5CoGmiWaPi9l86qaz5B) - أكاديمية ترميز
 * [برمجة المواقع \| سلسلة دروس لغة css](https://www.youtube.com/playlist?list=PLYyqC4bNbCIdES52srHE6xTiIgvgMkBWu) - أكاديمية ترميز

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -29,7 +29,7 @@
 * [Git](#git)
 * [Go](#go)
 * [Haskell](#haskell)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [iOS](#ios)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -458,7 +458,7 @@
 * [RWTH Aachen University: Functional Programming](https://videoag.fsmpi.rwth-aachen.de/?course=12ss-funkprog) - Jürgen Giesl
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [Bento CSS Learning Track](https://bento.io/topic/css) (Bento)
 * [Bento HTML Learning Track](https://bento.io/topic/html) (Bento)

--- a/courses/free-courses-fr.md
+++ b/courses/free-courses-fr.md
@@ -7,7 +7,7 @@
 * [C#](#csharp)
 * [C++](#cpp)
 * [Git](#git)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [jQuery](#jquery)
@@ -62,7 +62,7 @@
 * [Formation Git en vidéo, Cours Complet](https://www.youtube.com/playlist?list=PLjwdMgw5TTLXuY5i7RW0QqGdW0NZntqiP) - Grafikart
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [Apprendre à coder en HTML et CSS \| Cours complet (2020)](https://www.pierre-giraud.com/html-css-apprendre-coder-cours/) - Pierre Giraud
 * [Apprendre à utiliser le framework Bootstrap \| Cours complet (2020)](https://www.pierre-giraud.com/bootstrap-apprendre-cours/) - Pierre Giraud

--- a/courses/free-courses-id.md
+++ b/courses/free-courses-id.md
@@ -14,7 +14,7 @@
 * [Git](#git)
 * [Go](#go)
 * [Gradle](#gradle)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
   * [Spring](#spring)
 * [JavaScript](#javascript)
@@ -151,7 +151,7 @@
 * [Belajar Gradle](https://www.youtube.com/playlist?list=PL-CtdCApEFH8yGJzfU_gners0ybO4MlrV) - Eko Kurniawan Khannedy, Programmer Zaman Now (YouTube)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [Belajar CSS](https://alwaysngoding.com/belajar-css/teori) - Muhammad Saleh Solahudin, Always Ngoding (account *required*)
 * [Belajar FLEXBOX](https://www.youtube.com/playlist?list=PLFIM0718LjIU1lWlM34j6E9fMlrrSGZ1k) - Web Programming UNPAS

--- a/courses/free-courses-kk.md
+++ b/courses/free-courses-kk.md
@@ -1,8 +1,8 @@
 ### Index
 
 * [Android](#android)
-* [HTML/CSS](#html/css)
-* [Javascript](#javascript)
+* [HTML and CSS](#html-and-css)
+* [JavaScript](#javascript)
 * [PHP](#php)
 * [Python](#python)
 
@@ -19,7 +19,7 @@ ADVANCED - дамытушы. Детальді кодты үйрену.
 * [Android](https://bilgen.academy/course/view.php?id=512) (BEGINNER)
 
 
-### HTML/CSS
+### HTML and CSS
 
 * [HTML/CSS. базалық веб-дизайн құрудағы кодтау.](https://bilgen.academy/course/view.php?id=510) (BEGINNER)
 
@@ -37,5 +37,3 @@ ADVANCED - дамытушы. Детальді кодты үйрену.
 ### Python
 
 * [Python тiлiнде бағдарламалау негiздерi.](https://openu.kz/kz/courses/python-tilinde-badarlamalau-negizderi) - Жасдәурен Дүйсебеков (Қазақстанның ашық университеті) *(тіркелуді талап етпейді)*
-
-

--- a/courses/free-courses-pl.md
+++ b/courses/free-courses-pl.md
@@ -6,8 +6,7 @@
 * [C](#c)
 * [C#](#csharp)
 * [C++](#cpp)
-* [CSS](#css)
-* [HTML](#html)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [MySQL](#mysql)
@@ -48,14 +47,10 @@
 * [PROGRAMOWANIE W C++. KURS OD PODSTAW, DLA KAŻDEGO (VIDEO)](https://www.youtube.com/playlist?list=PLOYHgt8dIdoxx0Y5wzs7CFpmBzb40PaDo) - Mirosław Zelent, Damian Stelmach
 
 
-### CSS
+### HTML and CSS
 
 * [Kurs CSS](http://www.kurshtmlcss.pl/kurs-css) (Netido Interactive Agency)
 * [Kurs CSS. Wygląd strony www - kaskadowe arkusze stylów - Pasja informatyki (VIDEO)](https://www.youtube.com/playlist?list=PLOYHgt8dIdow6b2Qm3aTJbKT2BPo5iybv) - Mirosław Zelent, Damian Stelmach
-
-
-### HTML
-
 * [Kurs HTML](http://www.kurshtmlcss.pl/kurs-html) (Netido Interactive Agency)
 * [Kurs HTML](https://www.youtube.com/playlist?list=PLpwxuvBp359NntV2cLO5LaH6tmd6efmHH)
 * [Kurs HTML - od zera do Webmastera](https://www.youtube.com/playlist?list=PL0zYPqHK5yJWsIn3PIproSyxO3nchPd99)

--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -4,7 +4,6 @@
 * [C](#c)
 * [C#](#csharp)
 * [C++](#cpp)
-* [CSS](#css)
 * [Dart](#dart)
 * [Database](#database)
 * [Delphi](#delphi)
@@ -13,7 +12,7 @@
 * [Go](#go)
 * [Gulp](#gulp)
 * [Haskell](#haskell)
-* [HTML](#html)
+* [HTML and CSS](#html-and-css)
 * [IDE](#ide)
 * [Ionic](#ionic)
 * [Java](#java)
@@ -70,12 +69,6 @@
 * [Curso de C++ - A linguagem de programação fundamental para quem quer ser um programador](https://www.youtube.com/playlist?list=PLx4x_zx8csUjczg1qPHavU1vw1IkBcm40) - Canal Fessor Bruno (CFBCursos)
 
 
-### CSS
-
-* [Introdução à linguagem CSS](https://www.udemy.com/introducao-a-linguagem-css/) - Diego Mariano (Udemy)
-* [Novo curso HTML5 e CSS3: 100% atual](https://www.youtube.com/playlist?list=PLHz_AreHm4dkZ9-atkcmcBaMZdmLHft8n) - Gustavo Guanabara (Curso em Vídeo)
-
-
 ### Dart
 
 * [Curso de Dart Lang](https://www.udemy.com/curso-de-dart-lang-completo/) - Sthefane Soares (Udemy)
@@ -126,8 +119,9 @@
 * [Curso Haskell para Iniciantes](https://www.udemy.com/curso-haskell/) - Marcos Castro (Udemy)
 
 
-### HTML
+### HTML and CSS
 
+* [Introdução à linguagem CSS](https://www.udemy.com/introducao-a-linguagem-css/) - Diego Mariano (Udemy)
 * [Introdução à Linguagem HTML](https://www.udemy.com/introducao-a-linguagem-html/) - Diego Mariano (Udemy)
 * [Novo curso HTML5 e CSS3: 100% atual](https://www.youtube.com/playlist?list=PLHz_AreHm4dkZ9-atkcmcBaMZdmLHft8n) - Gustavo Guanabara (Curso em Vídeo)
 

--- a/courses/free-courses-ru.md
+++ b/courses/free-courses-ru.md
@@ -3,11 +3,10 @@
 * [Дизайн и Aрхитектура](#design-architecture)
 * [C++](#cpp)
 * [Clojure](#clojure)
-* [CSS](#css)
 * [Dart](#dart)
 * [Go](#go)
 * [Haskell](#haskell)
-* [HTML](#html)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [Node.js](#nodejs)
@@ -50,11 +49,6 @@ ADV - Продвинутый. Тонкости.
 * [Курс Clojure](https://clojurecourse.by) (BEG)
 
 
-### CSS
-
-* [CSS для начинающих](https://ru.code-basics.com/languages/css) (BEG)
-
-
 ### Dart
 
 * [Основы Dart](https://stepik.org/course/92982) - Анна Музыкина (Stepik) (BEG)
@@ -73,8 +67,9 @@ ADV - Продвинутый. Тонкости.
 * [Функциональное программирование на языке Haskell (часть 2)](https://stepik.org/course/693) - Stepik (ADV)
 
 
-### HTML
+### HTML and CSS
 
+* [CSS для начинающих](https://ru.code-basics.com/languages/css) (BEG)
 * [HTML для начинающих](https://ru.code-basics.com/languages/html) (BEG)
 
 

--- a/courses/free-courses-si.md
+++ b/courses/free-courses-si.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [ASP.NET Core](#aspnet_core)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [React](#react)
@@ -12,7 +12,7 @@
 * [WEB API-ASP.NET Core in Sinhala](https://youtube.com/playlist?list=PLvvtf05eMZ2CpeAsq93DqWJHHyvCSa2Qn) - Fiqri Ismail (YouTube)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [HTML සිංහලෙන්](https://youtube.com/playlist?list=PLWAgeLqk4SjDlN6nHs91rECgx4PbzfoZh) - SL Geek School (YouTube)
 
@@ -30,4 +30,3 @@
 #### React
 
 * [Fundamentals \| React JS in Sinhala](https://youtube.com/playlist?list=PLvvtf05eMZ2DpDyWwmAjEuicvVxx4vIYB) - Fiqri Ismail (YouTube)
-

--- a/courses/free-courses-tr.md
+++ b/courses/free-courses-tr.md
@@ -1,7 +1,7 @@
 ### Index
 
 * [Algoritmalar](#algoritmalar)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [IDE / Editors](#ide--editors)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -16,7 +16,7 @@
 * [Algoritmalara giriş](https://acikders.tuba.gov.tr/course/view.php?id=133) - Charles Leiserson / Erik Demaine (Çev. Ali Yazıcı - Haluk Ar)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [Bootstrap Eğitim Serisi](https://youtube.com/playlist?list=PLGrTHqyRDvx5ZUs7h8mfGACFpnVipTNkA) - Hakan Yalçınkaya \| Kodluyoruz
 * [CSS Eğitim Serisi](https://youtube.com/playlist?list=PLGrTHqyRDvx501K3-IMgS1fz-KfEB37gM) - Hakan Yalçınkaya \| Kodluyoruz

--- a/courses/free-courses-vi.md
+++ b/courses/free-courses-vi.md
@@ -8,10 +8,9 @@
 * [C](#c)
 * [C#](#csharp)
 * [Cấu trúc dữ liệu và Giải thuật](#cautrucdulieuvagiaithuat)
-* [CSS](#css)
 * [Git](#git)
 * [Go](#go)
-* [HTML](#html)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
   * [AngularJS](#angularjs)
@@ -98,12 +97,6 @@
 * [Lập trình ứng dụng Lập Lịch với C# Winform](https://www.youtube.com/playlist?list=PL33lvabfss1zfGzpSGQN7CUoHKS6OQbJc) - Kteam
 
 
-### CSS
-
-* [CSS Cơ Bản](https://www.codehub.com.vn/CSS-Co-Ban)
-* [CSS Cơ Bản](https://www.youtube.com/playlist?list=PLl4nkmb3a8w1cnIhegAj5_mE8w_mbYvY4) - Thạch Phạm
-
-
 ### Cấu trúc dữ liệu và Giải thuật
 
 * [Cấu trúc dữ liệu và Giải thuật](https://www.youtube.com/playlist?list=PLoaAbmGPgTSNMAzkKBHkh2mLuBk54II5L) - Ông Dev
@@ -122,8 +115,10 @@
 * [Lập trình Golang](https://www.youtube.com/playlist?list=PLVDJsRQrTUz5icsxSfKdymhghOtLNFn-k) - Code4Func
 
 
-### HTML
+### HTML and CSS
 
+* [CSS Cơ Bản](https://www.codehub.com.vn/CSS-Co-Ban)
+* [CSS Cơ Bản](https://www.youtube.com/playlist?list=PLl4nkmb3a8w1cnIhegAj5_mE8w_mbYvY4) - Thạch Phạm
 * [HTML Cơ Bản](https://www.codehub.com.vn/HTML-Co-Ban)
 * [HTML Cơ Bản](https://www.youtube.com/playlist?list=PLl4nkmb3a8w135_M4YRPzYD9_6tERz3ce) - Thạch Phạm
 

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -11,7 +11,7 @@
 * [Docker](#docker)
 * [Git](#git)
 * [Go](#go)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [IDE / Editors](#ide--editors)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -125,7 +125,7 @@
 * [Go Cheatsheet](https://devhints.io/go) - devhints, Rico Santa Cruz (HTML)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [CSS CheatSheet](https://htmlcheatsheet.com/css/) (HTML)
 * [CSS Flexbox Cheatsheet](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) - Chris Coyier (HTML)

--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -16,7 +16,7 @@
 * [GLSL](#glsl)
 * [Go](#go)
 * [Haskell](#haskell)
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
   * [Bootstrap](#bootstrap)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -156,7 +156,7 @@
 * [Try Haskell!](http://tryhaskell.org)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [CSS Diner](http://flukeout.github.io)
 * [CSS Speedrun \| Test your CSS Skills](https://css-speedrun.netlify.app) - Vincent Will (HTML)

--- a/more/free-programming-interactive-tutorials-ja.md
+++ b/more/free-programming-interactive-tutorials-ja.md
@@ -1,12 +1,12 @@
 ### Index
 
-* [HTML / CSS](#html--css)
+* [HTML and CSS](#html-and-css)
 * [JavaScript](#javascript)
   * [React](#react)
 * [Python](#python)
 
 
-### HTML / CSS
+### HTML and CSS
 
 * [レスポンシブウェブデザイン](https://www.freecodecamp.org/japanese/learn/responsive-web-design) - freeCodeCamp
 

--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -7,7 +7,6 @@
 * [C++](#cpp)
 * [ClojureScript](#clojurescript)
 * [Crystal](#crystal)
-* [CSS](#css)
 * [Dart](#dart)
 * [Docker](#docker)
 * [Elm](#elm)
@@ -16,6 +15,7 @@
 * [Git](#git)
 * [Go](#go)
 * [Haskell](#haskell)
+* [HTML and CSS](#html-and-css)
 * [Ionic](#ionic)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -93,15 +93,6 @@
 * [Compile & run code in Crystal](https://play.crystal-lang.org/#/cr)
 
 
-### CSS
-
-* [CodePen](https://codepen.io)
-* [CSSdeck](https://cssdeck.com)
-* [Dabblet](https://dabblet.com)
-* [Flexy Boxes](https://the-echoplex.net/flexyboxes/)
-* [SoloLearn](https://code.sololearn.com/web#css)
-
-
 ### Dart
 
 * [DartPad](https://dartpad.dev)
@@ -144,6 +135,15 @@
 ### Haskell
 
 * [Try Haskell](https://www.tryhaskell.org)
+
+
+### HTML and CSS
+
+* [CodePen](https://codepen.io)
+* [CSSdeck](https://cssdeck.com)
+* [Dabblet](https://dabblet.com)
+* [Flexy Boxes](https://the-echoplex.net/flexyboxes/)
+* [SoloLearn](https://code.sololearn.com/web#css)
 
 
 ### Ionic


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

### Why is this valuable (or not)?

- Merge HTML and CSS categories. Some duplicated resources were found and then ignoring it
- In those that are already merged, homogenize section title to `HTML and CSS`, the most currently common form
- Handling #4579 

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
