### PR TITLE
Added the The Official Raspberry Pi Handbook 2023[pdf]

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2057,7 +2057,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Raspberry Pi: Measure, Record, Explore](https://leanpub.com/RPiMRE/read) - Malcolm Maclean (HTML)
 * [Raspberry Pi Users Guide (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)
 * [The Official Raspberry Pi Project Book 1 (2015)](https://magpi.raspberrypi.com/books/projects-1) (PDF)
-
+* [The Official Raspberry Pi Handbook 2023](https://magpi.raspberrypi.com/books/handbook-2023/pdf/download)
 
 ### REBOL
 

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2082,7 +2082,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Raspberry Pi Beginner's Guide 4th Edition](https://magpi.raspberrypi.com/books/beginners-guide-4th-ed) - The MagPi magazine (PDF)
 * [Raspberry Pi: Measure, Record, Explore](https://leanpub.com/RPiMRE/read) - Malcolm Maclean (HTML)
 * [Raspberry Pi Users Guide (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)
-* [The Official Raspberry Pi Handbook 2023](https://magpi.raspberrypi.com/books/handbook-2023)
+* [The Official Raspberry Pi Handbook 2023](https://magpi.raspberrypi.com/books/handbook-2023) - The MagPi magazine (PDF)
 * [The Official Raspberry Pi Project Book 1 (2015)](https://magpi.raspberrypi.com/books/projects-1) (PDF)
 
 

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2058,7 +2058,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Raspberry Pi Users Guide (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)
 * [The Official Raspberry Pi Project Book 1 (2015)](https://magpi.raspberrypi.com/books/projects-1) (PDF)
 * [The Official Raspberry Pi Handbook 2023](https://magpi.raspberrypi.com/books/handbook-2023/pdf/download)
-
+* [Raspberry Pi Beginner's Guide 4th Edition])(https://magpi.raspberrypi.com/books/beginners-guide-4th-ed/pdf/download)
 ### REBOL
 
 * [Learn REBOL](http://www.lulu.com/shop/nick-antonaccio/learn-rebol/ebook/product-17383182.html) - Nick Antonaccio

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2079,7 +2079,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 ### Raspberry Pi
 
-* [Raspberry Pi Beginner's Guide 4th Edition](https://magpi.raspberrypi.com/books/beginners-guide-4th-ed)
+* [Raspberry Pi Beginner's Guide 4th Edition](https://magpi.raspberrypi.com/books/beginners-guide-4th-ed) - The MagPi magazine (PDF)
 * [Raspberry Pi: Measure, Record, Explore](https://leanpub.com/RPiMRE/read) - Malcolm Maclean (HTML)
 * [Raspberry Pi Users Guide (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)
 * [The Official Raspberry Pi Handbook 2023](https://magpi.raspberrypi.com/books/handbook-2023)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2078,12 +2078,13 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 
 ### Raspberry Pi
-
+* [Raspberry Pi Beginner's Guide 4th Edition](https://magpi.raspberrypi.com/books/beginners-guide-4th-ed)
 * [Raspberry Pi: Measure, Record, Explore](https://leanpub.com/RPiMRE/read) - Malcolm Maclean (HTML)
 * [Raspberry Pi Users Guide (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)
-* [The Official Raspberry Pi Project Book 1 (2015)](https://magpi.raspberrypi.com/books/projects-1) (PDF)
 * [The Official Raspberry Pi Handbook 2023](https://magpi.raspberrypi.com/books/handbook-2023)
-* [Raspberry Pi Beginner's Guide 4th Edition](https://magpi.raspberrypi.com/books/beginners-guide-4th-ed)
+* [The Official Raspberry Pi Project Book 1 (2015)](https://magpi.raspberrypi.com/books/projects-1) (PDF)
+
+
 ### REBOL
 
 * [Learn REBOL](http://www.lulu.com/shop/nick-antonaccio/learn-rebol/ebook/product-17383182.html) - Nick Antonaccio

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2057,8 +2057,8 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Raspberry Pi: Measure, Record, Explore](https://leanpub.com/RPiMRE/read) - Malcolm Maclean (HTML)
 * [Raspberry Pi Users Guide (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)
 * [The Official Raspberry Pi Project Book 1 (2015)](https://magpi.raspberrypi.com/books/projects-1) (PDF)
-* [The Official Raspberry Pi Handbook 2023](https://magpi.raspberrypi.com/books/handbook-2023/pdf/download)
-* [Raspberry Pi Beginner's Guide 4th Edition])(https://magpi.raspberrypi.com/books/beginners-guide-4th-ed/pdf/download)
+* [The Official Raspberry Pi Handbook 2023](https://magpi.raspberrypi.com/books/handbook-2023)
+* [Raspberry Pi Beginner's Guide 4th Edition])(https://magpi.raspberrypi.com/books/beginners-guide-4th-ed)
 ### REBOL
 
 * [Learn REBOL](http://www.lulu.com/shop/nick-antonaccio/learn-rebol/ebook/product-17383182.html) - Nick Antonaccio

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2078,6 +2078,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 
 
 ### Raspberry Pi
+
 * [Raspberry Pi Beginner's Guide 4th Edition](https://magpi.raspberrypi.com/books/beginners-guide-4th-ed)
 * [Raspberry Pi: Measure, Record, Explore](https://leanpub.com/RPiMRE/read) - Malcolm Maclean (HTML)
 * [Raspberry Pi Users Guide (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2058,7 +2058,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Raspberry Pi Users Guide (2012)](http://www.cs.unca.edu/~bruce/Fall14/360/RPiUsersGuide.pdf) - Eben Upton (PDF)
 * [The Official Raspberry Pi Project Book 1 (2015)](https://magpi.raspberrypi.com/books/projects-1) (PDF)
 * [The Official Raspberry Pi Handbook 2023](https://magpi.raspberrypi.com/books/handbook-2023)
-* [Raspberry Pi Beginner's Guide 4th Edition])(https://magpi.raspberrypi.com/books/beginners-guide-4th-ed)
+* [Raspberry Pi Beginner's Guide 4th Edition](https://magpi.raspberrypi.com/books/beginners-guide-4th-ed)
 ### REBOL
 
 * [Learn REBOL](http://www.lulu.com/shop/nick-antonaccio/learn-rebol/ebook/product-17383182.html) - Nick Antonaccio


### PR DESCRIPTION
## What does this PR do?
 | Improve repo 

## For resources
[The Official Raspberry Pi Handbook 2023 (204-page PDF)](https://magpi.raspberrypi.com/books/handbook-2023/pdf/download)
### Description
It is the most recent edition of official Raspberry Pi Handbook. It consists of collection of Inspirational projects which totally belongs to DIY category.

### Why is this valuable (or not)?
This handbook has been prepared by the makers of the MagPi that is the official Raspberry Pi magazine. Here the ideas has been conveyed in very creative way, the authors have used attractive photos  and interactive design for quickly dragging the readers attention.

### How do we know it's really free?
It is clearly mentioned on **[the official TheMagPi Website](https://magpi.raspberrypi.com/books/handbook-2023)** that the soft copy of the Handbook is freely available to download. 

### For book lists, is it a book? For course lists, is it a course? etc.
It is a book.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
- **Please add the ***Hacktoberfest*** tag.**
