### PR TITLE
ci(stale): create `stale.yml` workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,8 +25,8 @@ jobs:
       cancel-in-progress: false
     # export variables used by reporter job
     outputs:
-      staled-issues: ${{ steps.staler.outputs.staled-issues-prs }}
-      closed-issues: ${{ steps.staler.outputs.closed-issues-prs }}
+      staled-issues: ${{ steps.stale.outputs.staled-issues-prs }}
+      closed-issues: ${{ steps.stale.outputs.closed-issues-prs }}
     # enable write access rights to allow comment and labeling by bot
     permissions:
       issues: write
@@ -55,6 +55,21 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
+      - name: Set outputs
+        ## Removing private properties from each JSON object.
+        ## TODO: Remove this ugly fix for actions/stale#806
+        id: stale
+        run: |
+          echo $STALED  \
+            | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
+            | sed -e 's/^/::set-output name=staled-issues-prs::/'
+          echo $CLOSED  \
+            | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
+            | sed -e 's/^/::set-output name=closed-issues-prs::/'
+        env:
+          STALED: ${{ steps.staler.outputs.staled-issues-prs }}
+          CLOSED: ${{ steps.staler.outputs.closed-issues-prs }}
+
 
   process-prs:
     name: Process Pull Requests
@@ -64,8 +79,8 @@ jobs:
       cancel-in-progress: false
     # export variables used by reporter job
     outputs:
-      staled-prs: ${{ steps.staler.outputs.staled-issues-prs }}
-      closed-prs: ${{ steps.staler.outputs.closed-issues-prs }}
+      staled-prs: ${{ steps.stale.outputs.staled-issues-prs }}
+      closed-prs: ${{ steps.stale.outputs.closed-issues-prs }}
     # enable write access rights to allow comment and labeling by bot
     permissions:
       pull-requests: write
@@ -94,6 +109,21 @@ jobs:
           exempt-draft-pr: true
           days-before-issue-stale: -1
           days-before-issue-close: -1
+
+      - name: Set outputs
+        ## Removing private properties from each JSON object.
+        ## TODO: Remove this ugly fix for actions/stale#806
+        id: stale
+        run: |
+          echo $STALED  \
+            | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
+            | sed -e 's/^/::set-output name=staled-issues-prs::/'
+          echo $CLOSED  \
+            | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
+            | sed -e 's/^/::set-output name=closed-issues-prs::/'
+        env:
+          STALED: ${{ steps.staler.outputs.staled-issues-prs }}
+          CLOSED: ${{ steps.staler.outputs.closed-issues-prs }}
 
 
   reporter:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,12 +28,12 @@ jobs:
       - uses: actions/stale@v5
         with:
           operations-per-run: 30
-          days-before-issue-stale: 30
-          days-before-issue-close: 7
+          days-before-issue-stale: 60
+          days-before-issue-close: 30
           stale-issue-label: "stale"
           close-issue-label: "stale: closed"
-          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
           remove-issue-stale-when-updated: true
           exempt-issue-labels: "👥 discussion,👀 Needs Review,📌 pinned"
           days-before-pr-stale: -1
@@ -51,12 +51,12 @@ jobs:
       - uses: actions/stale@v5
         with:
           operations-per-run: 30
-          days-before-pr-stale: 30
-          days-before-pr-close: 7
+          days-before-pr-stale: 60
+          days-before-pr-close: 30
           stale-pr-label: "stale"
           close-pr-label: "stale: closed"
-          stale-pr-message: "This pull request is stale because it has been open for 30 days with no activity."
-          close-pr-message: "This pull request was closed because it has been inactive for 7 days since being marked as stale."
+          stale-pr-message: "This pull request is stale because it has been open for 60 days with no activity."
+          close-pr-message: "This pull request was closed because it has been inactive for 30 days since being marked as stale."
           remove-pr-stale-when-updated: true
           exempt-pr-labels: "👥 discussion,👀 Needs Review"
           exempt-draft-pr: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,105 @@
