### PR TITLE
Add 'Linux IP Stacks Commentary - Web Edition'

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -610,7 +610,7 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [IPv6 for IPv4 Experts](https://sites.google.com/site/yartikhiy/home/ipv6book) - Yar Tikhiy (PDF)
 * [Kafka gentle introduction](https://www.gentlydownthe.stream) - Mitch Seymour
 * [Kafka, The definitive Guide](https://assets.confluent.io/m/1b509accf21490f0/original/20170707-EB-Confluent_Kafka_Definitive-Guide_Complete.pdf) - Neha Narkhede (PDF)
-* [Linux IP Stacks Commentary](https://www.satchell.net/ipstacks/) - Stephen Satchell, H. B. J. Clifford (HTML)
+* [Linux IP Stacks Commentary](https://www.satchell.net/ipstacks/) - Stephen Satchell, H. B. J. Clifford (HTML) *(:construction: in process)*
 * [Network Science](http://networksciencebook.com) - Albert-Laszló Barabási
 * [Securing Wireless Networks for the Home User Guide](https://mohamedation.github.io/securing-wifi/index-en.html) - Mohamed Adel (HTML)
 * [The TCP/IP Guide](http://www.tcpipguide.com/free/t_toc.htm)

--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -610,6 +610,7 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [IPv6 for IPv4 Experts](https://sites.google.com/site/yartikhiy/home/ipv6book) - Yar Tikhiy (PDF)
 * [Kafka gentle introduction](https://www.gentlydownthe.stream) - Mitch Seymour
 * [Kafka, The definitive Guide](https://assets.confluent.io/m/1b509accf21490f0/original/20170707-EB-Confluent_Kafka_Definitive-Guide_Complete.pdf) - Neha Narkhede (PDF)
+* [Linux IP Stacks Commentary](https://www.satchell.net/ipstacks/) - Stephen Satchell, H. B. J. Clifford (HTML)
 * [Network Science](http://networksciencebook.com) - Albert-Laszló Barabási
 * [Securing Wireless Networks for the Home User Guide](https://mohamedation.github.io/securing-wifi/index-en.html) - Mohamed Adel (HTML)
 * [The TCP/IP Guide](http://www.tcpipguide.com/free/t_toc.htm)


### PR DESCRIPTION
## What does this PR do?
Adds the HTML (web edition) of "Linux IP Stacks Commentary".

## For resources
### Description
This book is an online publication that describes the IP stack in the Linux kernel (currently the book describes kernel v2.0.36, but the plan is for it to be updated).

### Why is this valuable (or not)?
It looks like a useful network-related programming resource with information about a real-world open source networking stack.

### How do we know it's really free?
Although the book's [website](https://www.satchell.net/ipstacks/) doesn't explicitly list a license, it does say:

"Unlike the original printed edition, the Web edition is an online book that updates the text to incorporate the most recent version of the Linux kernel. The book will be updated from time to time as new kernels are released, to reflect the changes in the new release."

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!