### PR TITLE
 Fix broken link in Spanish free podcasts #7156 

### DIFF
--- a/casts/free-podcasts-screencasts-es.md
+++ b/casts/free-podcasts-screencasts-es.md
@@ -12,7 +12,7 @@
 ### Ciencia de Datos
 
 * [BigDateame](https://bigdateame.com) - Iker Gómez García (podcast)
-* [DataFuturologyEspanol](https://www.datafuturology.com/data-futurology-espanol) - Felipe Flores (podcast)
+* [DataFuturologyEspanol](https://podcasts.apple.com/us/podcast/data-futurology-espa%C3%B1ol/id1523527265) - Felipe Flores (podcast)
 * [DataLatam](http://www.datalatam.com) - Diego May, Frans van Dunné (podcast)
 * [SoyData](https://www.ivoox.com/podcast-soydata-ciencia-datos-a-tu_sq_f1414925_1.html) (podcast)
 

--- a/casts/free-podcasts-screencasts-es.md
+++ b/casts/free-podcasts-screencasts-es.md
@@ -12,7 +12,7 @@
 ### Ciencia de Datos
 
 * [BigDateame](https://bigdateame.com) - Iker Gómez García (podcast)
-* [DataFuturologyEspanol](https://podcasts.apple.com/us/podcast/data-futurology-espa%C3%B1ol/id1523527265) - Felipe Flores (podcast)
+* [DataFuturologyEspanol](https://podcasts.apple.com/es/podcast/data-futurology-espa%C3%B1ol/id1523527265) - Felipe Flores (podcast)
 * [DataLatam](http://www.datalatam.com) - Diego May, Frans van Dunné (podcast)
 * [SoyData](https://www.ivoox.com/podcast-soydata-ciencia-datos-a-tu_sq_f1414925_1.html) (podcast)
 


### PR DESCRIPTION
## What does this PR do?
This Pull Request addresses the broken link in Spanish's free podcasts (`casts/free-podcasts-screencasts-es.md`) from issue #6942. The original link is broken. However, it is still available on the Apple Podcasts site.

## For resources
### Description
N/A

### Why is this valuable (or not)?
N/A

### How do we know it's really free?
N/A

### For book lists, is it a book? For course lists, is it a course? etc.
N/A

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