+name: Stale and close inactive issues/PRs
+
+on:
+  schedule:
+    - cron: "30 1 * * *"  # each day at 1:30AM
+  workflow_dispatch:      # or manually
+
+permissions:
+  issues: read
+  pull-requests: read
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref || github.run_id }}'
+  cancel-in-progress: true
+
+jobs:
+
+  process-issues:
+    name: Process Issues
+
+    permissions:
+      issues: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          operations-per-run: 30
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          close-issue-label: "stale: closed"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          remove-issue-stale-when-updated: true
+          exempt-issue-labels: "👥 discussion,👀 Needs Review,📌 pinned"
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+  process-prs:
+    name: Process Pull Requests
+
+    permissions:
+      pull-requests: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          operations-per-run: 30
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          close-pr-label: "stale: closed"
+          stale-pr-message: "This pull request is stale because it has been open for 30 days with no activity."
+          close-pr-message: "This pull request was closed because it has been inactive for 7 days since being marked as stale."
+          remove-pr-stale-when-updated: true
+          exempt-pr-labels: "👥 discussion,👀 Needs Review"
+          exempt-draft-pr: true
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+  generate-summary:
+    name: GitHub report
+
+    needs: [process-issues, process-prs]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          echo "### Staled issues"  \
+            >> $GITHUB_STEP_SUMMARY
+          echo "$STALED_ISSUES"  \
+            | jq --raw-output 'map("* [#\(.number)](\(env.GITHUB_ISSUES_URL)/\(.number)): \(.title)") | join("\n")'  \
+            >> $GITHUB_STEP_SUMMARY
+
+          echo "### Staled pull requests"  \
+            >> $GITHUB_STEP_SUMMARY
+          echo "$STALED_PRS"  \
+            | jq --raw-output 'map("* [#\(.number)](\(env.GITHUB_PULL_URL)/\(.number)): \(.title)") | join("\n")'  \
+            >> $GITHUB_STEP_SUMMARY
+
+          echo "### Closed issues"  \
+            >> $GITHUB_STEP_SUMMARY
+          echo "$CLOSED_ISSUES"  \
+            | jq --raw-output 'map("* [#\(.number)](\(env.GITHUB_ISSUES_URL)/\(.number)): \(.title)") | join("\n")'  \
+            >> $GITHUB_STEP_SUMMARY
+
+          echo "### Closed pull requests"  \
+            >> $GITHUB_STEP_SUMMARY
+          echo "$CLOSED_PRS"  \
+            | jq --raw-output 'map("* [#\(.number)](\(env.GITHUB_PULL_URL)/\(.number)): \(.title)") | join("\n")'  \
+            >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_REPO_URL:   ${{ format('{0}/{1}', github.server_url, github.repository) }}
+          GITHUB_ISSUES_URL: ${{ format('{0}/{1}/issues', github.server_url, github.repository) }}
+          GITHUB_PULL_URL:   ${{ format('{0}/{1}/pull', github.server_url, github.repository) }}
+          STALED_ISSUES: ${{ needs.process-issues.outputs.staled-issues-prs }}
+          CLOSED_ISSUES: ${{ needs.process-issues.outputs.closed-issues-prs }}
+          STALED_PRS:    ${{ needs.process-prs.outputs.staled-issues-prs }}
+          CLOSED_PRS:    ${{ needs.process-prs.outputs.closed-issues-prs }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,8 @@ name: Stale and close inactive issues/PRs
 
 on:
   schedule:
-    - cron: "30 1 * * *"  # each day at 1:30AM
-  workflow_dispatch:      # or manually
+    - cron: "0 0,6,12,18 * * *"  # every 6 hours o'clock... 0:00am 6:00am 12:00pm 18:00pm
+  workflow_dispatch:             # or manually
 
 permissions:
   issues: read
@@ -39,6 +39,7 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
+
   process-prs:
     name: Process Pull Requests
 
@@ -63,8 +64,9 @@ jobs:
           days-before-issue-stale: -1
           days-before-issue-close: -1
 
-  generate-summary:
-    name: GitHub report
+
+  reporter:
+    name: GitHub reporter
 
     needs: [process-issues, process-prs]
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5
+        id: staler
         with:
           operations-per-run: 30
           days-before-issue-stale: 60
@@ -71,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5
+        id: staler
         with:
           operations-per-run: 30
           days-before-pr-stale: 60
@@ -127,7 +129,7 @@ jobs:
           GITHUB_REPO_URL:   ${{ format('{0}/{1}', github.server_url, github.repository) }}
           GITHUB_ISSUES_URL: ${{ format('{0}/{1}/issues', github.server_url, github.repository) }}
           GITHUB_PULL_URL:   ${{ format('{0}/{1}/pull', github.server_url, github.repository) }}
-          STALED_ISSUES: ${{ needs.process-issues.outputs.staled-issues-prs }}
-          CLOSED_ISSUES: ${{ needs.process-issues.outputs.closed-issues-prs }}
-          STALED_PRS:    ${{ needs.process-prs.outputs.staled-issues-prs }}
-          CLOSED_PRS:    ${{ needs.process-prs.outputs.closed-issues-prs }}
+          STALED_ISSUES: ${{ needs.process-issues.outputs.staled-issues }}
+          CLOSED_ISSUES: ${{ needs.process-issues.outputs.closed-issues }}
+          STALED_PRS:    ${{ needs.process-prs.outputs.staled-prs }}
+          CLOSED_PRS:    ${{ needs.process-prs.outputs.closed-prs }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ on:
         required: true
         default: true
   schedule:                           # or
-    - cron: "0 0,6,12,18 * * *"       # every 6 hours at o'clock
+    - cron: "0 0 * * *"               # once a day at 00:00 o'clock
 
 permissions:
   # no checkout/branching needed

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:             # or manually
 
 permissions:
+  contents: none
   issues: read
   pull-requests: read
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,8 @@ name: Stale and close inactive issues/PRs
 
 on:
   schedule:
-    - cron: "0 0,6,12,18 * * *"  # every 6 hours o'clock... 0:00am 6:00am 12:00pm 18:00pm
-  workflow_dispatch:             # or manually
+    - cron: "0 0-23 * * *"  # every 1 hour at o'clock
+  workflow_dispatch:        # or manually
 
 permissions:
   contents: none

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,13 +11,22 @@ permissions:
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref || github.run_id }}'
+  group: '${{ github.workflow }} @ ${{ github.run_id }}'
   cancel-in-progress: true
 
 jobs:
 
   process-issues:
     name: Process Issues
