### PR TITLE
fix: escape markdown in resources titles/links

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -330,7 +330,7 @@
 * [Codecasts](https://www.youtube.com/playlist?list=PL_qGav8csvade05RSAYtnxvCfQKTJcZR4) - Daniel Roy Greenfeld (screencast)
 * [Diving into Django](https://code.tutsplus.com/articles/diving-into-django--net-2969) - Jeff Hui (screencast)
 * [Import this](https://soundcloud.com/import-this) - Kenneth Reitz (podcast)
-* [Podcast.__init__](https://podcastinit.com) - Tobias Macey (podcast)
+* [Podcast.\_\_init\_\_](https://podcastinit.com) - Tobias Macey (podcast)
 * [Practical Flask Web Development Tutorials](https://www.youtube.com/playlist?list=PLQVvvaa0QuDc_owjTbIY4rbgXOFkUYOUB) - Harrison Kinsley (screencast)
 * [Python Bytes](https://pythonbytes.fm) - Michael Kennedy, Brian Okken (podcast)
 * [Python Tips](https://www.youtube.com/playlist?list=PLP8GkvaIxJP3ignHY_Dq7bFsvwzAcqZ1i) - Christopher Bailey (screencast)


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

A regresion in the previous PR #7086 was introduded due to a revert in 2e2bb3196126528e30e2534ef96bd9df53d35a6e. So apply it again

### Why is this valuable (or not)?

Fixes how is visualized in both apps (static and search) since the title of the resource is `Podcast.__init__` not `init` formatted in bold neither `Podcast.` respectively

- https://ebookfoundation.github.io/free-programming-books/casts/free-podcasts-screencasts-en.html#python
- https://ebookfoundation.github.io/free-programming-books-search/ and search by `Tobias Macey`

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates. #7086
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
