### PR TITLE
fix(books): free-programming-books-fa_IR broken link

### DIFF
--- a/books/free-programming-books-fa_IR.md
+++ b/books/free-programming-books-fa_IR.md
@@ -63,7 +63,7 @@
 
 #### Symfony
 
-* [سیمفونی ۵: سریع‌ترین مسیر](https://symfony.com/doc/current/the-fast-track/fa/index.html)
+* [سیمفونی ۵: سریع‌ترین مسیر](https://web.archive.org/web/20210122133755/https://symfony.com/doc/current/the-fast-track/fa/index.html) *(:card_file_box: archived)*
 
 
 ### Python


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Solved a problem of #6942.
`1. [L23]  http://networksciencebook.com/` works

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Put lists in alphabetical order, correct spacing.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
