### PR TITLE
Adding Pascal

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -150,6 +150,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [OpenMP](#openmp)
 * [OpenResty](#openresty)
 * [OpenSCAD](#openscad)
+* [Pascal](#pascal)
 * [Perl](#perl)
 * [PHP](#php)
   * [CakePHP](#cakephp)
@@ -1652,6 +1653,18 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 * [TrueOS® Users Handbook](https://www.trueos.org/handbook/trueos.html)
 
+
+### Pascal
+
+* [Free Pascal Reference guide](https://www.freepascal.org/docs-html/ref/ref.html)
+* [Pascal Quick Reference](https://ksvi.mff.cuni.cz/~dingle/2017/pascal_reference.html)
+* [Pascal Language Reference](https://docs.oracle.com/cd/E19957-01/802-5762/802-5762.pdf)
+* [VSI Pascal for OpenVMS Reference Manual](https://vmssoftware.com/docs/VSI_PASCAL_REF.pdf)
+* [Modern Object Pascal Introduction for Programmers](https://castle-engine.io/modern_pascal_introduction.html)
+* [Pascal Programming Reference Manual](https://public.support.unisys.com/aseries/docs/clearpath-mcp-17.0/pdf/86000080-103.pdf)
+* [Turbo Pascal Reference Guide](http://bitsavers.org/pdf/borland/turbo_pascal/Turbo_Pascal_Version_5.0_Reference_Guide_1989.pdf)
+* [Vector Pascal Reference Manual](https://www.researchgate.net/publication/220177664_Vector_Pascal_reference_manual)
+* [Vector Pascal, an Array Language](http://www.dcs.gla.ac.uk/~wpc/reports/compilers/compilerindex/vp-ver2.html)
 
 ### Perl
 


### PR DESCRIPTION
Adding Pascal references

## What does this PR do?
Add Pascal to the list

## For resources
### Description
Adding Pascal language and related references

### Why is this valuable (or not)?
Pascal is not listed in the current list of programming languages

### How do we know it's really free?
The links are currently free and available for access - I checked using proxies as well as other methods to verify the websites are able to be accessed.

### For book lists, is it a book? For course lists, is it a course? etc.
Book and reference list

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
