### PR TITLE
change upper case to lower cas in fragment ids

### DIFF
--- a/books/free-programming-books-az.md
+++ b/books/free-programming-books-az.md
@@ -3,7 +3,7 @@
 * [C](#c)
 * [HTML and CSS](#html-and-css)
 * [JavaScript](#javascript)
-* [Linux](#Linux)
+* [Linux](#linux)
 * [PHP](#php)
 
 

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -46,7 +46,7 @@
 * [SPIP](#spip)
 * [SQL](#sql)
 * [Systèmes d'exploitation](#systemes-d-exploitation)
-* [TEI](#TEI)
+* [TEI](#tei)
 * [Vim](#vim)
 
 

--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -2,7 +2,7 @@
 
 * [Amazon Web Service](#amazon-web-service)
 * [Assembly Language](#assembly-language)
-* [AWK](#AWK)
+* [AWK](#awk)
 * [C](#c)
 * [C++](#cpp)
 * [Docker](#docker)
@@ -29,9 +29,9 @@
 * [Ruby](#ruby)
 * [Rust](#rust)
 * [Scratch](#scratch)
-* [Sed](#Sed)
+* [Sed](#sed)
 * [Software Engineering](#software-engineering)
-* [Springboot](#Springboot)
+* [Springboot](#springboot)
 * [Unicode](#unicode)
 
 

--- a/books/free-programming-books-ta.md
+++ b/books/free-programming-books-ta.md
@@ -1,14 +1,14 @@
 ## Index
 
-* [Big Data](#BigData)
-* [Database](#Database)
+* [Big Data](#bigdata)
+* [Database](#database)
 * [HTML and CSS](#html-and-css)
-* [JavaScript](#Javascript)
-* [Machine Learning](#MachineLearning)
-* [MySQL](#MySQL)
-* [PHP](#PHP)
-* [Ruby](#Ruby)
-* [Selenium](#Selenium)
+* [JavaScript](#javascript)
+* [Machine Learning](#machine-learning)
+* [MySQL](#mysql)
+* [PHP](#php)
+* [Ruby](#ruby)
+* [Selenium](#selenium)
 
 
 ### BigData

--- a/courses/free-courses-hi.md
+++ b/courses/free-courses-hi.md
@@ -1,8 +1,8 @@
 ### Index
 
 * [Algorithms](#algo)
-* [Android](#Android)
-* [C](#C)
+* [Android](#android)
+* [C](#c)
 * [C++](#cpp)
 * [Data Structures](#data-structures)
 * [DevOps](#devops)

--- a/courses/free-courses-ru.md
+++ b/courses/free-courses-ru.md
@@ -17,7 +17,7 @@
 * [PHP](#php)
 * [PostgreSQL](#postgresql)
 * [Python](#python)
-* [R](#R)
+* [R](#r)
 * [Ruby](#ruby)
 
 

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -20,7 +20,7 @@
     * [Nuxt.js](#nuxtjs)
     * [React.js](#reactjs)
     * [Vue.js](#vuejs)
-* [Kotlin](#Kotlin)
+* [Kotlin](#kotlin)
 * [Kubernetes](#kubernetes)
 * [Language Translations](#language-translations)
 * [Markdown](#markdown)


### PR DESCRIPTION
## What does this PR do?
the Markdown processor  creates ids for hearding by changing to lower case, changing space to dash, and removing other characters. This PR fixes index links that use capital letters. note- caps are ok in hex-escaped fragments