### PR TITLE
Removed broken link from free-programming-books-de

### DIFF
--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -249,6 +249,5 @@
 
 ### Visual Basic
 
-* [Einstieg in Visual Basic 2010](http://openbook.rheinwerk-verlag.de/einstieg_vb_2010) - Thomas Theis (Online)
 * [Einstieg in Visual Basic 2012](http://openbook.rheinwerk-verlag.de/einstieg_vb_2012) - Thomas Theis (Online)
 * [Visual Basic 2008](http://openbook.rheinwerk-verlag.de/visualbasic_2008) Andreas Kuehnel, Stephan Leibbrandt (Online)


### PR DESCRIPTION
## What does this PR do?
Remove resource(s) 
## For resources
### Description
Removed 'Einstieg in Visual Basic 2010' from [free-programming-books-de.md](https://github.com/EbookFoundation/free-programming-books/blob/c0cd3ddaf925c219bd64ebe96aff311721c553cb/books/free-programming-books-de.md) 

### Why is this valuable (or not)?
- The link was broken.
- The book cannot be found on the [site](http://openbook.rheinwerk-verlag.de) anymore.
- A more recent publication is already enlisted in the [file](https://github.com/EbookFoundation/free-programming-books/blob/c0cd3ddaf925c219bd64ebe96aff311721c553cb/books/free-programming-books-de.md).
### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
