### PR TITLE
Replace the broken course for wordpress

### DIFF
--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -274,7 +274,7 @@
 
 ### Sistemas de gestión de contenidos / CMS
 
-* [Aprende Wordpress de forma sencilla (Curso desde cero - Youtube)](https://www.youtube.com/watch?v=OAWTixdQjqM&list=PLs-v5LWbw7JnwF9RquAuuxLi-Ha1rths6)
+* [CURSO de WORDPRESS (Desde Cero) - 2020](https://www.youtube.com/playlist?list=PLs-v5LWbw7JnwF9RquAuuxLi-Ha1rths6) - Academia Coder (YouTube)
 
 
 ### Técnico de Software & Hardware

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -274,7 +274,7 @@
 
 ### Sistemas de gestión de contenidos / CMS
 
-* [Aprende Wordpress de forma sencilla](https://miriadax.net/web/aprende-wordpress-de-forma-sencilla-2-edicion-)
+* [Aprende Wordpress de forma sencilla (Curso desde cero - Youtube)](https://www.youtube.com/watch?v=OAWTixdQjqM&list=PLs-v5LWbw7JnwF9RquAuuxLi-Ha1rths6)
 
 
 ### Técnico de Software & Hardware


### PR DESCRIPTION
I replace the broken link for the course on WordPress in Spanish, so I added a new one fully available on Youtube

## What does this PR do?
This course teaches us to learn WordPress without previous knowledge and is fully on Spanish

## For resources
### Description
All the credits of the course are for the Youtube Channel [Academia Coder](https://www.youtube.com/c/AcademiaCoder)
### Why is this valuable (or not)?
It's very important because is the only course on WordPress in Spanish on this repo
### How do we know it's really free?
Because all the videos on youtube are free
### For book lists, is it a book? For course lists, is it a course? etc.
It's a course with 17 videos available on demand
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