+
+    # This allows a subsequently queued workflow run to wait for previous runs completion
+    concurrency:
+      group: '${{ github.workflow }} @ ${{ github.run_id }} :: issues'
+      cancel-in-progress: false
+
+    outputs:
+      staled-issues: ${{ steps.staler.outputs.staled-issues-prs }}
+      closed-issues: ${{ steps.staler.outputs.closed-issues-prs }}
 
     permissions:
       issues: write
@@ -50,6 +59,15 @@ jobs:
 
   process-prs:
     name: Process Pull Requests
+
+    # This allows a subsequently queued workflow run to wait for previous runs completion
+    concurrency:
+      group: '${{ github.workflow }} @ ${{ github.run_id }} :: PRs'
+      cancel-in-progress: false
+
+    outputs:
+      staled-prs: ${{ steps.staler.outputs.staled-issues-prs }}
+      closed-prs: ${{ steps.staler.outputs.closed-issues-prs }}
 
     permissions:
       pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -50,7 +50,7 @@ jobs:
 
             Anyway, thank you for your contributions.
           remove-issue-stale-when-updated: true
-          exempt-issue-labels: "👥 discussion,👀 Needs Review,📌 pinned"
+          exempt-issue-labels: "blocked,must,should,keep,👥 discussion,👀 Needs Review,📌 pinned"
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
@@ -88,7 +88,7 @@ jobs:
 
             Anyway, thank you for your contributions.
           remove-pr-stale-when-updated: true
