### PR TITLE
Update link to Modern Perl

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1679,7 +1679,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Higher-Order Perl](http://hop.perl.plover.com/book/) - M. J. Dominus (PDF)
 * [Impatient Perl](https://www.perl.org/books/impatient-perl/)
 * [Learning Perl The Hard Way](http://www.greenteapress.com/perl/)
-* [Modern Perl](https://pragprog.com/titles/swperl/modern-perl-fourth-edition/)
+* [Modern Perl](http://modernperlbooks.com/books/modern_perl_2016/)
 * [Perl & LWP](http://lwp.interglacial.com/index.html)
 * [Perl 5 Internals](http://www.faqs.org/docs/perl5int/)
 * [Perl for the Web](http://www.globalspin.com/thebook/) - C. Radcliff

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1679,7 +1679,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Higher-Order Perl](http://hop.perl.plover.com/book/) - M. J. Dominus (PDF)
 * [Impatient Perl](https://www.perl.org/books/impatient-perl/)
 * [Learning Perl The Hard Way](http://www.greenteapress.com/perl/)
-* [Modern Perl 5](http://www.onyxneon.com/books/modern_perl/)
+* [Modern Perl](https://pragprog.com/titles/swperl/modern-perl-fourth-edition/)
 * [Perl & LWP](http://lwp.interglacial.com/index.html)
 * [Perl 5 Internals](http://www.faqs.org/docs/perl5int/)
 * [Perl for the Web](http://www.globalspin.com/thebook/) - C. Radcliff


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

The page that our Modern Perl link goes to is no longer available. This updates our list to point to the ~~publisher's~~ author's website, where you can still get the book for free.

Archive of the old link https://web.archive.org/web/20210326030126/http://onyxneon.com/books/modern_perl/ indicates that "5" is not part of the title of the book. It is about Perl 5, but it's just called Modern Perl.

### Why is this valuable (or not)?

N/A, maintaining an existing entry.

### How do we know it's really free?

The publisher's website also lists the ebooks for free https://pragprog.com/titles/swperl/modern-perl-fourth-edition/ :

> Get all eBook formats here for $0.00 (USD)

Wikipedia article on the author mentioning the book https://en.wikipedia.org/wiki/Chromatic_(programmer) :

> In 2010, he released the book Modern Perl in print and in electronic form, with the latter redistributable freely (though with a suggested donation). An updated edition was released in 2012, with the entire text online.

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
