### PR TITLE
Add Xamarin.Forms Notes for professionals

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -485,7 +485,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Porting Existing ASP.NET Apps to .NET 6](https://docs.microsoft.com/en-us/dotnet/architecture/porting-existing-aspnet-apps/) - Steve "ardalis" Smith
 * [Threading in C#](http://www.albahari.com/threading/)
 * [Xamarin.Forms for macOS Succinctly](https://www.syncfusion.com/ebooks/xamarin_forms_for_mac_os_succinctly) - Alessandro Del Sole
-* [Xamarin.Forms Notes for professionals](https://books.goalkicker.com/XamarinFormsBook/) - Compiled from Stack Overflow documentaion
+* [Xamarin.Forms Notes for professionals](https://books.goalkicker.com/XamarinFormsBook/) - Compiled from StackOverflow documentaion (PDF)
 * [Xamarin.Forms Succinctly](https://www.syncfusion.com/ebooks/xamarin-forms-succinctly) - Alessandro Del Sole
 
 

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -485,6 +485,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Porting Existing ASP.NET Apps to .NET 6](https://docs.microsoft.com/en-us/dotnet/architecture/porting-existing-aspnet-apps/) - Steve "ardalis" Smith
 * [Threading in C#](http://www.albahari.com/threading/)
 * [Xamarin.Forms for macOS Succinctly](https://www.syncfusion.com/ebooks/xamarin_forms_for_mac_os_succinctly) - Alessandro Del Sole
+* [Xamarin.Forms Notes for professionals](https://books.goalkicker.com/XamarinFormsBook/) - Compiled from Stack Overflow documentaion
 * [Xamarin.Forms Succinctly](https://www.syncfusion.com/ebooks/xamarin-forms-succinctly) - Alessandro Del Sole
 
 


### PR DESCRIPTION
## What does this PR do?
Add a book: Xamarin.Forms notes for professionals

## For resources
https://books.goalkicker.com/XamarinFormsBook/

### Description

### Why is this valuable (or not)?
It is a complete guide to Xamarin.Forms and is totally free of cost. Can be referred as a handbook as well

### How do we know it's really free?
All the books and notes provided by Goalkicker are free and require no active email address or signup

### For book lists, is it a book? For course lists, is it a course? etc.
It is a book

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
