### PR TITLE
fix broken link

### DIFF
--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -10,7 +10,7 @@
 ### Competitive Programming
 
 * [4Clojure](http://www.4clojure.com)
-* [A2 Online Judge](https://a2oj.com)
+* [A2 Online Judge](https://a2oj.netlify.app/)
 * [Algorithms for Competitive Programming](https://cp-algorithms.com)
 * [APL Problem Solving Competition](https://contest.dyalog.com)
 * [AtCoder](https://atcoder.jp)
@@ -82,7 +82,7 @@
 ### Problem Sets
 
 * [500 Data structures and algorithms interview questions and their solutions in C++](https://www.quora.com/q/techiedelight/500-Data-Structures-and-Algorithms-interview-questions-and-their-solutions)
-* [A2 Online Judge](https://a2oj.com/ps)
+* [A2 Online Judge](https://a2oj.netlify.app/)
 * [Advent Of Code](http://adventofcode.com)
 * [AdventJS - 25 días de retos con JavaScript](https://adventjs.dev) - Miguel Ángel Durán «midudev» *(GitHub account requested, not required)*
 * [Anarchy Golf](http://golf.shinh.org)


### PR DESCRIPTION
## What does this PR do?
This Pull Request addresses the broken link in Problem Sets and Competitive Programming (problem-sets-competitive-programming.md) from issues #6942 and #7306. The original link of A2 Online Judge is broken. However, there is an alternative website that contains its static pages/ladders.

https://a2oj.com/ -> https://a2oj.netlify.app/
## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