-          exempt-pr-labels: "👥 discussion,👀 Needs Review"
+          exempt-pr-labels: "blocked,must,should,keep,👥 discussion,👀 Needs Review"
           exempt-draft-pr: true
           days-before-issue-stale: -1
           days-before-issue-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,8 +32,16 @@ jobs:
           days-before-issue-close: 30
           stale-issue-label: "stale"
           close-issue-label: "stale: closed"
-          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had activity during the last 60 days.
+
+            It will be closed if no further activity occurs on the next 30 days.
+
+            Thank you for your contributions.
+          close-issue-message: |
+            This issue has been automatically closed because it has been inactive during the last 30 days since being marked as stale.
+
+            Anyway, thank you for your contributions.
           remove-issue-stale-when-updated: true
           exempt-issue-labels: "👥 discussion,👀 Needs Review,📌 pinned"
           days-before-pr-stale: -1
@@ -56,8 +64,16 @@ jobs:
           days-before-pr-close: 30
           stale-pr-label: "stale"
           close-pr-label: "stale: closed"
-          stale-pr-message: "This pull request is stale because it has been open for 60 days with no activity."
-          close-pr-message: "This pull request was closed because it has been inactive for 30 days since being marked as stale."
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had activity during the last 60 days.
+
+            It will be closed if no further activity occurs on the next 30 days.
+
+            Thank you for your contributions.
+          close-pr-message: |
+            This pull request has been automatically closed because it has been inactive during the last 30 days since being marked as stale.
+
+            Anyway, thank you for your contributions.
           remove-pr-stale-when-updated: true
           exempt-pr-labels: "👥 discussion,👀 Needs Review"
           exempt-draft-pr: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,8 @@ name: Stale and close inactive issues/PRs
 
 on:
   schedule:
-    - cron: "0 0-23 * * *"  # every 1 hour at o'clock
-  workflow_dispatch:        # or manually
+    - cron: "0 0,6,12,18 * * *"  # every 6 hours at o'clock
+  workflow_dispatch:             # or manually
 
 permissions:
   contents: none

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,165 +1,201 @@
-name: Stale and close inactive issues/PRs
+name: Stale handler
 
 on:
-  schedule:
-    - cron: "0 0,6,12,18 * * *"  # every 6 hours at o'clock
-  workflow_dispatch:             # or manually
+  push:                               # when push this files to branches....
+    branches:
+      - 'main'
+      - 'gh-actions/test'
+    paths:
+      - '.github/workflows/stale.yml' #    - this workflow
+  workflow_dispatch:                  # manually
+    inputs:
+      debug-only:
+        type: boolean
+        description: 'If enabled, debug mode is on and then API calls that can alter your issues will not happen'
+        required: true
+        default: true
+  schedule:                           # or
+    - cron: "0 0,6,12,18 * * *"       # every 6 hours at o'clock
 
 permissions:
+  # no checkout/branching needed
   contents: none
-  issues: read
-  pull-requests: read
 
-# This allows a subsequently queued workflow run to interrupt previous runs
+# This allows a subsequently queued workflow run to interrupt/wait for previous runs
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.run_id }}'
-  cancel-in-progress: true
+  group: '${{ github.workflow }}'
+  cancel-in-progress: false  # true: interrupt, false = wait for
 
 jobs:
-
-  process-issues:
-    name: Process Issues
-    # This allows a subsequently queued workflow run to wait for previous runs completion
-    concurrency:
-      group: '${{ github.workflow }} @ ${{ github.run_id }} :: issues'
-      cancel-in-progress: false
-    # export variables used by reporter job
+  stale:
+    name: Staler job
+    runs-on: ubuntu-latest
     outputs:
