### PR TITLE
Remove broken link for Symfony 5.0 in Arabic

### DIFF
--- a/books/free-programming-books-ar.md
+++ b/books/free-programming-books-ar.md
@@ -14,7 +14,6 @@
 * [Open Source Software](#open-source-software)
 * [Operating System](#operating-systems)
 * [PHP](#php)
-    * [Symfony](#symfony)
 * [Python](#python)
 * [Raspberry Pi](#raspberry-pi)
 * [Ruby](#ruby)

--- a/books/free-programming-books-ar.md
+++ b/books/free-programming-books-ar.md
@@ -101,11 +101,6 @@
 * [تعلم البرمجة بلغة PHP](http://librebooks.org/learn-programming-with-php/)
 
 
-#### Symfony
-
-* [سيمفوني 5 : المسار السريع](https://symfony.com/doc/5.0/the-fast-track/ar/index.html)
-
-
 ### Python
 
 * [البرمجة بلغة بايثون](https://academy.hsoub.com/files/15-البرمجة-بلغة-بايثون/)


### PR DESCRIPTION
## What does this PR do?
Remove resource

## For resources
### Description
Remove broken link for Symfony 5.0 book in Arabic. The Wayback Machine did not archive all of the book chapter links.

### Why is this valuable (or not)?
Removes a broken link.

### How do we know it's really free?
N/A

### For book lists, is it a book? For course lists, is it a course? etc.
It is a book.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
