### PR TITLE
PULL_REQUEST_TEMPLATE: add clause for informative pr names

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,11 +11,12 @@ Add resource(s) | Remove resource(s) | Add info | Improve repo
 ### For book lists, is it a book? For course lists, is it a course? etc.
 
 ## Checklist:
-- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
+- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
 - [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
 - [ ] Include author(s) and platform where appropriate.
 - [ ] Put lists in alphabetical order, correct spacing.
-- [ ] Add needed indications (PDF, access notes, under construction)
+- [ ] Add needed indications (PDF, access notes, under construction).
+- [ ] Used an informative name for this pull request.
 
 ## Follow-up
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Add a clause which encourages users to name there PR in an informative way rather than things such as "add a book"  


## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md)
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
