### PR TITLE
Removed some inaccessible links in programming books of Chinese

### DIFF
--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -259,14 +259,11 @@
 
 ### Web
 
-* [3 Web Designs in 3 Weeks](https://www.gitbook.com/book/juntao/3-web-designs-in-3-weeks/details)
-* [关于浏览器和网络的 20 项须知](http://www.20thingsilearned.com/zh-CN/home)
 * [浏览器开发工具的秘密](http://jinlong.github.io/2013/08/29/devtoolsecrets/)
 * [前端代码规范 及 最佳实践](http://coderlmn.github.io/code-standards/)
 * [前端开发体系建设日记](https://github.com/fouber/blog/issues/2)
 * [前端资源分享（二）](https://github.com/hacke2/hacke2.github.io/issues/3)
 * [前端资源分享（一）](https://github.com/hacke2/hacke2.github.io/issues/1)
-* [一站式学习Wireshark](https://community.emc.com/thread/194901)
 * [移动前端开发收藏夹](https://github.com/hoosin/mobile-web-favorites)
 * [移动Web前端知识库](https://github.com/AlloyTeam/Mars)
 * [正则表达式30分钟入门教程](http://deerchao.net/tutorials/regex/regex.htm)
@@ -278,8 +275,6 @@
 * [Gulp 入门指南](https://github.com/nimojs/gulp-book)
 * [gulp中文文档](http://www.gulpjs.com.cn/docs/)
 * [HTTP 接口设计指北](https://github.com/bolasblack/http-api-guide)
-* [HTTP/2.0 中文翻译](http://yuedu.baidu.com/ebook/478d1a62376baf1ffc4fad99?pn=1)
-* [http2讲解](https://www.gitbook.com/book/ye11ow/http2-explained/details)
 * [JSON风格指南](https://github.com/darcyliu/google-styleguide/blob/master/JSONStyleGuide.md)
 * [Wireshark用户手册](https://web.archive.org/web/20200415002730/http://man.lupaworld.com/content/network/wireshark/index.html)
 
@@ -296,12 +291,9 @@
 ### Android
 
 * [Android Note(开发过程中积累的知识点)](https://github.com/CharonChui/AndroidNote)
-* [Android6.0新特性详解](http://leanote.com/blog/post/561658f938f41126b2000298)
 * [Android开发技术前线(android-tech-frontier)](https://github.com/bboyfeiyu/android-tech-frontier)
-* [Google Android官方培训课程中文版](http://hukai.me/android-training-course-in-chinese/index.html)
 * [Google Material Design 正體中文版](https://wcc723.gitbooks.io/google_design_translate/content/style-icons.html) - Tillonter, 陳世能, Sean Chen, et al.
 * [Google Material Design 中文协同翻译](https://github.com/1sters/material_design_zh) - 1sters 极客实验室, 四勾 4J, IceskYsl, et al.
-* [Material Design 中文版](http://wiki.jikexueyuan.com/project/material-design/)
 * [Point-of-Android](https://github.com/FX-Max/Point-of-Android)
 
 
@@ -716,7 +708,6 @@
 ### Scala
 
 * [Effective Scala](http://twitter.github.io/effectivescala/index-cn.html)
-* [Scala 初学者指南](https://www.gitbook.com/book/windor/beginners-guide-to-scala/details) (《The Neophyte's Guide to Scala》中文版)
 * [Scala 课堂](http://twitter.github.io/scala_school/zh_cn/index.html) (Twitter的Scala中文教程)
 
 


### PR DESCRIPTION
## What does this PR do?
Removed some inaccessible links in free-programming-books-zh.md.

## For resources
### Description
I removed some inaccessible links of programming books in Chinese. 
### Why is this valuable (or not)?
This would greatly help to save others' time on opening invalid links.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