-      staled-issues: ${{ steps.stale.outputs.staled-issues-prs }}
-      closed-issues: ${{ steps.stale.outputs.closed-issues-prs }}
-    # enable write access rights to allow comment and labeling by bot
+      # "XXX-len": the length of the "XXX" output object
+      staled-issues:     ${{ steps.set-staled.outputs.issues }}
+      staled-issues-len: ${{ steps.set-staled.outputs.issues-len }}
+      staled-prs:     ${{ steps.set-staled.outputs.prs }}
+      staled-prs-len: ${{ steps.set-staled.outputs.prs-len }}
+      closed-issues:     ${{ steps.set-closed.outputs.issues }}
+      closed-issues-len: ${{ steps.set-closed.outputs.issues-len }}
+      closed-prs:     ${{ steps.set-closed.outputs.prs }}
+      closed-prs-len: ${{ steps.set-closed.outputs.prs-len }}
+    # enable write access rights to allow bot comments and labeling
     permissions:
       issues: write
-    runs-on: ubuntu-latest
+      pull-requests: write
     steps:
-      - uses: actions/stale@v5
-        id: staler
+      - name: Stale issues
+        uses: actions/stale@v5
+        id: stale-issues
         with:
+          debug-only: ${{ github.event.inputs.debug-only == 'true' }}
           operations-per-run: 30
-          days-before-issue-stale: 60
-          days-before-issue-close: 30
+          days-before-stale: 60
+          days-before-close: 30
+          ignore-updates: false
+          remove-stale-when-updated: true
           stale-issue-label: "stale"
           close-issue-label: "stale: closed"
           stale-issue-message: |
-            This issue has been automatically marked as stale because it has not had activity during the last 60 days.
+            This issue has been automatically marked as stale because it has not had recent activity during last 60 days :sleeping:
 
-            It will be closed if no further activity occurs on the next 30 days.
+            It will be closed in 30 days if no further activity occurs. To unstale this issue, remove stale label or add a comment with a detailed explanation.
 
-            Thank you for your contributions.
+            There can be many reasons why some specific issue has no activity. The most probable cause is lack of time, not lack of interest.
+
+            Thank you for your patience :heart:
           close-issue-message: |
             This issue has been automatically closed because it has been inactive during the last 30 days since being marked as stale.
 
-            Anyway, thank you for your contributions.
-          remove-issue-stale-when-updated: true
+            As author or maintainer, it can always be reopened if you see that carry on been useful.
+
+            Anyway, thank you for your interest in contribute :heart:
+          close-issue-reason: not_planned
           exempt-issue-labels: "blocked,must,should,keep,:busts_in_silhouette: discussion,:eyes: Needs Review,:pushpin: pinned"
+          # disable PR processing at all (this step is for treat issues)
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          ignore-pr-updates: true
+          remove-pr-stale-when-updated: false
+          stale-pr-label: " "
 
-      - name: Set outputs
-        ## Removing private properties from each JSON object.
-        ## TODO: Remove this ugly fix for actions/stale#806
-        id: stale
-        run: |
-          echo $STALED  \
-            | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
-            | sed -e 's/^/::set-output name=staled-issues-prs::/'
-          echo $CLOSED  \
-            | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
-            | sed -e 's/^/::set-output name=closed-issues-prs::/'
-        env:
-          STALED: ${{ steps.staler.outputs.staled-issues-prs }}
-          CLOSED: ${{ steps.staler.outputs.closed-issues-prs }}
+      - name: Print outputs for issues
+        run: echo ${{ join(steps.stale-issues.outputs.*, ',') }}
 
-
-  process-prs:
-    name: Process Pull Requests
-    # This allows a subsequently queued workflow run to wait for previous runs completion
-    concurrency:
-      group: '${{ github.workflow }} @ ${{ github.run_id }} :: PRs'
-      cancel-in-progress: false
-    # export variables used by reporter job
-    outputs:
-      staled-prs: ${{ steps.stale.outputs.staled-issues-prs }}
-      closed-prs: ${{ steps.stale.outputs.closed-issues-prs }}
-    # enable write access rights to allow comment and labeling by bot
-    permissions:
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v5
-        id: staler
+      - name: Stale Pull Requests
+        uses: actions/stale@v5
+        id: stale-prs
         with:
