### PR TITLE
chore!: join `IDE and editors` into same section

### DIFF
--- a/books/free-programming-books-es.md
+++ b/books/free-programming-books-es.md
@@ -27,7 +27,6 @@
 * [LaTeX](#latex)
 * [Linux](#linux)
 * [Lisp](#lisp)
-    * [Emacs Lisp](#emacs-lisp)
 * [Matemáticas](#matem%C3%A1ticas)
 * [.NET (C# Visual Studio)](#net-c--visual-studio)
 * [NoSQL](#nosql)
@@ -259,11 +258,6 @@
 
 
 ### Lisp
-
-<!-- Waiting to add in -->
-
-
-#### Emacs Lisp
 
 * [Una Introducción a Emacs Lisp en Español](http://savannah.nongnu.org/git/?group=elisp-es) (HTML)
 

--- a/books/free-programming-books-es.md
+++ b/books/free-programming-books-es.md
@@ -11,7 +11,6 @@
 * [Android](#android)
 * [C](#c)
 * [C++](#cpp)
-* [Emacs Lisp](#emacs-lisp)
 * [Ensamblador](#ensamblador)
 * [Erlang](#erlang)
 * [Git](#git)
@@ -27,6 +26,8 @@
     * [React](#react)
 * [LaTeX](#latex)
 * [Linux](#linux)
+* [Lisp](#lisp)
+    * [Emacs Lisp](#emacs-lisp)
 * [Matemáticas](#matem%C3%A1ticas)
 * [.NET (C# Visual Studio)](#net-c--visual-studio)
 * [NoSQL](#nosql)
@@ -150,11 +151,6 @@
 * [Programación en Erlang](https://es.wikibooks.org/wiki/Programaci%C3%B3n_en_Erlang) - WikiLibros
 
 
-### Emacs Lisp
-
-* [Una Introducción a Emacs Lisp en Español](http://savannah.nongnu.org/git/?group=elisp-es) (HTML)
-
-
 ### Git
 
 * [Git Immersión en Español](https://esparta.github.io/gitimmersion-spanish)
@@ -260,6 +256,16 @@
 * [BASH Scripting Avanzado: Utilizando Declare para definición de tipo](https://web.archive.org/web/20150307181233/http://library.originalhacker.org:80/biblioteca/articulo/ver/123) (descarga directa)
 * [El Manual de BASH Scripting Básico para Principiantes](https://es.wikibooks.org/wiki/El_Manual_de_BASH_Scripting_B%C3%A1sico_para_Principiantes) - WikiLibros
 * [El Manual del Administrador de Debian](https://debian-handbook.info/browse/es-ES/stable/) (HTML) [(PDF, ePub, Mobi)](https://debian-handbook.info/get/now/)
+
+
+### Lisp
+
+<!-- Waiting to add in -->
+
+
+#### Emacs Lisp
+
+* [Una Introducción a Emacs Lisp en Español](http://savannah.nongnu.org/git/?group=elisp-es) (HTML)
 
 
 ### Matemáticas

--- a/books/free-programming-books-es.md
+++ b/books/free-programming-books-es.md
@@ -11,7 +11,7 @@
 * [Android](#android)
 * [C](#c)
 * [C++](#cpp)
-* [Emacs](#emacs)
+* [Emacs Lisp](#emacs-lisp)
 * [Ensamblador](#ensamblador)
 * [Erlang](#erlang)
 * [Git](#git)
@@ -150,7 +150,7 @@
 * [Programación en Erlang](https://es.wikibooks.org/wiki/Programaci%C3%B3n_en_Erlang) - WikiLibros
 
 
-### Emacs
+### Emacs Lisp
 
 * [Una Introducción a Emacs Lisp en Español](http://savannah.nongnu.org/git/?group=elisp-es) (HTML)
 

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -3,6 +3,7 @@
 * [0 - Méta-listes](#0---méta-listes)
 * [1 - Non dépendant du langage](#1---non-dépendant-du-langage)
     * [Algorithmique](#algorithmique)
+    * [IDE and editors](#ide-and-editors)
     * [Logiciels libres](#logiciels-libres)
     * [Makefile](#makefile)
     * [Pédagogie pour enfants et adolescents](#pédagogie-pour-enfants-et-adolescents)
@@ -47,7 +48,6 @@
 * [SQL](#sql)
 * [Systèmes d'exploitation](#systemes-d-exploitation)
 * [TEI](#tei)
-* [Vim](#vim)
 
 
 ### 0 - Méta-listes
@@ -65,6 +65,12 @@
 * [Éléments d'algorithmique](http://www-igm.univ-mlv.fr/~berstel/Elements/Elements.pdf) - D. Beauquier, J. Berstel, Ph. Chrétienne (PDF)
 * [France-IOI](http://www.france-ioi.org)
 * [Prologin](https://prologin.org)
+
+
+#### IDE and editors
+
+* [Learn Vim Progressively](http://yannesposito.com/Scratch/fr/blog/Learn-Vim-Progressively/) - Yann Esposito
+* [Vim pour les humains](https://vimebook.com/fr) - Vincent Jousse (le livre n'est pas **gratuit** mais **à prix libre**)
 
 
 #### Logiciels libres
@@ -326,9 +332,3 @@
 ### TEI
 
 * [Qu'est-ce que la Text Encoding Initiative ?](http://books.openedition.org/oep/1237) - Lou Burnard, `trl.:` Marjorie Burghart
-
-
-### Vim
-
-* [Learn Vim Progressively](http://yannesposito.com/Scratch/fr/blog/Learn-Vim-Progressively/)
-* [Vim pour les humains](https://vimebook.com/fr) - Vincent Jousse (le livre n'est pas **gratuit** mais **à prix libre**)

--- a/books/free-programming-books-hu.md
+++ b/books/free-programming-books-hu.md
@@ -8,7 +8,7 @@
 * [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [Lego Mindstorms](#lego-mindstorms)
-* [LISP](#lisp)
+* [Lisp](#lisp)
 * [.NET](#net)
 * [PHP](#php)
 * [PowerShell](#powershell)
@@ -73,7 +73,7 @@
 * [Egyszerű robotika, A Mindstorms NXT robotok programozásának alapjai](http://www.banyai-kkt.sulinet.hu/robotika/Segedanyag/Egyszeru_robotika.pdf) - Kiss Róbert, Badó Zsolt (PDF)
 
 
-### LISP
+### Lisp
 
 * [A LISP programozási nyelv](http://mek.oszk.hu/07200/07258/index.phtml) - Zimányi Magdolna, Kálmán László, Fadgyas Tibor (PDF)
 

--- a/books/free-programming-books-id.md
+++ b/books/free-programming-books-id.md
@@ -5,11 +5,11 @@
 * [C#](#csharp)
 * [C++](#cpp)
 * [CodeIgniter](#codeigniter)
-* [Emacs](#emacs)
 * [Flutter](#flutter)
 * [Git](#git)
 * [Go](#go)
 * [HTML and CSS](#html-and-css)
+* [IDE and editors](#ide-and-editors)
 * [Java](#java)
 * [JavaScript](#javascript)
     * [Vue.js](#vuejs)
@@ -57,11 +57,6 @@
 * [Tutorial CodeIgniter 4](http://mfikri.com/artikel/tutorial-codeigniter4)
 
 
-### Emacs
-
-* [Dokumentasi Emacs Bahasa Indonesia](https://github.com/kholidfu/emacs_doc)
-
-
 ### Flutter
 
 * [Belajar Flutter](https://belajarflutter.com) - Herry Prasetyo (HTML)
@@ -86,6 +81,11 @@
 * [Ebook Belajar HTML Dan CSS Dasar](https://www.malasngoding.com/download-ebook-belajar-html-dan-css-dasar-gratis/)
 * [Tutorial Dasar CSS untuk Pemula](https://www.petanikode.com/tutorial/css/) - Ahmad Muhardian (Petani Kode) *(:construction: Dalam Proses)*
 * [Tutorial HTML untuk Pemula](https://www.petanikode.com/tutorial/html/) - Ahmad Muhardian (Petani Kode)
+
+
+### IDE and editors
+
+* [Dokumentasi Emacs Bahasa Indonesia](https://github.com/kholidfu/emacs_doc) - Kholid Fuadi
 
 
 ### Java

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -52,7 +52,6 @@
 * [LaTeX](#latex)
 * [Linux](#linux)
 * [Lisp](#lisp)
-    * [Emacs Lisp](#emacs-lisp)
 * [Lua](#lua)
 * [Maven](#maven)
 * [Mercurial](#mercurial)
@@ -475,18 +474,12 @@
 ### Lisp
 
 * [Common Lisp 入門](http://www.nct9.ne.jp/m_hiroi/xyzzy_lisp.html#abclisp) - 広井誠
+* [Emacs Lisp基礎文法最速マスター](https://d.hatena.ne.jp/rubikitch/20100201/elispsyntax) - るびきち
+* [GNU Emacs Lispリファレンスマニュアル](http://www.fan.gr.jp/~ring/doc/elisp_20/elisp.html)
 * [Google Common Lisp スタイルガイド 日本語訳](https://lisphub.jp/doc/google-common-lisp-style-guide/lispguide.xml) - Robert Brown, François-René Rideau, TOYOZUMIKouichi 他(翻訳)
 * [LISP and PROLOG](https://web.archive.org/web/20060526095202/http://home.soka.ac.jp/~unemi/LispProlog) - 畝見達夫
 * [On Lisp (草稿)](http://www.asahi-net.or.jp/~kc7k-nd) - Paul Graham, 野田開(翻訳)
 * [マンガで分かるLisp(Manga Guide to Lisp)](http://lambda.bugyo.tk/cdr/mwl) - λ組
-
-
-#### Emacs Lisp
-
-> :information_source: See also &#8230; [IDE and editors](#ide-and-editors)
-
-* [Emacs Lisp基礎文法最速マスター](https://d.hatena.ne.jp/rubikitch/20100201/elispsyntax) - るびきち
-* [GNU Emacs Lispリファレンスマニュアル](http://www.fan.gr.jp/~ring/doc/elisp_20/elisp.html)
 
 
 ### Lua

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -1,6 +1,7 @@
 ### Index
 
 * [0 - 言語非依存](#0---%e8%a8%80%e8%aa%9e%e9%9d%9e%e4%be%9d%e5%ad%98)
+    * [IDE and editors](#ide-and-editors)
     * [アクセシビリティ](#%e3%82%a2%e3%82%af%e3%82%bb%e3%82%b7%e3%83%93%e3%83%aa%e3%83%86%e3%82%a3)
     * [オープンソースエコシステム](#%e3%82%aa%e3%83%bc%e3%83%97%e3%83%b3%e3%82%bd%e3%83%bc%e3%82%b9%e3%82%a8%e3%82%b3%e3%82%b7%e3%82%b9%e3%83%86%e3%83%a0)
     * [ガベージコレクション](#%e3%82%ac%e3%83%99%e3%83%bc%e3%82%b8%e3%82%b3%e3%83%ac%e3%82%af%e3%82%b7%e3%83%a7%e3%83%b3)
@@ -19,7 +20,6 @@
     * [組み込みシステム](#%e7%b5%84%e3%81%bf%e8%be%bc%e3%81%bf%e3%82%b7%e3%82%b9%e3%83%86%e3%83%a0)
     * [並列プログラミング](#%e4%b8%a6%e5%88%97%e3%83%97%e3%83%ad%e3%82%b0%e3%83%a9%e3%83%9f%e3%83%b3%e3%82%b0)
     * [理論計算機科学](#%e7%90%86%e8%ab%96%e8%a8%88%e7%ae%97%e6%a9%9f%e7%a7%91%e5%ad%a6)
-    * [IDE and editors](#ide-and-editors)
 * [Android](#android)
 * [AppleScript](#applescript)
 * [Assembly](#assembly)
@@ -87,6 +87,13 @@
 
 
 ### 0 - 言語非依存
+
+#### IDE and editors
+
+* [Vim スクリプトリファレンス](https://nanasi.jp/code.html) - 小見拓
+* [Vim スクリプト基礎文法最速マスター](https://thinca.hatenablog.com/entry/20100201/1265009821) - id:thinca
+* [Vim スクリプト書法](https://vim-jp.org/vimdoc-ja/usr_41.html) - Bram Moolenaar, vimdoc-ja プロジェクト(翻訳)
+
 
 #### アクセシビリティ
 
@@ -221,13 +228,6 @@
 #### 理論計算機科学
 
 * [計算機プログラムの構造と解釈 第二版](https://sicp.iijlab.net/fulltext) - Gerald Jay Sussman, et al.
-
-
-#### IDE and editors
-
-* [Vim スクリプトリファレンス](https://nanasi.jp/code.html) - 小見拓
-* [Vim スクリプト基礎文法最速マスター](https://thinca.hatenablog.com/entry/20100201/1265009821) - id:thinca
-* [Vim スクリプト書法](https://vim-jp.org/vimdoc-ja/usr_41.html) - Bram Moolenaar, vimdoc-ja プロジェクト(翻訳)
 
 
 ### Android

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -19,6 +19,7 @@
     * [組み込みシステム](#%e7%b5%84%e3%81%bf%e8%be%bc%e3%81%bf%e3%82%b7%e3%82%b9%e3%83%86%e3%83%a0)
     * [並列プログラミング](#%e4%b8%a6%e5%88%97%e3%83%97%e3%83%ad%e3%82%b0%e3%83%a9%e3%83%9f%e3%83%b3%e3%82%b0)
     * [理論計算機科学](#%e7%90%86%e8%ab%96%e8%a8%88%e7%ae%97%e6%a9%9f%e7%a7%91%e5%ad%a6)
+    * [IDE and editors](#ide-and-editors)
 * [Android](#android)
 * [AppleScript](#applescript)
 * [Assembly](#assembly)
@@ -83,7 +84,6 @@
 * [TypeScript](#typescript)
     * [Angular](#angular)
 * [VBA](#vba)
-* [Vim](#vim)
 
 
 ### 0 - 言語非依存
@@ -223,6 +223,13 @@
 * [計算機プログラムの構造と解釈 第二版](https://sicp.iijlab.net/fulltext) - Gerald Jay Sussman, et al.
 
 
+#### IDE and editors
+
+* [Vim スクリプトリファレンス](https://nanasi.jp/code.html) - 小見拓
+* [Vim スクリプト基礎文法最速マスター](https://thinca.hatenablog.com/entry/20100201/1265009821) - id:thinca
+* [Vim スクリプト書法](https://vim-jp.org/vimdoc-ja/usr_41.html) - Bram Moolenaar, vimdoc-ja プロジェクト(翻訳)
+
+
 ### Android
 
 * [Android Open Text book](https://github.com/TechBooster/AndroidOpenTextbook) - TechBooster
@@ -326,6 +333,8 @@
 
 
 ### Emacs Lisp
+
+> :information_source: See also &#8230; [IDE and editors](#ide-and-editors)
 
 * [Emacs Lisp基礎文法最速マスター](https://d.hatena.ne.jp/rubikitch/20100201/elispsyntax) - るびきち
 * [GNU Emacs Lispリファレンスマニュアル](http://www.fan.gr.jp/~ring/doc/elisp_20/elisp.html)
@@ -721,10 +730,3 @@
 * [Excel 2013 で学ぶ Visual Basic for Applications (VBA)](https://brain.cc.kogakuin.ac.jp/~kanamaru/lecture/vba2013) - 金丸隆志
 * [VBA基礎文法最速マスター](https://nattou-curry-2.hatenadiary.org/entry/20100129/1264787849) - id:nattou\_curry
 * [Visual Basic for Applications (VBA) の言語リファレンス](https://docs.microsoft.com/ja-jp/office/vba/api/overview/language-reference) - Microsoft Docs
-
-
-### Vim
-
-* [Vim スクリプトリファレンス](https://nanasi.jp/code.html) - 小見拓
-* [Vim スクリプト基礎文法最速マスター](https://thinca.hatenablog.com/entry/20100201/1265009821) - id:thinca
-* [Vim スクリプト書法](https://vim-jp.org/vimdoc-ja/usr_41.html) - Bram Moolenaar, vimdoc-ja プロジェクト(翻訳)

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -29,11 +29,9 @@
 * [C++](#cpp)
 * [Clojure](#clojure)
 * [CoffeeScript](#coffeescript)
-* [Common Lisp](#common-lisp)
 * [Coq](#coq)
 * [D](#d)
 * [Elixir](#elixir)
-* [Emacs Lisp](#emacs-lisp)
 * [Erlang](#erlang)
 * [Git](#git)
 * [Go](#go)
@@ -53,6 +51,8 @@
 * [Julia](#julia)
 * [LaTeX](#latex)
 * [Linux](#linux)
+* [Lisp](#lisp)
+    * [Emacs Lisp](#emacs-lisp)
 * [Lua](#lua)
 * [Maven](#maven)
 * [Mercurial](#mercurial)
@@ -308,15 +308,6 @@
 * [正規表現リファレンス（CoffeeScript)](https://kyu-mu.net/coffeescript/regexp) - 飯塚直
 
 
-### Common Lisp
-
-* [Common Lisp 入門](http://www.nct9.ne.jp/m_hiroi/xyzzy_lisp.html#abclisp) - 広井誠
-* [Google Common Lisp スタイルガイド 日本語訳](https://lisphub.jp/doc/google-common-lisp-style-guide/lispguide.xml) - Robert Brown, François-René Rideau, TOYOZUMIKouichi 他(翻訳)
-* [LISP and PROLOG](https://web.archive.org/web/20060526095202/http://home.soka.ac.jp/~unemi/LispProlog) - 畝見達夫
-* [On Lisp (草稿)](http://www.asahi-net.or.jp/~kc7k-nd) - Paul Graham, 野田開(翻訳)
-* [マンガで分かるLisp(Manga Guide to Lisp)](http://lambda.bugyo.tk/cdr/mwl) - λ組
-
-
 ### Coq
 
 * [ソフトウェアの基礎](http://proofcafe.org/sf) - Benjamin C. Pierce, Chris Casinghino, Michael Greenberg, Vilhelm Sjöberg, Brent Yorgey, 梅村晃広(翻訳), 片山功士(翻訳), 水野洋樹(翻訳), 大橋台地(翻訳), 増子萌(翻訳), 今井宜洋(翻訳)
@@ -330,14 +321,6 @@
 ### Elixir
 
 * [Elixir 基礎文法最速マスター](https://qiita.com/niku/items/729ece76d78057b58271) - niku
-
-
-### Emacs Lisp
-
-> :information_source: See also &#8230; [IDE and editors](#ide-and-editors)
-
-* [Emacs Lisp基礎文法最速マスター](https://d.hatena.ne.jp/rubikitch/20100201/elispsyntax) - るびきち
-* [GNU Emacs Lispリファレンスマニュアル](http://www.fan.gr.jp/~ring/doc/elisp_20/elisp.html)
 
 
 ### Erlang
@@ -487,6 +470,23 @@
 * [Linux Device Driver](https://www.mech.tohoku-gakuin.ac.jp/rde/contents/linux/drivers/indexframe.html) - 熊谷正朗
 * [Linux from Scratch (Version 7.4)](https://lfsbookja.osdn.jp/7.4.ja/) - Gerard Beekmans, 松山道夫(翻訳)
 * [Secure Programming for Linux and Unix HOWTO](https://linuxjf.osdn.jp/JFdocs/Secure-Programs-HOWTO) - David A. Wheeler, 高橋聡(翻訳)
+
+
+### Lisp
+
+* [Common Lisp 入門](http://www.nct9.ne.jp/m_hiroi/xyzzy_lisp.html#abclisp) - 広井誠
+* [Google Common Lisp スタイルガイド 日本語訳](https://lisphub.jp/doc/google-common-lisp-style-guide/lispguide.xml) - Robert Brown, François-René Rideau, TOYOZUMIKouichi 他(翻訳)
+* [LISP and PROLOG](https://web.archive.org/web/20060526095202/http://home.soka.ac.jp/~unemi/LispProlog) - 畝見達夫
+* [On Lisp (草稿)](http://www.asahi-net.or.jp/~kc7k-nd) - Paul Graham, 野田開(翻訳)
+* [マンガで分かるLisp(Manga Guide to Lisp)](http://lambda.bugyo.tk/cdr/mwl) - λ組
+
+
+#### Emacs Lisp
+
+> :information_source: See also &#8230; [IDE and editors](#ide-and-editors)
+
+* [Emacs Lisp基礎文法最速マスター](https://d.hatena.ne.jp/rubikitch/20100201/elispsyntax) - るびきち
+* [GNU Emacs Lispリファレンスマニュアル](http://www.fan.gr.jp/~ring/doc/elisp_20/elisp.html)
 
 
 ### Lua

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -53,7 +53,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
     * [Ecto](#ecto)
     * [Phoenix](#phoenix)
 * [Elm](#elm)
-* [Emacs](#emacs)
+* [Emacs Lisp](#emacs-lisp)
 * [Embedded Systems](#embedded-systems)
 * [Erlang](#erlang)
 * [F#](#f-sharp)
@@ -213,7 +213,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [V](#v)
 * [Verilog](#verilog)
 * [VHDL](#vhdl)
-* [Vim](#vim)
 * [Visual Basic](#visual-basic)
 * [Visual Prolog](#visual-prolog)
 * [Vulkan](#vulkan)
@@ -453,7 +452,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [The Basics of C Programming](https://www.phys.uconn.edu/~rozman/Courses/P2200_13F/downloads/TheBasicsofCProgramming-draft-20131030.pdf) - Marshall Brain (PDF)
 * [The C book](http://publications.gbdirect.co.uk/c_book/) - Mike Banahan, Declan Brady, Mark Doran (PDF, HTML)
 * [The C Programming Language Handbook](https://flaviocopes.com/page/c-handbook/) - Flavio Copes (PDF, EPUB, Kindle) *(email address requested)*
-* [The Craft of Text Editing or A Cookbook for an Emacs](http://www.finseth.com/craft/) - Craig A. Finseth
 * [The Current C Programming Language Standard – ISO/IEC 9899:2018 (C17/C18), Draft](https://web.archive.org/web/20181230041359/http://www.open-std.org/jtc1/sc22/wg14/www/abq/c17_updated_proposed_fdis.pdf) - Open Standards Org - www.open-std.org (PDF)
 * [The GNU C Programming Tutorial](http://www.crasseux.com/books/ctut.pdf) - Mark Burgess, Ron Hale-Evans (PDF)
 * [The GNU C Reference Manual](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html) - Trevis Rothwell, James Youngman (HTML) [(PDF)](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.pdf)
@@ -681,12 +679,12 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Versioned APIs with Phoenix](https://elviovicosa.com/freebies/versioned-apis-with-phoenix-by-elvio-vicosa.pdf) - Elvio Vicosa (PDF)
 
 
-### Emacs
+### Emacs Lisp
+
+> :information_source: See also &#8230; [IDE and editors](free-programming-books-subjects.md#ide-and-editors)
 
 * [An Introduction to Programming in Emacs Lisp](https://www.gnu.org/software/emacs/manual/eintr.html)
-* [Emacs for the Modern World](https://www.finseth.com/craft/) (HTML)
 * [GNU Emacs Lisp Reference Manual](http://www.gnu.org/software/emacs/manual/elisp.html)
-* [GNU Emacs Manual](https://www.gnu.org/software/emacs/manual/emacs.html)
 
 
 ### Embedded Systems
@@ -1546,8 +1544,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [NuGet In-House Succinctly](https://www.syncfusion.com/ebooks/nuget-in-house-succinctly) - José Roberto Olivas Mendoza
 * [Rider Succinctly](https://www.syncfusion.com/ebooks/rider-succinctly) - Dmitri Nesteruk
 * [Under the Hood of .NET Memory Management](https://assets.red-gate.com/community/books/under-the-hood-of-net-memory-management.pdf) - Chris Farrell, Nick Harrison (PDF)
-* [Visual Studio .NET Tips and Tricks](http://www.infoq.com/minibooks/vsnettt) (VS 2003-2005 only)
-* [Visual Studio 2019 Succinctly](https://www.syncfusion.com/ebooks/visual-studio-2019-succinctly) - Alessandro Del Sole
 
 
 ### NewSQL
@@ -2416,19 +2412,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Free Range VHDL](https://github.com/fabriziotappero/Free-Range-VHDL-book) - Bryan Mealy, Fabrizio Tappero (TeX and PDF)
 * [VHDL Tutorial](http://www.seas.upenn.edu/~ese171/vhdl/vhdl_primer.html)
 * [VHDL Tutorial: Learn By Example](http://esd.cs.ucr.edu/labs/tutorial/)
-
-
-### Vim
-
-* [A Byte of Vim](http://www.swaroopch.com/notes/vim/)
-* [Learn Vim (the Smart Way)](https://github.com/iggredible/Learn-Vim) (HTML) (:construction: *in process*)
-* [Learn Vim For the Last Time](https://danielmiessler.com/study/vim/) - Daniel Miessler
-* [Learn Vim Progressively](http://yannesposito.com/Scratch/en/blog/Learn-Vim-Progressively/)
-* [Learn Vimscript the Hard Way](http://learnvimscriptthehardway.stevelosh.com) - Steve Losh
-* [Vi Improved -- Vim](http://www.truth.sk/vim/vimbook-OPL.pdf) - Steve Oualline (PDF)
-* [VIM-GALORE - All things Vim!](https://github.com/mhinz/vim-galore#readme) (HTML)
-* [Vim Recipes](https://web.archive.org/web/20130302172911/http://vim.runpaint.org/vim-recipes.pdf) (PDF)
-* [Vim Regular Expressions 101](http://vimregex.com)
 
 
 ### Visual Basic

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -53,7 +53,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
     * [Ecto](#ecto)
     * [Phoenix](#phoenix)
 * [Elm](#elm)
-* [Emacs Lisp](#emacs-lisp)
 * [Embedded Systems](#embedded-systems)
 * [Erlang](#erlang)
 * [F#](#f-sharp)
@@ -123,6 +122,8 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Limbo](#limbo)
 * [Linux](#linux)
 * [Lisp](#lisp)
+    * [Emacs Lisp](#emacs-lisp)
+    * [PicoLisp](#picolisp)
 * [Livecode](#livecode)
 * [Lua](#lua)
 * [Make](#make)
@@ -157,7 +158,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
     * [Laravel](#laravel)
     * [Symfony](#symfony)
     * [Zend](#zend)
-* [PicoLisp](#picolisp)
 * [PostgreSQL](#postgresql)
 * [PowerShell](#powershell)
 * [Processing](#processing)
@@ -677,14 +677,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 * [Phoenix Framework Guide](https://hexdocs.pm/phoenix/overview.html) (HTML)
 * [Versioned APIs with Phoenix](https://elviovicosa.com/freebies/versioned-apis-with-phoenix-by-elvio-vicosa.pdf) - Elvio Vicosa (PDF)
-
-
-### Emacs Lisp
-
-> :information_source: See also &#8230; [IDE and editors](free-programming-books-subjects.md#ide-and-editors)
-
-* [An Introduction to Programming in Emacs Lisp](https://www.gnu.org/software/emacs/manual/eintr.html)
-* [GNU Emacs Lisp Reference Manual](http://www.gnu.org/software/emacs/manual/elisp.html)
 
 
 ### Embedded Systems
@@ -1425,6 +1417,20 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [The Evolution of Lisp](http://www.dreamsongs.com/Files/HOPL2-Uncut.pdf) - Guy L. Steele Jr., Richard P. Gabriel (PDF)
 
 
+#### Emacs Lisp
+
+> :information_source: See also &#8230; [IDE and editors](free-programming-books-subjects.md#ide-and-editors)
+
+* [An Introduction to Programming in Emacs Lisp](https://www.gnu.org/software/emacs/manual/eintr.html)
+* [GNU Emacs Lisp Reference Manual](http://www.gnu.org/software/emacs/manual/elisp.html)
+
+
+#### PicoLisp
+
+* [PicoLisp by Example](https://github.com/tj64/picolisp-by-example)
+* [PicoLisp Works](https://github.com/tj64/picolisp-works)
+
+
 ### Livecode
 
 * [LiveCode userguide](http://www.scribd.com/doc/216789127/LiveCode-userguide) (PDF)
@@ -1728,12 +1734,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 #### Zend
 
 * [Using Zend Framework 3](https://olegkrivtsov.github.io/using-zend-framework-3-book/html/)
-
-
-### PicoLisp
-
-* [PicoLisp by Example](https://github.com/tj64/picolisp-by-example)
-* [PicoLisp Works](https://github.com/tj64/picolisp-works)
 
 
 ### PostgreSQL

--- a/books/free-programming-books-pl.md
+++ b/books/free-programming-books-pl.md
@@ -7,13 +7,13 @@
 * [C](#c)
 * [C#](#csharp)
 * [C++](#cpp)
-* [Common Lisp](#common-lisp)
 * [Coq](#coq)
 * [Haskell](#haskell)
 * [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [LaTeX](#latex)
+* [Lisp](#lisp)
 * [MySQL](#mysql)
 * [Perl](#perl)
 * [PHP](#php)
@@ -86,11 +86,6 @@
 * [Megatutorial "Od zera do gier kodera"](http://xion.org.pl/productions/texts/coding/megatutorial/) - Karol Kuczmarski
 
 
-### Common Lisp
-
-* [Kurs programowania w języku Common Lisp](http://jcubic.pl/lisp_tutorial.php) - Jakub Jankiewicz
-
-
 ### Haskell
 
 * [Haskell](https://pl.wikibooks.org/wiki/Haskell) - Wikibooks
@@ -127,6 +122,11 @@
 * [LaTeX kurs](http://www.latex-kurs.x25.pl) - Przemysław Spurek
 * [LaTeX. Książka kucharska](https://ptm.org.pl/sites/default/files/latex-ksiazka-kucharska.pdf) - Marcin Borkowski, Bartłomiej Przybylski (PDF)
 * [Nie za krótkie wprowadzeniedo systemu LATEX 2ε](http://www.ctan.org/tex-archive/info/lshort/polish) - Janusz Goldasz, Ryszard Ku­biak, To­masz Przech­lewski
+
+
+### Lisp
+
+* [Kurs programowania w języku Common Lisp](http://jcubic.pl/lisp_tutorial.php) - Jakub Jankiewicz
 
 
 ### MySQL

--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -1,7 +1,7 @@
 ### Índice
 
 * [Agnósticos](#agnósticos)
-    * [IDE / Editores](#ide--editores)
+    * [IDE and editors](#ide-and-editors)
     * [Programação](#programação)
     * [Sistemas Operacionais](#sistemas-operacionais)
 * [Android](#android)
@@ -53,14 +53,10 @@
 
 ### Agnósticos
 
-#### IDE / Editores
-
-* [Visual Studio Code: Produtividade infinita](https://github.com/bylearn/VS-Code-Produtividade-Infinita) - Felipe Cabrera Ribeiro dos Santos
-
-
-#### Vim
+#### IDE and editors
 
 * [O Editor de Texto Vim](https://code.google.com/p/vimbook) - Sérgio Luiz Araújo Silva, et al.
+* [Visual Studio Code: Produtividade infinita](https://github.com/bylearn/VS-Code-Produtividade-Infinita) - Felipe Cabrera Ribeiro dos Santos
 * [Vim para Noobs](https://woliveiras.com.br/vimparanoobs/) - William Oliveira Souza (HTML, PDF, EPUB) (*Necessário criar uma conta (gratuita) no Leanpub para baixar o livro completo*)
 * [Vimbook](https://cassiobotaro.dev/vimbook/) - Cássio Botaro (HTML)
 
@@ -385,7 +381,7 @@
 
 #### Angular
 
-> :information_source: Veja também &#8230; [AngularJS](#angularjs)
+> :information_source: Veja também &#8230; [AngularJS](#angularjs), [IDE and editors](#ide-and-editors)
 
 * [Angular 2 - Criando sua primeira aplicação no Visual Studio Code](http://www.macoratti.net/17/02/net_ang2vsc1.htm) - José Carlos Macoratti (HTML)
 * [Implemente um aplicativo de página única com o Angular 2](https://www.ibm.com/developerworks/br/library/implemente-aplicativo-pagina-unica-angular-2/) - IBM, Babu Suresh (HTML)

--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -56,9 +56,9 @@
 #### IDE and editors
 
 * [O Editor de Texto Vim](https://code.google.com/p/vimbook) - Sérgio Luiz Araújo Silva, et al.
-* [Visual Studio Code: Produtividade infinita](https://github.com/bylearn/VS-Code-Produtividade-Infinita) - Felipe Cabrera Ribeiro dos Santos
 * [Vim para Noobs](https://woliveiras.com.br/vimparanoobs/) - William Oliveira Souza (HTML, PDF, EPUB) (*Necessário criar uma conta (gratuita) no Leanpub para baixar o livro completo*)
 * [Vimbook](https://cassiobotaro.dev/vimbook/) - Cássio Botaro (HTML)
+* [Visual Studio Code: Produtividade infinita](https://github.com/bylearn/VS-Code-Produtividade-Infinita) - Felipe Cabrera Ribeiro dos Santos
 
 
 #### Programação

--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -37,7 +37,7 @@
     * [Vue.js](#vuejs)
 * [Kubernetes](#kubernetes)
 * [LaTeX](#latex)
-* [LISP](#lisp)
+* [Lisp](#lisp)
 * [Lua](#lua)
 * [Pascal](#pascal)
 * [PHP](#php)
@@ -296,7 +296,7 @@
 * [Latexação](https://www.ime.usp.br/~tassio/arquivo/latex/apostila.pdf) - Tássio Naia dos Santos (PDF)
 
 
-### LISP
+### Lisp
 
 * [Introdução a linguagem LISP](http://www.dca.fee.unicamp.br/courses/EA072/lisp9596/Lisp9596.html) (HTML)
 

--- a/books/free-programming-books-ru.md
+++ b/books/free-programming-books-ru.md
@@ -6,6 +6,7 @@
     * [Работа c cетью](#Работа-с-сетью)
     * [Управление конфигурациями](#Управление-конфигурациями)
     * [Экосистема открытого исходного кода](#open-source-ecosystem)
+    * [IDE and editors](#ide-and-editors)
 * [Assembly](#assembly)
 * [Bash](#bash)
 * [C](#c)
@@ -71,7 +72,6 @@
 * [TypeScript](#typescript)
     * [Angular](#angular)
 * [Unix](#unix)
-* [Vim](#vim)
 
 
 ### 0 - Language Agnostic
@@ -118,6 +118,12 @@
 #### Экосистема открытого исходного кода
 
 * [Архитектура приложений с открытым исходным кодом](http://rus-linux.net/MyLDP/BOOKS/Architecture-Open-Source-Applications/index.html)
+
+
+#### IDE and editors
+
+* [Поваренная Книга Vim](http://www.opennet.ru/docs/RUS/vim_cookbook) - Steve Oualline
+* [Просто о Vim](http://rus-linux.net/MyLDP/BOOKS/Vim/prosto-o-vim.pdf) - Swaroop (PDF)
 
 
 ### Assembly
@@ -602,9 +608,3 @@
 2011-12-30)](http://rus-linux.net/nlib.php?name=/MyLDP/BOOKS/BLFS-ru/blfs-ru-index.html)
 * [Linux From Scratch (version 6.8)](http://rus-linux.net/nlib.php?name=/MyLDP/BOOKS/LFS-BOOK-6.8-ru/lfs-6.8-ru-index.html)
 * [The Linux Kernel Module Programming Guide](http://www.opennet.ru/docs/RUS/lkmpg26) - Peter Jay Salzman, Michael Burian, Ori Pomerantz
-
-
-### Vim
-
-* [Поваренная Книга Vim](http://www.opennet.ru/docs/RUS/vim_cookbook) - Steve Oualline
-* [Просто о Vim](http://rus-linux.net/MyLDP/BOOKS/Vim/prosto-o-vim.pdf) (PDF)

--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -23,6 +23,7 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [Game Development](#game-development)
 * [Graphical user interfaces](#graphical-user-interfaces)
 * [Graphics Programming](#graphics-programming)
+* [IDE and editors](#ide-and-editors)
 * [Information Retrieval](#information-retrieval)
 * [Licensing](#licensing)
 * [Machine Learning](#machine-learning)
@@ -311,6 +312,25 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [The GLib/GTK+ Development Platform](https://people.gnome.org/~swilmet/glib-gtk-dev-platform.pdf) - Sébastien Wilmet (PDF)
 * [Web Design Primer](https://pressbooks.library.ryerson.ca/webdesign/) - Richard Adams, Ahmed Sagarwala
 * [Web Style Guide Online](https://www.webstyleguide.com/wsg3/index.html) - Patrick J. Lynch, Sarah Horton
+
+
+### IDE and editors
+
+> :information_source: See also &#8230; [Emacs Lisp](free-programming-books-langs.md#emacs-lisp), [Regular Expressions](#regular-expressions)
+
+* [A Byte of Vim](http://www.swaroopch.com/notes/vim/) - Swaroop (PDF)
+* [GNU Emacs Manual](https://www.gnu.org/software/emacs/manual/emacs.html) - Free Software Foundation Inc. (HTML, PDF)
+* [Learn Vim (the Smart Way)](https://github.com/iggredible/Learn-Vim) - Igor Irianto (HTML) (:construction: *in process*)
+* [Learn Vim For the Last Time](https://danielmiessler.com/study/vim/) - Daniel Miessler
+* [Learn Vim Progressively](http://yannesposito.com/Scratch/en/blog/Learn-Vim-Progressively/) - Yann Esposito
+* [Learn Vimscript the Hard Way](http://learnvimscriptthehardway.stevelosh.com) - Steve Losh
+* [The Craft of Text Editing or A Cookbook for an Emacs](http://www.finseth.com/craft/) - Craig A. Finseth (HTML, PDF, ePUB, Kindle, PostScript, LaTeX)
+* [Vi Improved -- Vim](http://www.truth.sk/vim/vimbook-OPL.pdf) - Steve Oualline (PDF)
+* [VIM-GALORE - All things Vim!](https://github.com/mhinz/vim-galore#readme) - Marco Hinz (HTML)
+* [Vim Recipes](https://web.archive.org/web/20130302172911/http://vim.runpaint.org/vim-recipes.pdf) - Run Paint Run Run, Run Paint Press (PDF)
+* [Vim Regular Expressions 101](http://vimregex.com) - Oleg Raisky
+* [Visual Studio .NET Tips and Tricks](http://www.infoq.com/minibooks/vsnettt) - Minh T. Nguyen (PDF)
+* [Visual Studio 2019 Succinctly](https://www.syncfusion.com/ebooks/visual-studio-2019-succinctly) - Alessandro Del Sole (online, PDF)
 
 
 ### Information Retrieval

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -53,7 +53,7 @@
         * [Vue.js](#vuejs)
         * [Zepto.js](#zeptojs)
     * [LaTeX](#latex)
-    * [LISP](#lisp)
+    * [Lisp](#lisp)
     * [Lua](#lua)
     * [Markdown](#markdown)
     * [MySQL](#mysql)
@@ -578,7 +578,7 @@
 * [LaTeX 笔记](http://www.dralpha.com/zh/tech/tech.htm)
 
 
-### LISP
+### Lisp
 
 * [ANSI Common Lisp 中文翻译版](http://acl.readthedocs.org/en/latest/)
 * [Common Lisp 高级编程技术](http://www.ituring.com.cn/minibook/862) (《On Lisp》中文版)

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -3,7 +3,6 @@
 * [语言无关](#语言无关)
     * [版本控制](#版本控制)
     * [编程艺术](#编程艺术)
-    * [编辑器](#编辑器)
     * [编译原理](#编译原理)
     * [操作系统](#操作系统)
     * [程序员杂谈](#程序员杂谈)
@@ -20,7 +19,7 @@
     * [在线教育](#在线教育)
     * [正则表达式](#正则表达式)
     * [智能系统](#智能系统)
-    * [IDE](#ide)
+    * [IDE and editors](#ide-and-editors)
     * [Web](#web)
     * [WEB服务器](#web服务器)
 * [语言相关](#语言相关)
@@ -79,7 +78,6 @@
         * [Angular](#angular)
         * [Deno](#deno)
     * [VBA](#vba-microsoft-visual-basic-applications)
-    * [Vim](#vim)
     * [Visual Prolog](#visual-prolog)
 
 
@@ -114,13 +112,6 @@
 * [编程入门指南](http://www.kancloud.cn/kancloud/intro-to-prog/52592)
 * [程序员编程艺术](https://github.com/julycoding/The-Art-Of-Programming-by-July)
 * [每个程序员都应该了解的内存知识 (第一部分)](http://www.oschina.net/translate/what-every-programmer-should-know-about-memory-part1)
-
-
-### 编辑器
-
-* [所需即所获：像 IDE 一样使用 vim](https://github.com/yangyangwithgnu/use_vim_as_ide)
-* [exvim--vim 改良成IDE项目](http://exvim.github.io/docs-zh/intro/)
-* [Vim中文文档](https://github.com/vimcn/vimcdoc)
 
 
 ### 编译原理
@@ -258,9 +249,13 @@
 * [一步步搭建物联网系统](https://github.com/phodal/designiot)
 
 
-### IDE
+### IDE and editors
 
-* [IntelliJ IDEA 简体中文专题教程](https://github.com/judasn/IntelliJ-IDEA-Tutorial)
+* [大家來學 VIM](http://www.study-area.org/tips/vim/index.html) - Edward Lee
+* [所需即所获：像 IDE 一样使用 vim](https://github.com/yangyangwithgnu/use_vim_as_ide) - yangyangwithgnu
+* [exvim--vim 改良成IDE项目](http://exvim.github.io/docs-zh/intro/)
+* [Vim中文文档](https://github.com/vimcn/vimcdoc) - Vim 中文计划, Yian Willis
+* [IntelliJ IDEA 简体中文专题教程](https://github.com/judasn/IntelliJ-IDEA-Tutorial) - Judas.n
 
 
 ### Web
@@ -776,11 +771,6 @@
 ### VBA (Microsoft Visual Basic Applications)
 
 * [简明Excel VBA](https://github.com/Youchien/concise-excel-vba)
-
-
-### Vim
-
-* [大家來學 VIM](http://www.study-area.org/tips/vim/index.html)
 
 
 ### Visual Prolog

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -254,8 +254,8 @@
 * [大家來學 VIM](http://www.study-area.org/tips/vim/index.html) - Edward Lee
 * [所需即所获：像 IDE 一样使用 vim](https://github.com/yangyangwithgnu/use_vim_as_ide) - yangyangwithgnu
 * [exvim--vim 改良成IDE项目](http://exvim.github.io/docs-zh/intro/)
-* [Vim中文文档](https://github.com/vimcn/vimcdoc) - Vim 中文计划, Yian Willis
 * [IntelliJ IDEA 简体中文专题教程](https://github.com/judasn/IntelliJ-IDEA-Tutorial) - Judas.n
+* [Vim中文文档](https://github.com/vimcn/vimcdoc) - Vim 中文计划, Yian Willis
 
 
 ### Web

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -4,7 +4,6 @@
 * [C#](#csharp)
 * [C++](#cpp)
 * [Clojure](#clojure)
-* [Common Lisp](#common-lisp)
 * [Data Science](#data-science)
 * [Elixir](#elixir)
 * [Erlang](#erlang)
@@ -24,6 +23,7 @@
     * [React.js](#reactjs)
 * [Kotlin](#kotlin)
 * [Language Agnostic](#language-agnostic)
+* [Lisp](#lisp)
 * [Machine Learning](#machine-learning)
 * [PHP](#php)
 * [PostgreSQL](#postgresql)
@@ -58,12 +58,6 @@
 
 * [ClojureScript Podcast](https://clojurescriptpodcast.com) - Jacek Schae (podcast)
 * [Parens of the Dead](http://www.parens-of-the-dead.com) - Magnar Sveen, Elisabeth Irgens (screencast)
-
-
-### Common Lisp
-
-* [Common Lisp for Beginners](https://www.youtube.com/playlist?list=PLCpux10P7KDKPb4eI5b_qSnQaY1ePGKGK) - Neil Munro (screencast)
-* [Little Bits of Lisp](https://www.youtube.com/playlist?list=PL2VAYZE_4wRJi_vgpjsH75kMhN4KsuzR_) - Cecilie Baggers (screencast)
 
 
 ### Data Science
@@ -292,6 +286,12 @@
 * [TTL Podcast](https://podtail.com/es/podcast/ttl-podcast/) - Rebecca Murphey (podcast)
 * [Web Security Warriors](https://www.stitcher.com/show/web-security-warriors) (podcast)
 * [Women in TECH with Ariana](https://www.wallwaytech.com/podcast) - Ariana The Techie (podcast)
+
+
+### Lisp
+
+* [Common Lisp for Beginners](https://www.youtube.com/playlist?list=PLCpux10P7KDKPb4eI5b_qSnQaY1ePGKGK) - Neil Munro (screencast)
+* [Little Bits of Lisp](https://www.youtube.com/playlist?list=PL2VAYZE_4wRJi_vgpjsH75kMhN4KsuzR_) - Cecilie Baggers (screencast)
 
 
 ### Machine Learning

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -13,7 +13,7 @@
 * [Gulp](#gulp)
 * [Haskell](#haskell)
 * [HTML and CSS](#html-and-css)
-* [IDE and Editors](#ide-and-editors)
+* [IDE and editors](#ide-and-editors)
 * [Java](#java)
 * [JavaScript](#javascript)
     * [Angular](#angular)
@@ -142,7 +142,7 @@
 * [The CSS Podcast](https://thecsspodcast.libsyn.com) - Una Kravets, Adam Argyle (podcast)
 
 
-### IDE and Editors
+### IDE and editors
 
 * [Emacs Cast](https://emacscast.org) - Rakhim Davletkaliyev (podcast)
 * [Emacs Rocks!](http://emacsrocks.com) - Christian Johansen (screencast)

--- a/courses/free-courses-bn.md
+++ b/courses/free-courses-bn.md
@@ -11,7 +11,7 @@
 * [HTML and CSS](#html-and-css)
     * [Bootstrap](#bootstrap)
     * [Tailwind](#tailwind)
-* [IDE and Editors](#ide-and-editors)
+* [IDE and editors](#ide-and-editors)
 * [Java](#java)
 * [JavaScript](#javascript)
     * [jQuery](#jquery)
@@ -99,7 +99,7 @@
 * [Tailwind CSS Bangla Tutorial Series](https://youtube.com/playlist?list=PLHiZ4m8vCp9P23SqlHL0QAqiwS_oCofV2) - Learn with Sumit
 
 
-### IDE and Editors
+### IDE and editors
 
 * [VSCode Complete Tutorial Series \| VSCode টিউটোরিয়াল সিরিজ](https://www.youtube.com/playlist?list=PL_XxuZqN0xVB_lroSm_xvTqvVBCpR4PQE) - Stack Learner
 

--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -13,7 +13,7 @@
 * [Gulp](#gulp)
 * [Haskell](#haskell)
 * [HTML and CSS](#html-and-css)
-* [IDE](#ide)
+* [IDE and editors](#ide-and-editors)
 * [Ionic](#ionic)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -132,7 +132,7 @@
 * [Introdução à Linguagem HTML](https://www.udemy.com/introducao-a-linguagem-html/) - Diego Mariano (Udemy)
 
 
-### IDE
+### IDE and editors
 
 * [Domine o sublime text](https://www.udemy.com/course/domine-o-sublime-text/) - Alexandre Cardoso (Udemy)
 * [Eclipse IDE para Desenvolvedores Java](https://www.udemy.com/eclipse-ide-para-desenvolvedores-java/) - Fernando Franzini (Udemy)

--- a/courses/free-courses-tr.md
+++ b/courses/free-courses-tr.md
@@ -2,7 +2,7 @@
 
 * [Algoritmalar](#algoritmalar)
 * [HTML and CSS](#html-and-css)
-* [IDE / Editors](#ide--editors)
+* [IDE and editors](#ide-and-editors)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [Python](#python)
@@ -25,7 +25,7 @@
 * [Sıfırdan CSS Eğitim](https://www.youtube.com/playlist?list=PLadt0EaV4m3BX9JaZbKS9B8076bruv93Y) - Adem Ilter
 
 
-### IDE / Editors
+### IDE and editors
 
 * [Visual Studio Code Eğitim Serisi](https://youtube.com/playlist?list=PLGrTHqyRDvx72uHNQ6aZXxa1pSKViqIhE) - Hakan Yalçınkaya \| Kodluyoruz
 

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -12,7 +12,7 @@
 * [Git](#git)
 * [Go](#go)
 * [HTML and CSS](#html-and-css)
-* [IDE / Editors](#ide--editors)
+* [IDE and editors](#ide-and-editors)
 * [Java](#java)
 * [JavaScript](#javascript)
     * [jQuery](#jquery)
@@ -139,7 +139,7 @@
 * [HTML CheatSheet](https://htmlcheatsheet.com) - htmlcheatsheet.com (HTML, [PDF](https://htmlcheatsheet.com/HTML-Cheat-Sheet.pdf))
 
 
-### <a id="ide--editores"></a>IDE / Editors
+### IDE and editors
 
 * [Editor VI - Guia de Referência (pt)](https://aurelio.net/curso/material/vim-ref.html) - Aurelio Marinho Jargas
 * [GNU Emacs Reference Card](https://www.gnu.org/software/emacs/refcards/pdf/refcard.pdf) - GNU.org (PDF)

--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -18,6 +18,7 @@
 * [Haskell](#haskell)
 * [HTML and CSS](#html-and-css)
     * [Bootstrap](#bootstrap)
+* [IDE and editors](#ide-and-editors)
 * [Java](#java)
 * [JavaScript](#javascript)
     * [AngularJS](#angularjs)
@@ -45,7 +46,6 @@
 * [Selenium](#selenium)
 * [Solidity](#solidity)
 * [SQL](#sql)
-* [Vim](#vim)
 
 
 ### Ada
@@ -176,6 +176,11 @@
 * [Learn HTML & CSS interactively](https://www.codecademy.com/learn/web)
 * [Prototyping a professional website](https://www.codecademy.com/learn/make-a-website)
 * [Responsive Web Design Certification](https://www.freecodecamp.org/learn/responsive-web-design/) - freeCodeCamp
+
+
+### IDE and editors
+
+* [Interactive Vim Tutorial](http://www.openvim.com/tutorial.html) - Henrik Huttunen
 
 
 #### Bootstrap
@@ -384,8 +389,3 @@
 * [SQL Tutorial](https://www.w3schools.com/sql) - W3Schools
 * [SQL Tutorial](https://www.scaler.com/topics/sql/) - Scaler Topics
 * [SQLBolt](http://sqlbolt.com)
-
-
-### Vim
-
-* [Interactive Vim Tutorial](http://www.openvim.com/tutorial.html)


### PR DESCRIPTION
## What does this PR do?
Add info | Improve repo

## For resources
### Description

This homogenize the place where are organized the IDE and editors like Vim, Emacs, Visual Studio, Visual Studio Code, Eclipse, IntelliJ... into the same section.

Emacs Lisp is a language per sé. so apply and add some crosslinks #5535 in order to reference editors.

Moved books in `-langs.md` now are in `-subjects.md` since editors are language agnostic, I think.

At last but not least, complete this moved resources with author, formats and notes

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
