### PR TITLE
More fixes

### DIFF
--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -54,7 +54,7 @@
 
 ### Assembly Language
 
-* [PC Assembly Language](http://drpaulcarter.com/pcasm) - Paul A. Carter
+* [PC Assembly Language](https://pacman128.github.io/static/pcasm-book.pdf) - Paul A. Carter
 * [Reverse Engineering für Einsteiger](https://beginners.re/RE4B-DE.pdf) - Dennis Yurichev, Dennis Siekmeier, Julius Angres, Dirk Loser, Clemens Tamme, Philipp Schweinzer (PDF)
 
 
@@ -180,7 +180,7 @@
 
 #### Symfony
 
-* [Symfony 5: Auf der Überholspur](https://symfony.com/doc/5.0/the-fast-track/de/index.html) (Online)
+* [Symfony 5: Auf der Überholspur](https://symfony.com/doc/5.4/the-fast-track/en/index.html) (Online)
 
 
 ### Python

--- a/books/free-programming-books-hu.md
+++ b/books/free-programming-books-hu.md
@@ -70,7 +70,7 @@
 ### Lego Mindstorms
 
 * [A MINDSTORMS EV3 robotok programozásának alapjai](https://hdidakt.hu/wp-content/uploads/2016/01/dw_74.pdf) - Kiss Róbert (PDF)
-* [Egyszerű robotika, A Mindstorms NXT robotok programozásának alapjai](https://docplayer.hu/6807751-Kiss-robert-bado-zsolt-egyszeru-robotika-a-mindstorms-nxt-robotok-programozasanak-alapjai.html) - Kiss Róbert, Badó Zsolt (PDF)
+* [Egyszerű robotika, A Mindstorms NXT robotok programozásának alapjai](https://web.archive.org/web/20160607074029/http://www.banyai-kkt.sulinet.hu/robotika/Segedanyag/Egyszeru_robotika.pdf) - Kiss Róbert, Badó Zsolt (PDF) *(:card_file_box: archived)*
 
 
 ### Lisp

--- a/books/free-programming-books-hu.md
+++ b/books/free-programming-books-hu.md
@@ -70,7 +70,7 @@
 ### Lego Mindstorms
 
 * [A MINDSTORMS EV3 robotok programozásának alapjai](https://hdidakt.hu/wp-content/uploads/2016/01/dw_74.pdf) - Kiss Róbert (PDF)
-* [Egyszerű robotika, A Mindstorms NXT robotok programozásának alapjai](http://www.banyai-kkt.sulinet.hu/robotika/Segedanyag/Egyszeru_robotika.pdf) - Kiss Róbert, Badó Zsolt (PDF)
+* [Egyszerű robotika, A Mindstorms NXT robotok programozásának alapjai](https://docplayer.hu/6807751-Kiss-robert-bado-zsolt-egyszeru-robotika-a-mindstorms-nxt-robotok-programozasanak-alapjai.html) - Kiss Róbert, Badó Zsolt (PDF)
 
 
 ### Lisp
@@ -87,7 +87,7 @@
 ### .NET
 
 * [C#](http://mek.oszk.hu/10300/10384/index.phtml) - Reiter István (PDF)
-* [C# programozás lépésről lépésre](http://devportal.hu) - Reiter István (PDF)
+* [C# programozás lépésről lépésre](https://reiteristvan.files.wordpress.com/2018/01/reiter-istvc3a1n-c-programozc3a1s-lc3a9pc3a9src591l-lc3a9pc3a9sre.pdf) - Reiter István (PDF)
 * [Honlapépítés a XXI. században](http://mek.oszk.hu/10300/10392/index.phtml) - A WebMatrix csapat, Balássy György (PDF)
 * [Silverlight 4](http://mek.oszk.hu/10300/10382/index.phtml) - Árvai Zoltán, Csala Péter, Fár Attila Gergő, Kopacz Botond, Reiter István, Tóth László (PDF)
 


### PR DESCRIPTION
Broken Link Fix
Broken links resolved in books//free-programming-books-de.md
> Links
  1. [L057]  http://drpaulcarter.com/pcasm Failed to open TCP connection to drpaulcarter.com:80 (Connection timed out - connect(2) for "drpaulcarter.com" port 80)
  2. [L184] 404 https://symfony.com/doc/5.0/the-fast-track/de/index.html

