### PR TITLE
Add 'OCaml from the very beginning' book & OCaml playground

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1595,7 +1595,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Developing Applications With Objective Caml](http://caml.inria.fr/pub/docs/oreilly-book/)
 * [Functional Programming in OCaml](https://www.cs.cornell.edu/courses/cs3110/2019sp/textbook/) - Michael R. Clarkson
 * [OCaml From the Ground Up](https://ocamlbook.org) - Daniil Baturin (HTML) (:construction: *in process*)
-* [OCaml from the Very Beginning](https://johnwhitington.net/ocamlfromtheverybeginning/) - John Whitington (HTML, [PDF](https://johnwhitington.net/ocamlfromtheverybeginning/mlbook.pdf), [GitHub Repo](https://github.com/johnwhitington/mlbook))
+* [OCaml from the Very Beginning](https://johnwhitington.net/ocamlfromtheverybeginning/) - John Whitington (HTML, [GitHub Repo](https://github.com/johnwhitington/mlbook))
 * [OCaml Scientific Computing](https://ocaml.xyz/book/) - Liang Wang, Jianxin Zhao (HTML) (:construction: *in process*)
 * [Real World OCaml](https://dev.realworldocaml.org/toc.html)
 * [Think OCaml](http://greenteapress.com/thinkocaml/index.html) - Allen B. Downey, Nicholas Monje

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1595,7 +1595,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Developing Applications With Objective Caml](http://caml.inria.fr/pub/docs/oreilly-book/)
 * [Functional Programming in OCaml](https://www.cs.cornell.edu/courses/cs3110/2019sp/textbook/) - Michael R. Clarkson
 * [OCaml From the Ground Up](https://ocamlbook.org) - Daniil Baturin (HTML) (:construction: *in process*)
-* [OCaml from the Very Beginning](https://johnwhitington.net/ocamlfromtheverybeginning/) - John Whitington (HTML, [GitHub Repo](https://github.com/johnwhitington/mlbook))
+* [OCaml from the Very Beginning](https://johnwhitington.net/ocamlfromtheverybeginning/) - John Whitington
 * [OCaml Scientific Computing](https://ocaml.xyz/book/) - Liang Wang, Jianxin Zhao (HTML) (:construction: *in process*)
 * [Real World OCaml](https://dev.realworldocaml.org/toc.html)
 * [Think OCaml](http://greenteapress.com/thinkocaml/index.html) - Allen B. Downey, Nicholas Monje

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1595,6 +1595,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Developing Applications With Objective Caml](http://caml.inria.fr/pub/docs/oreilly-book/)
 * [Functional Programming in OCaml](https://www.cs.cornell.edu/courses/cs3110/2019sp/textbook/) - Michael R. Clarkson
 * [OCaml From the Ground Up](https://ocamlbook.org) - Daniil Baturin (HTML) (:construction: *in process*)
+* [OCaml from the Very Beginning](https://johnwhitington.net/ocamlfromtheverybeginning/) - John Whitington (HTML, [PDF](https://johnwhitington.net/ocamlfromtheverybeginning/mlbook.pdf), [GitHub Repo](https://github.com/johnwhitington/mlbook))
 * [OCaml Scientific Computing](https://ocaml.xyz/book/) - Liang Wang, Jianxin Zhao (HTML) (:construction: *in process*)
 * [Real World OCaml](https://dev.realworldocaml.org/toc.html)
 * [Think OCaml](http://greenteapress.com/thinkocaml/index.html) - Allen B. Downey, Nicholas Monje

--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -214,6 +214,7 @@
 
 ### OCaml
 
+* [OCaml Playground](https://ocaml.org/play)
 * [Try OCaml](https://try.ocamlpro.com)
 
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes EbookFoundation#7070 and adds another free OCaml book, 'OCaml from the very beginning' by John Whitington, also fixes #7073 and adds OCaml.org's playground.


## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!