### PR TITLE
fix: translator role abbr is `trl.:` not `trad.:`

### DIFF
--- a/books/free-programming-books-tr.md
+++ b/books/free-programming-books-tr.md
@@ -141,7 +141,7 @@
 ### R
 
 * [Ekonometriye Yeni Başlayanlar için Kısa bir R Kılavuzu](https://www.github.com/emraher/eybkbrk) - Emrah Er
-* [R for Data Science](http://tr.r4ds.hadley.nz) - Garrett Grolemund, Hadley Wickham, `trad.:` İsmail Bekar, `trad.:` Nurbahar Usta, `trad.:` Bilgecan Şen
+* [R for Data Science](http://tr.r4ds.hadley.nz) - Garrett Grolemund, Hadley Wickham, `trl.:` İsmail Bekar, `trl.:` Nurbahar Usta, `trl.:` Bilgecan Şen
 * [R ile Programlamaya Giriş ve Uygulamalar (2014)](http://inet-tr.org.tr/inetconf19/sunum/16.pdf) - Mustafa Gökçe Baydoğan, Berk Orbay, Uzay Çetin (PDF)
 
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

### Why is this valuable (or not)?

Homogenize the translator role abbreviation to the same text (`trl.:`) according to https://loc.gov/marc/relators/relaterm.html

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
