### PR TITLE
Add "Qt6 QML Book" by Johan Thelin, Jürgen Bocklage-Ryannel, Cyril Lorquet (HTML, PDF)

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2005,7 +2005,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 ### QML
 
 * [Qt5 Cadaques](http://qmlbook.github.io) - Juergen Bocklage-Ryannel and Johan Thelin (HTML, PDF, ePub) (:construction: *in process*)
-* [Qt6 Book](https://www.qt.io/product/qt6/qml-book/preface-preface) - Johan Thelin, Jürgen Bocklage-Ryannel, Cyril Lorquet (HTML) [(PDF)](https://www.qt.io/hubfs/_website/QML%20Book/qt6book-with-frontpage.pdf) (:construction: *in process*)
+* [Qt6 Book](https://www.qt.io/product/qt6/qml-book/preface-preface) - Johan Thelin, Jürgen Bocklage-Ryannel, Cyril Lorquet (HTML) (:construction: *in process*)
 
 
 ### R

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2005,6 +2005,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 ### QML
 
 * [Qt5 Cadaques](http://qmlbook.github.io) - Juergen Bocklage-Ryannel and Johan Thelin (HTML, PDF, ePub) (:construction: *in process*)
+* [Qt6 Book](https://www.qt.io/product/qt6/qml-book/preface-preface) - Johan Thelin, Jürgen Bocklage-Ryannel, Cyril Lorquet (HTML) [(PDF)](https://www.qt.io/hubfs/_website/QML%20Book/qt6book-with-frontpage.pdf) (:construction: *in process*)
 
 
 ### R

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2005,7 +2005,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 ### QML
 
 * [Qt5 Cadaques](http://qmlbook.github.io) - Juergen Bocklage-Ryannel and Johan Thelin (HTML, PDF, ePub) (:construction: *in process*)
-* [Qt6 Book](https://www.qt.io/product/qt6/qml-book/preface-preface) - Johan Thelin, Jürgen Bocklage-Ryannel, Cyril Lorquet (HTML) (:construction: *in process*)
+* [Qt6 Book](https://www.qt.io/product/qt6/qml-book/preface-preface) - Johan Thelin, Jürgen Bocklage-Ryannel, Cyril Lorquet (HTML, PDF) (:construction: *in process*)
 
 
 ### R


### PR DESCRIPTION
## What does this PR do?
Add resources

## For resources
https://www.qt.io/product/qt6/qml-book/preface-preface - HTML
https://www.qt.io/hubfs/_website/QML%20Book/qt6book-with-frontpage.pdf - PDF

### Description
Add QML Book (Qt6) as book resource to "by language" QML section

### Why is this valuable (or not)?
See https://www.qt.io/product/qt6/qml-book/preface-preface#welcome

### How do we know it's really free?
It's released under [Attribution-NonCommercial-ShareAlike 4.0](https://github.com/qmlbook/qt6book/blob/main/LICENSE.text) license and available on github

### For book lists, is it a book? For course lists, is it a course? etc.
It's a book

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