+          debug-only: ${{ github.event.inputs.debug-only == 'true' }}
           operations-per-run: 30
-          days-before-pr-stale: 60
-          days-before-pr-close: 30
+          days-before-stale: 60
+          days-before-close: 30
+          ignore-updates: false
+          remove-stale-when-updated: true
           stale-pr-label: "stale"
           close-pr-label: "stale: closed"
           stale-pr-message: |
-            This pull request has been automatically marked as stale because it has not had activity during the last 60 days.
+            This Pull Request has been automatically marked as stale because it has not had recent activity during last 60 days :sleeping:
 
-            It will be closed if no further activity occurs on the next 30 days.
+            It will be closed in 30 days if no further activity occurs. To unstale this PR, draft it, remove stale label, comment with a detailed explanation or push more commits.
 
-            Thank you for your contributions.
+            There can be many reasons why some specific PR has no activity. The most probable cause is lack of time, not lack of interest.
+
+            Thank you for your patience :heart:
           close-pr-message: |
-            This pull request has been automatically closed because it has been inactive during the last 30 days since being marked as stale.
+            This Pull Request has been automatically closed because it has been inactive during the last 30 days since being marked as stale.
 
-            Anyway, thank you for your contributions.
-          remove-pr-stale-when-updated: true
-          exempt-pr-labels: "blocked,must,should,keep,:busts_in_silhouette: discussion,:eyes: Needs Review"
+            As author or maintainer, it can always be reopened if you see that carry on been useful.
+
+            Anyway, thank you for your interest in contribute :heart:
           exempt-draft-pr: true
+          exempt-pr-labels: "blocked,must,should,keep,:busts_in_silhouette: discussion,:eyes: Needs Review"
+          delete-branch: false  # if true, job needs permissions "contents: write"
+          # disable issues processing at all (this step is for treat PRs)
           days-before-issue-stale: -1
           days-before-issue-close: -1
+          ignore-issue-updates: true
+          remove-issue-stale-when-updated: false
+          stale-issue-label: " "
 
-      - name: Set outputs
-        ## Removing private properties from each JSON object.
-        ## TODO: Remove this ugly fix for actions/stale#806
-        id: stale
+      - name: Print outputs for PRs
+        run: echo ${{ join(steps.stale-prs.outputs.*, ',') }}
+
+      ## Removing private properties from each JSON object and compute array length
+      ## TODO: Delete these set-* workarounds when resolve actions/stale#806 ?
+      - name: Set staled
+        id: set-staled
         run: |
-          echo $STALED  \
+          echo $INPUT_ISSUES  \
             | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
-            | sed -e 's/^/::set-output name=staled-issues-prs::/'
-          echo $CLOSED  \
+            | sed -e 's/^/::set-output name=issues::/'
+          echo $INPUT_ISSUES  \
+            | jq --raw-output '. | length'  \
+            | sed -e 's/^/::set-output name=issues-len::/'
+
+          echo $INPUT_PRS  \
             | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
-            | sed -e 's/^/::set-output name=closed-issues-prs::/'
+            | sed -e 's/^/::set-output name=prs::/'
+          echo $INPUT_PRS  \
+            | jq --raw-output '. | length'  \
+            | sed -e 's/^/::set-output name=prs-len::/'
         env:
