### PR TITLE
fix: `check-url` report crashes on empty changed files

### DIFF
--- a/.github/actions/awesomebot-gh-summary-action/action.yml
+++ b/.github/actions/awesomebot-gh-summary-action/action.yml
@@ -60,8 +60,18 @@ runs:
         # Loop ForEach files
         $env:INPUT_FILES -split $env:INPUT_SEPARATOR | ForEach {
           $file = $_
+          if ($file -match "\s+" ) {
+            continue # is empty string
+          }
           $abr_file = $env:INPUT_AB_ROOT + "/ab-results-" + ($file -replace "[/\\]","-") + "-markdown-table.json"
-          $json = Get-Content $abr_file | ConvertFrom-Json
+
+          try {
+            $json = Get-Content $abr_file | ConvertFrom-Json
+          } catch {
+            $message = $_
+            echo "::error ::$message" # Notify as GitHub Actions annotation
+            continue                  # Don't crash!!
+          }
 
           $text += "`n`n"
           if ("true" -eq $json.error) {


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

- Hotfix over #7046
- If a PR hasn't any changed file, the GitHub report fails with an exception
    - Simulated evidence: https://github.com/EbookFoundation/free-programming-books/actions/runs/3077422402/jobs/4972278109
    - Fixed: https://github.com/davorpa/free-programming-books/actions/runs/3007755638

So, check if filename is empty, and then capture file-not-found or JSON parse errors.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
