### PR TITLE
fix: Escape Markdown in resources titles/links

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -330,7 +330,7 @@
 * [Codecasts](https://www.youtube.com/playlist?list=PL_qGav8csvade05RSAYtnxvCfQKTJcZR4) - Daniel Roy Greenfeld (screencast)
 * [Diving into Django](https://code.tutsplus.com/articles/diving-into-django--net-2969) - Jeff Hui (screencast)
 * [Import this](https://soundcloud.com/import-this) - Kenneth Reitz (podcast)
-* [Podcast.__init__](https://podcastinit.com) - Tobias Macey (podcast)
+* [Podcast.\_\_init\_\_](https://podcastinit.com) - Tobias Macey (podcast)
 * [Practical Flask Web Development Tutorials](https://www.youtube.com/playlist?list=PLQVvvaa0QuDc_owjTbIY4rbgXOFkUYOUB) - Harrison Kinsley (screencast)
 * [Python Bytes](https://pythonbytes.fm) - Michael Kennedy, Brian Okken (podcast)
 * [Python Tips](https://www.youtube.com/playlist?list=PLP8GkvaIxJP3ignHY_Dq7bFsvwzAcqZ1i) - Christopher Bailey (screencast)


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Resources with markdown tokens in it titles are not rendered well or at least as expected according to it original form. So needs escape using

- `\|` for table cells (see #5176)
- `\_\_`, `\*\*` for bolds
- `\_`, `\*` for emphasis

### Why is this valuable (or not)?

It escapes to get the raw form instead of the formatted output.

It also needs patch [the parser component](https://github.com/EbookFoundation/free-programming-books-parser) because this parts are stripped instead of mantain as formatted (more or less like happens in the past for sections text EbookFoundation/free-programming-books-parser#2).

![image](https://user-images.githubusercontent.com/3125580/190848931-db544d1f-5729-4ec0-a928-9ddc2617ec29.png)
![image](https://user-images.githubusercontent.com/3125580/190848876-90ae8b29-7416-460a-8bb4-fabdfdbb0a6b.png)

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
