### PR TITLE
ci(conflicts): create `conflicts.yml` workflow

### DIFF
--- a/.github/workflows/detect-conflicting-prs.yml
+++ b/.github/workflows/detect-conflicting-prs.yml
@@ -1,0 +1,71 @@
+name: "Detect conflicting PRs"
+
+on:
+  workflow_dispatch:              # manually
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolved
+  pull_request_target:            # - A pull request (even with conflicts)
+    types:
+      - synchronize               #   pushing more commits
+
+permissions:
+  # no checkouts/branching needed
+  contents: none
+  # need by "eps1lon/actions-label-merge-conflict" to manage PR label/comments
+  pull-requests: write
+
+# This allows a subsequently queued workflow run to interrupt/wait for previous runs
+concurrency:
+  group: '${{ github.workflow }}'
+  cancel-in-progress: false  # true: interrupt, false = wait for
+
+jobs:
+  detect-prs:
+    name: Detect
+    if: ${{ github.actor != 'dependabot[bot]' }} # avoid dependabot PRs
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Label conflicting PRs that are open
+        id: pr-labeler
+        uses: eps1lon/actions-label-merge-conflict@v2.0.1
+        with:
+          repoToken:  ${{ secrets.GITHUB_TOKEN }}
+          retryAfter: 30 # seconds
+          retryMax:   5  # atemps
+          dirtyLabel: conflicts
+          commentOnDirty: |
+            Oh no 😟! A dirty state was reached.
+
+            Please 🙏, take a moment and [address the merge conflicts](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-on-github) of your pull request before we can evaluate it again.
+
+            Thanks in advance you for your effort and patience ❤️!
+          continueOnMissingPermissions: true
+
+      - name: Print outputs
+        run: echo ${{ join(steps.pr-labeler.outputs.*, ',') }}
+
+      - name: Set PRs outputs
+        id: set-prs
+        run: |
+          echo "$INPUT_PRS"  \
+            | jq --compact-output --raw-output 'to_entries | map({number: .key, dirty: .value})'  \
+            | sed -e 's/^/::set-output name=prs::/'
+          echo "$INPUT_PRS"  \
+            | jq --raw-output 'to_entries | length'  \
+            | sed -e 's/^/::set-output name=prs-len::/'
+        env:
+          INPUT_PRS: ${{ steps.pr-labeler.outputs.prDirtyStatuses }}
+
+      - name: Write job summary
+        run: |
+          echo "### Pull Request statuses"  \
+            >> $GITHUB_STEP_SUMMARY
+          # render json array to a Markdown table with an optional "No records" message if empty
+          echo "$INPUT_PRS"  \
+            | jq --raw-output 'map("| [#\(.number)](\(env.GITHUB_PUBLIC_URL)/\(.number)) | \(if (.dirty) then "❌" else "✔️" end) |") | join("\n") | if (. == "") then "\nNo records.\n" else "\n| PR | Mergeable? |\n|---:|:----------:|\n\(.)\n" end'  \
+            >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_PUBLIC_URL:   ${{ format('{0}/{1}/pull', github.server_url, github.repository) }}
+          INPUT_PRS: ${{ steps.set-prs.outputs.prs }}

--- a/.github/workflows/detect-conflicting-prs.yml
+++ b/.github/workflows/detect-conflicting-prs.yml
@@ -36,7 +36,7 @@ jobs:
           retryMax:   5  # atemps
           dirtyLabel: conflicts
           commentOnDirty: |
-            Oh no 😟! A dirty state was reached.
+            Oh no 😟! A dirty status was reached.
 
             Please 🙏, take a moment and [address the merge conflicts](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-on-github) of your pull request before we can evaluate it again.
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

The `conflicts` tag is commonly used to mark those PR that have merge conflicts / dirty status with the base branch. But this was a manually process.

Well, as part of enhacements requested in #7024 this workflow/pipeline automates that process using a GitHub Action, [`eps1lon/actions-label-merge-conflict`](https://github.com/eps1lon/actions-label-merge-conflict), with which we...
- automanages the `conflicts` label
- post a message when conflicts are arisen.
- A summary report is composed on the fly with the mergeability results.

Workflow could be raised:
- manually (all PRs are checked. Useful as start up / for stucks)
- on push (all PR with linked base commit are checked)
- on pull request synchronize (current PR is checked)

Tests:
- https://github.com/davorpa/free-programming-books/pull/32
- https://github.com/davorpa/free-programming-books/pull/33
- workflow runs at: https://github.com/davorpa/free-programming-books/actions/workflows/detect-conflicting-prs.yml

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Used an informative name for this pull request.
- [ ] Review message wording/spelling

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