-          STALED: ${{ steps.staler.outputs.staled-issues-prs }}
-          CLOSED: ${{ steps.staler.outputs.closed-issues-prs }}
+          INPUT_ISSUES: ${{ steps.stale-issues.outputs.staled-issues-prs }}
+          INPUT_PRS:    ${{ steps.stale-prs.outputs.staled-issues-prs }}
+      - name: Set closed
+        id: set-closed
+        run: |
+          echo $INPUT_ISSUES  \
+            | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
+            | sed -e 's/^/::set-output name=issues::/'
+          echo $INPUT_ISSUES  \
+            | jq --raw-output '. | length'  \
+            | sed -e 's/^/::set-output name=issues-len::/'
 
+          echo $INPUT_PRS  \
+            | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
+            | sed -e 's/^/::set-output name=prs::/'
+          echo $INPUT_PRS  \
+            | jq --raw-output '. | length'  \
+            | sed -e 's/^/::set-output name=prs-len::/'
+        env:
+          INPUT_ISSUES: ${{ steps.stale-issues.outputs.closed-issues-prs }}
+          INPUT_PRS:    ${{ steps.stale-prs.outputs.closed-issues-prs }}
 
-  reporter:
-    name: GitHub reporter
-    needs: [process-issues, process-prs]
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
+      - name: Write job summary
+        run: |
           echo "### Staled issues"  \
             >> $GITHUB_STEP_SUMMARY
+          # render json array to a Markdown table with an optional "No records" message if empty
           echo "$STALED_ISSUES"  \
-            | jq --raw-output 'map("* [#\(.number)](\(env.GITHUB_ISSUES_URL)/\(.number)): \(.title)") | join("\n")'  \
+            | jq --raw-output 'map("| [#\(.number)](\(env.GITHUB_ISSUES_URL)/\(.number)) | \(.title) |") | join("\n") | if (. == "") then "\nNo records.\n" else "\n|    | Title |\n|---:|:------|\n\(.)\n" end'  \
             >> $GITHUB_STEP_SUMMARY
 
           echo "### Staled pull requests"  \
             >> $GITHUB_STEP_SUMMARY
+          # render json array to a Markdown table with an optional "No records" message if empty
           echo "$STALED_PRS"  \
-            | jq --raw-output 'map("* [#\(.number)](\(env.GITHUB_PULL_URL)/\(.number)): \(.title)") | join("\n")'  \
+            | jq --raw-output 'map("| [#\(.number)](\(env.GITHUB_PULL_URL)/\(.number)) | \(.title) |") | join("\n") | if (. == "") then "\nNo records.\n" else "\n|    | Title |\n|---:|:------|\n\(.)\n" end'  \
             >> $GITHUB_STEP_SUMMARY
 
           echo "### Closed issues"  \
             >> $GITHUB_STEP_SUMMARY
+          # render json array to a Markdown table with an optional "No records" message if empty
           echo "$CLOSED_ISSUES"  \
-            | jq --raw-output 'map("* [#\(.number)](\(env.GITHUB_ISSUES_URL)/\(.number)): \(.title)") | join("\n")'  \
+            | jq --raw-output 'map("| [#\(.number)](\(env.GITHUB_ISSUES_URL)/\(.number)) | \(.title) |") | join("\n") | if (. == "") then "\nNo records.\n" else "\n|    | Title |\n|---:|:------|\n\(.)\n" end'  \
             >> $GITHUB_STEP_SUMMARY
 
           echo "### Closed pull requests"  \
             >> $GITHUB_STEP_SUMMARY
+          # render json array to a Markdown table with an optional "No records" message if empty
           echo "$CLOSED_PRS"  \
-            | jq --raw-output 'map("* [#\(.number)](\(env.GITHUB_PULL_URL)/\(.number)): \(.title)") | join("\n")'  \
+            | jq --raw-output 'map("| [#\(.number)](\(env.GITHUB_PULL_URL)/\(.number)) | \(.title) |") | join("\n") | if (. == "") then "\nNo records.\n" else "\n|    | Title |\n|---:|:------|\n\(.)\n" end'  \
             >> $GITHUB_STEP_SUMMARY
         env:
