### PR TITLE
More Broken Link Fixes

### DIFF
--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -55,7 +55,7 @@
 
 ### Assembly Language
 
-* [PC Assembly Language](http://drpaulcarter.com/pcasm) - Paul A. Carter
+* [PC Assembly Language](https://pacman128.github.io/static/pcasm-book.pdf) - Paul A. Carter
 * [Reverse Engineering für Einsteiger](https://beginners.re/RE4B-DE.pdf) - Dennis Yurichev, Dennis Siekmeier, Julius Angres, Dirk Loser, Clemens Tamme, Philipp Schweinzer (PDF)
 
 
@@ -188,7 +188,7 @@
 
 #### Symfony
 
-* [Symfony: Auf der Überholspur](https://symfony.com/doc/current/the-fast-track/de/index.html) (Online)
+* [Symfony: Auf der Überholspur](https://symfony.com/doc/5.4/the-fast-track/en/index.html) (Online)
 
 
 ### Python

--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -55,7 +55,7 @@
 
 ### Assembly Language
 
-* [PC Assembly Language](https://pacman128.github.io/static/pcasm-book.pdf) - Paul A. Carter
+* [PC Assembly Language](https://pacman128.github.io/static/pcasm-book.pdf) - Paul A. Carter (PDF)
 * [Reverse Engineering für Einsteiger](https://beginners.re/RE4B-DE.pdf) - Dennis Yurichev, Dennis Siekmeier, Julius Angres, Dirk Loser, Clemens Tamme, Philipp Schweinzer (PDF)
 
 


### PR DESCRIPTION
Fix to [Broken links](https://github.com/EbookFoundation/free-programming-books/issues/6942#top)
#6942
Broken links resolved in books//free-programming-books-de.md
> Links
  1. [L057]  http://drpaulcarter.com/pcasm Failed to open TCP connection to drpaulcarter.com:80 (Connection timed out - connect(2) for "drpaulcarter.com" port 80)
  2. [L184] 404 https://symfony.com/doc/5.0/the-fast-track/de/index.html

## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
