### PR TITLE
Fix broken links in spanish free programming books

### DIFF
--- a/books/free-programming-books-es.md
+++ b/books/free-programming-books-es.md
@@ -299,7 +299,7 @@
 
 #### Symfony
 
-* [Symfony 5: La Vía Rápida](https://symfony.com/doc/5.0/the-fast-track/es/index.html)
+* [Symfony 5: La Vía Rápida](https://web.archive.org/web/20210805141343/https://symfony.com/doc/current/the-fast-track/es/index.html)
 
 
 ### Perl

--- a/books/free-programming-books-es.md
+++ b/books/free-programming-books-es.md
@@ -123,7 +123,7 @@
 
 ### Android
 
-* [Curso Android](http://www.hermosaprogramacion.com/android) (HTML)
+* [Curso Android](https://www.develou.com/android/) (HTML)
 * [Manual de Programación Android v.2.0](http://ns2.elhacker.net/timofonica/manuales/Manual_Programacion_Android_v2.0.pdf) - Salvador Gómez Oliver (PDF)
 
 


### PR DESCRIPTION
## What does this PR do?
This Pull Request addresses the broken free programming books (` books//free-programming-books-es.md`) from issue #6942. The issue references some books that had a network timeout. However, as of today, opening those links work fine.

## For resources
### Description
N/A

### Why is this valuable (or not)?
N/A

### How do we know it's really free?
N/A

### For book lists, is it a book? For course lists, is it a course? etc.
N/A

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