-          GITHUB_REPO_URL:   ${{ format('{0}/{1}', github.server_url, github.repository) }}
           GITHUB_ISSUES_URL: ${{ format('{0}/{1}/issues', github.server_url, github.repository) }}
           GITHUB_PULL_URL:   ${{ format('{0}/{1}/pull', github.server_url, github.repository) }}
-          STALED_ISSUES: ${{ needs.process-issues.outputs.staled-issues }}
-          CLOSED_ISSUES: ${{ needs.process-issues.outputs.closed-issues }}
-          STALED_PRS:    ${{ needs.process-prs.outputs.staled-prs }}
-          CLOSED_PRS:    ${{ needs.process-prs.outputs.closed-prs }}
+          STALED_ISSUES: ${{ steps.set-staled.outputs.issues }}
+          CLOSED_ISSUES: ${{ steps.set-closed.outputs.issues }}
+          STALED_PRS:    ${{ steps.set-staled.outputs.prs }}
+          CLOSED_PRS:    ${{ steps.set-closed.outputs.prs }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -51,7 +51,7 @@ jobs:
 
             Anyway, thank you for your contributions.
           remove-issue-stale-when-updated: true
-          exempt-issue-labels: "blocked,must,should,keep,👥 discussion,👀 Needs Review,📌 pinned"
+          exempt-issue-labels: "blocked,must,should,keep,:busts_in_silhouette: discussion,:eyes: Needs Review,:pushpin: pinned"
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
@@ -105,7 +105,7 @@ jobs:
 
             Anyway, thank you for your contributions.
           remove-pr-stale-when-updated: true
-          exempt-pr-labels: "blocked,must,should,keep,👥 discussion,👀 Needs Review"
+          exempt-pr-labels: "blocked,must,should,keep,:busts_in_silhouette: discussion,:eyes: Needs Review"
           exempt-draft-pr: true
           days-before-issue-stale: -1
           days-before-issue-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,21 +18,18 @@ jobs:
 
   process-issues:
     name: Process Issues
-
     # This allows a subsequently queued workflow run to wait for previous runs completion
     concurrency:
       group: '${{ github.workflow }} @ ${{ github.run_id }} :: issues'
       cancel-in-progress: false
-
+    # export variables used by reporter job
     outputs:
       staled-issues: ${{ steps.staler.outputs.staled-issues-prs }}
       closed-issues: ${{ steps.staler.outputs.closed-issues-prs }}
-
+    # enable write access rights to allow comment and labeling by bot
     permissions:
       issues: write
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/stale@v5
         with:
@@ -59,21 +56,18 @@ jobs:
 
   process-prs:
     name: Process Pull Requests
-
     # This allows a subsequently queued workflow run to wait for previous runs completion
     concurrency:
       group: '${{ github.workflow }} @ ${{ github.run_id }} :: PRs'
       cancel-in-progress: false
-
+    # export variables used by reporter job
     outputs:
       staled-prs: ${{ steps.staler.outputs.staled-issues-prs }}
       closed-prs: ${{ steps.staler.outputs.closed-issues-prs }}
-
+    # enable write access rights to allow comment and labeling by bot
     permissions:
       pull-requests: write
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/stale@v5
         with:
@@ -101,11 +95,8 @@ jobs:
 
   reporter:
     name: GitHub reporter
-
     needs: [process-issues, process-prs]
-
     runs-on: ubuntu-latest
-
     steps:
       - run: |
           echo "### Staled issues"  \


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

- Developed using action: [`actions/stale`](https://github.com/actions/stale)
- requested at #7024 by @LuigiImVector 
- Treat issues and PRs ~separately and concurrently~ in serie using same job.
- At the end, a cross-linked summary with all processed issues/PRs is generated

Current Configuration:
- Run as ~diary~hourly cron or also manually
- ~30~ 60 days elapsed until stale
- ~7~ 30 days more to close that staled issue/PRs
- Each step is automanaged with labels: `stale`, `stale: closed`. Some exemptions like discussions, reviews or pinnings

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
