### PR TITLE
fix: refine concurrency policy of `check-urls.yml` workflow

### DIFF
--- a/.github/workflows/check-urls.yml
+++ b/.github/workflows/check-urls.yml
@@ -7,10 +7,10 @@ on:
 permissions:
   contents: read
 
-# This allows a subsequently queued workflow run to interrupt previous runs
+# This allows a subsequently queued workflow run to interrupt/wait for previous runs
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref || github.run_id }}'
-  cancel-in-progress: true
+  group: '${{ github.workflow }} @ ${{ github.run_id }}'
+  cancel-in-progress: false  # true: interrupt, false = wait for
 
 jobs:
   check-urls:

--- a/.github/workflows/check-urls.yml
+++ b/.github/workflows/check-urls.yml
@@ -10,7 +10,7 @@ permissions:
 # This allows a subsequently queued workflow run to interrupt/wait for previous runs
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.run_id }}'
-  cancel-in-progress: false  # true: interrupt, false = wait for
+  cancel-in-progress: false         # true = interrupt, false = wait
 
 jobs:
   check-urls:


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Workflow seems to fail on too many executions in a row.

This parametrization makes don't fail with a cancellation

Previous runs:
- https://github.com/EbookFoundation/free-programming-books/commit/25a05812f7ed2399352b1c9fbacb1226b8ffac69#comments
- https://github.com/EbookFoundation/free-programming-books/commit/1955fd4e414bdf755f5cca20e893740aaa7c8398#comments
- https://github.com/EbookFoundation/free-programming-books/commit/62c0aa5a90688fdd3d72ad8484c8da20dc2f8d1e#comments


## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
