### PR TITLE
ci(fbp-lint): add 'cache' option to actions/setup-node

### DIFF
--- a/.github/workflows/fpb-lint.yml
+++ b/.github/workflows/fpb-lint.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: '16.x'
+        cache: 'npm'
     - run: npm install -g free-programming-books-lint
     - run: fpb-lint ./books/
     - run: fpb-lint ./casts/


### PR DESCRIPTION
## What does this PR do?
Adds `cache` option to `actions/setup` step in `fbp-lint` workflow. Uses `npm` cache because it installs dependencies in upcoming steps with `npm`