### PR TITLE
fix: format resources according guidelines

### DIFF
--- a/books/free-programming-books-fa_IR.md
+++ b/books/free-programming-books-fa_IR.md
@@ -21,7 +21,7 @@
 
 ### شبکه
 
-* آلبرت لازلو باراباسی - [علم شبکه](http://networksciencebook.com)
+* [علم شبکه](http://networksciencebook.com) - آلبرت لازلو باراباسی
 
 
 ### مهندسی نرم‌افزار

--- a/books/free-programming-books-ru.md
+++ b/books/free-programming-books-ru.md
@@ -597,7 +597,7 @@
 
 ### Unix
 
-* [Архитектура операционной системы Unix](http://lib.ru/BACH) - Maurice J. Bach
+* [Архитектура операционной системы Unix](http://lib.ru/BACH) - Maurice J. Bach, `trl.:` Крюкова А. В.
 * [Введение в системное администрирование UNIX](http://lib.ru/unixhelp) - Мошков Максим Евгеньевич
 * [Внутреннее устройство Ядра Linux 2.4](http://www.opennet.ru/docs/RUS/lki) - Tigran Aivazian
 * [Перевод Linux kernel and C library.](http://man-pages-ru.sourceforge.net)
@@ -605,6 +605,6 @@
 * [Руководство программиста для Linux](http://www.opennet.ru/docs/RUS/Lpg) - Sven Goldt, Matt Welsh
 * [Энциклопедия программиста Linux](http://www.opennet.ru/docs/RUS/lpg) - Алексей Паутов
 * [Энциклопедия разработчика модулей ядра Linux](http://www.opennet.ru/docs/RUS/lkmpg) - Ori Pomerantz
-* [Beyond Linux From Scratch (version 2011-12-30)](http://rus-linux.net/nlib.php?name=/MyLDP/BOOKS/BLFS-ru/blfs-ru-index.html)
+* [Beyond Linux From Scratch (version 2011-12-30)](http://rus-linux.net/nlib.php?name=/MyLDP/BOOKS/BLFS-ru/blfs-ru-index.html) - The BLFS Development Team, `trl.:` Н.Ромоданов, `trl.:` Сергея Каминского, `trl.:` Александра Андреева
 * [Linux From Scratch (version 6.8)](http://rus-linux.net/nlib.php?name=/MyLDP/BOOKS/LFS-BOOK-6.8-ru/lfs-6.8-ru-index.html)
 * [The Linux Kernel Module Programming Guide](http://www.opennet.ru/docs/RUS/lkmpg26) - Peter Jay Salzman, Michael Burian, Ori Pomerantz

--- a/books/free-programming-books-ru.md
+++ b/books/free-programming-books-ru.md
@@ -597,7 +597,7 @@
 
 ### Unix
 
-* [Beyond Linux From Scratch (version * [Архитектура операционной системы Unix](http://lib.ru/BACH) - Maurice J. Bach
+* [Архитектура операционной системы Unix](http://lib.ru/BACH) - Maurice J. Bach
 * [Введение в системное администрирование UNIX](http://lib.ru/unixhelp) - Мошков Максим Евгеньевич
 * [Внутреннее устройство Ядра Linux 2.4](http://www.opennet.ru/docs/RUS/lki) - Tigran Aivazian
 * [Перевод Linux kernel and C library.](http://man-pages-ru.sourceforge.net)
@@ -605,6 +605,6 @@
 * [Руководство программиста для Linux](http://www.opennet.ru/docs/RUS/Lpg) - Sven Goldt, Matt Welsh
 * [Энциклопедия программиста Linux](http://www.opennet.ru/docs/RUS/lpg) - Алексей Паутов
 * [Энциклопедия разработчика модулей ядра Linux](http://www.opennet.ru/docs/RUS/lkmpg) - Ori Pomerantz
-2011-12-30)](http://rus-linux.net/nlib.php?name=/MyLDP/BOOKS/BLFS-ru/blfs-ru-index.html)
+* [Beyond Linux From Scratch (version 2011-12-30)](http://rus-linux.net/nlib.php?name=/MyLDP/BOOKS/BLFS-ru/blfs-ru-index.html)
 * [Linux From Scratch (version 6.8)](http://rus-linux.net/nlib.php?name=/MyLDP/BOOKS/LFS-BOOK-6.8-ru/lfs-6.8-ru-index.html)
 * [The Linux Kernel Module Programming Guide](http://www.opennet.ru/docs/RUS/lkmpg26) - Peter Jay Salzman, Michael Burian, Ori Pomerantz

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -300,7 +300,8 @@
 * [Android6.0新特性详解](http://leanote.com/blog/post/561658f938f41126b2000298)
 * [Android开发技术前线(android-tech-frontier)](https://github.com/bboyfeiyu/android-tech-frontier)
 * [Google Android官方培训课程中文版](http://hukai.me/android-training-course-in-chinese/index.html)
-* Google Material Design 正體中文版 ([译本一](https://wcc723.gitbooks.io/google_design_translate/content/style-icons.html)，[译本二](https://github.com/1sters/material_design_zh))
+* [Google Material Design 正體中文版](https://wcc723.gitbooks.io/google_design_translate/content/style-icons.html)
+* [Google Material Design 中文协同翻译](https://github.com/1sters/material_design_zh)
 * [Material Design 中文版](http://wiki.jikexueyuan.com/project/material-design/)
 * [Point-of-Android](https://github.com/FX-Max/Point-of-Android)
 

--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -300,8 +300,8 @@
 * [Android6.0新特性详解](http://leanote.com/blog/post/561658f938f41126b2000298)
 * [Android开发技术前线(android-tech-frontier)](https://github.com/bboyfeiyu/android-tech-frontier)
 * [Google Android官方培训课程中文版](http://hukai.me/android-training-course-in-chinese/index.html)
-* [Google Material Design 正體中文版](https://wcc723.gitbooks.io/google_design_translate/content/style-icons.html)
-* [Google Material Design 中文协同翻译](https://github.com/1sters/material_design_zh)
+* [Google Material Design 正體中文版](https://wcc723.gitbooks.io/google_design_translate/content/style-icons.html) - Tillonter, 陳世能, Sean Chen, et al.
+* [Google Material Design 中文协同翻译](https://github.com/1sters/material_design_zh) - 1sters 极客实验室, 四勾 4J, IceskYsl, et al.
 * [Material Design 中文版](http://wiki.jikexueyuan.com/project/material-design/)
 * [Point-of-Android](https://github.com/FX-Max/Point-of-Android)
 


### PR DESCRIPTION
## What does this PR do?
Add info | Improve repo

## For resources
### Description

- Fixes the format of some resources according guidelines
- Completes the info (creators) of these altered resources.

### Why is this valuable (or not)?

- `fa_IR` file: title goes before creators, not between title and url.
- `ru` file: 2 resources in one since #5273. I've recovered both
- `zh` file: Deduplicate versions since a resource starts always with a link. Moreover, it has different creators

Due to don't respect this simple rules, resources are not listed in the search results of `free-programming-books-search` app

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
