### PR TITLE
Fix broken links in Spanish courses

### DIFF
--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -53,10 +53,6 @@
 
 ### Big Data
 
-* [Big Data, el valor añadido de los datos de un negocio](https://miriadax.net/web/big-data-el-valor-anadido-de-los-datos-en-su-negocio)
-* [Big Data Marketing](https://miriadax.net/web/big-data-marketing)
-* [Big Data para una ciudad inteligente](https://miriadax.net/web/big-data-para-una-ciudad-inteligente-2-edicion-)
-* [Introducción al Bussiness Intelligence y al Big data](https://miriadax.net/web/introduccion-al-business-intelligence-y-al-big-data-3-edicion-)
 
 
 ### Ciencias de la Computación
@@ -75,8 +71,6 @@
 * [Ingieniería Electrónica y Automática - PLC (2014)](http://isa.uniovi.es/docencia/iea/)
 * [Laboratorio de Comunicaciones (2008)](http://ocw.bib.upct.es/course/view.php?id=80)
 * [Lenguajes unificado de modelado: UML (2016)](https://campusvirtual.ull.es/ocw/course/view.php?id=132)
-* [Matlab y Octave para ingenieros y científicos](https://miriadax.net/web/matlab-y-octave-para-ingenieros-y-cientificos)
-* [Pensamiento Computacional en la Escuela](https://miriadax.net/web/pensamiento-computacional-en-la-escuela-2ed)
 * [Programación Estadística, Programación en R](https://www.coursera.org/learn/intro-data-science-programacion-estadistica-r)
 * [Programación Multimedia (2013)](http://ocw.uv.es/ingenieria-y-arquitectura/programacionmultimedia/Course_listing)
 * [Sistemas de Telecomunicación (2011)](http://ocw.bib.upct.es/course/view.php?id=99&topic=1)
@@ -93,7 +87,6 @@
 
 * [Agilidad y Lean. Gestionando los proyectos y negocios del Siglo XXI](https://miriadax.net/web/agilidad-y-lean-gestionando-los-proyectos-y-negocios-del-s-xxi-6-edicion-)
 * [Cómo implantar grupos de mejora de procesos](https://www.edx.org/course/como-implantar-grupos-de-mejora-de-upvalenciax-gm201x-0)
-* [Gestión de proyectos con metodologías ágiles y enfoques Lean](https://miriadax.net/web/gestion-de-proyectos-con-metodologias-agiles-y-enfoques-lean-3-edicion-)
 * [Gestión de proyectos software (2015)](https://ocw.unican.es/course/view.php?id=23)
 * [Gestión Participativa: motivación y liderazgo organizacional](https://www.edx.org/course/gestion-participativa-high-involvement-upvalenciax-gp201x-0)
 * [Ingeniería del Software I (2011)](https://ocw.unican.es/course/view.php?id=169)
@@ -127,25 +120,21 @@
 
 * [Inteligencia artificial: Clips (2015)](https://campusvirtual.ull.es/ocw/course/view.php?id=112)
 * [Inteligencia artificial: Prolog (2011)](https://campusvirtual.ull.es/ocw/course/view.php?id=104)
-* [Introducción al Machine Learning](https://miriadax.net/web/introduccion-al-machine-learning-2-edicion-)
 
 
 ### Ofimática
 
 * [Access Avanzado (2010)](https://www.pildorasinformaticas.es/course/access-2010-avanzado) - Juan Díaz (Píldoras Informáticas)
 * [Access Básico (2010)](https://www.pildorasinformaticas.es/course/curso-access-2010-basico) - Juan Díaz (Píldoras Informáticas)
-* [Creación y retoque de imágenes con software libre](https://miriadax.net/web/creacion-y-retoque-2-ed)
 * [Excel 1 - Básico](https://www.edx.org/course/excel-upvalenciax-xls101x-1)
 * [Excel 2 - Gestión de Datos](https://www.edx.org/course/excel-2-gestion-de-datos-upvalenciax-xls201x)
 * [Excel Avanzado (2010)](https://www.pildorasinformaticas.es/course/excel-avanzado-2010) - Juan Díaz (Píldoras Informáticas)
 * [Excel Básico (2010)](https://www.pildorasinformaticas.es/course/excel-basico) - Juan Díaz (Píldoras Informáticas)
 * [Excel Básico a Avanzado (2019)](https://www.pildorasinformaticas.es/course/excel-2019-basico-medio-avanzado) - Juan Díaz (Píldoras Informáticas)
-* [OpenOffice](https://miriadax.net/web/software-libre-ofimatica-con-openoffice)
 * [OpenOffice Calc. Gestión de datos sobre hojas de cálculo (2014)](https://ocw.unican.es/course/view.php?id=61)
 * [PowerPoint (2013)](https://www.pildorasinformaticas.es/course/powerpoint-2013) - Juan Díaz (Píldoras Informáticas)
 * [Presentaciones eficaces (2012)](https://ocw.unican.es/course/view.php?id=188)
 * [Presentaciones eficaces con PowerPoint](https://www.edx.org/es/course/disena-presentaciones-eficaces-con-upvalenciax-ppt101x-0)
-* [Subtitulación de Vídeos](https://miriadax.net/web/subtitular-en-linea-2-edicion-)
 * [VBA Access](https://www.pildorasinformaticas.es/course/vba-access) - Juan Díaz (Píldoras Informáticas)
 * [VBA Excel](https://www.pildorasinformaticas.es/course/vba-excel) - Juan Díaz (Píldoras Informáticas)
 * [Word Avanzado (2010)](https://www.pildorasinformaticas.es/course/word-avanzado-2010) - Juan Díaz (Píldoras Informáticas)
@@ -172,12 +161,8 @@
 * [Fundamentos de informática en lenguaje C y Arduino - II](https://ocw.uca.es/course/view.php?id=74)
 * [Introducción a la programación](https://capacitateparaelempleo.org/pages.php?r=.tema&tagID=11663) - Carlos Slim Foundation (cuenta requerida)
 * [Introducción a la programación orientada a objetos en Java](https://www.coursera.org/learn/introduccion-programacion-java)
-* [Introducción a la programación para ciencias e ingieniería](https://miriadax.net/web/introduccion-programacion-ciencias-ingenieria-2edicion)
 * [Introducción a la programación, Python I](https://www.coursera.org/learn/aprendiendo-programar-python)
-* [Introducción a la programación. Descubre el lenguaje de la era digital](https://miriadax.net/web/introduccion-a-la-programacion-descubre-el-lenguaje-de-la-era-digital-5-edicion-)
 * [Introducción a Perl(2012)](https://campusvirtual.ull.es/ocw/course/view.php?id=43)
-* [Introducción al desarrollo web - iDesWeb](https://miriadax.net/web/introduccion_desarrollo_web)
-* [Introducción al tratamiento de datos con R y Rstudio](https://miriadax.net/web/aprende-r-rstudio)
 * [Java EE Módulo 1](https://www.pildorasinformaticas.es/course/java-ee-modulo-1) - Juan Díaz (Píldoras Informáticas)
 * [Java EE Módulo 2](https://www.pildorasinformaticas.es/course/java-ee-modulo-1/java-ee-modulo-2) - Juan Díaz (Píldoras Informáticas)
 * [Java SE Módulo 1](https://www.pildorasinformaticas.es/course/java-desde-0) - Juan Díaz (Píldoras Informáticas)
@@ -206,17 +191,14 @@
 ### Programación Web & Móvil
 
 * [Aplicaciones Web Avanzadas (2014)](http://ocw.uv.es/ingenieria-y-arquitectura/aplicaciones-web-avanzadas/Course_listing)
-* [Aprende a programar aplicaciones móviles](https://miriadax.net/web/creando-apps-aprende-a-programar-aplicaciones-moviles-4-edicion-)
 * [CSS Básico a Avanzado](https://www.pildorasinformaticas.es/course/css-avanzado-desde-0) - Juan Díaz (Píldoras Informáticas)
 * [Curso gratuito de JavaScript](https://argentinaprograma.com) - Fabricio Sodano (Argentina Programa)
 * [Curso gratuito de Next.js y Firebase](https://www.youtube.com/playlist?list=PLV8x_i1fqBw1VR86y4C72xMGJ8ifjBwJ6) - Miguel Ángel Durán «midudev» (YouTube)
 * [Curso JSON. De Novato a Experto](https://www.youtube.com/playlist?list=PLrDTf5qnZdEAiHO19QB9hq5QXAef1h8oY) - Camilo Martínez "Equimancho"
 * [Curso React.js desde cero - Crea una aplicación paso a paso](https://www.youtube.com/playlist?list=PLV8x_i1fqBw0B008sQn79YxCjkHJU84pC) - Miguel Ángel Durán «midudev» (YouTube)
-* [Desarrollo de servicios en la nube con HTML5, JavaScript y node.js](https://miriadax.net/web/desarrollo-de-servicios-en-la-nube-con-html5-javascript-y-nodejs-2-edicion-)
 * [Detección de objetos](https://www.coursera.org/learn/deteccion-objetos)
 * [Diseño Web - Principios de CSS](https://programadorwebvalencia.com/cursos/css/introducci%C3%B3n/) - Andros Fenollosa (Programador Web Valencia)
 * [Diseño Web - Principios de HTML](https://programadorwebvalencia.com/cursos/html/introducci%C3%B3n/) - Andros Fenollosa (Programador Web Valencia)
-* [Diseño web con HTML5+CSS](https://miriadax.net/web/diseno-web-con-html5-css-2-edicion-)
 * [Full Stack open: profundización en el desarrollo web moderno](https://fullstackopen.com/es/) - Universidad de Helsinki, Houston Inc., Terveystalo, Elisa, K-ryhmä, Unity Technologies, Konecranes
 * [FullStack JavaScript Bootcamp \| JavaScript, React.js, GraphQL, Node.js, TypeScript y +](https://www.youtube.com/playlist?list=PLV8x_i1fqBw0Kn_fBIZTa3wS_VZAqddX7) - Miguel Ángel Durán «midudev» (YouTube)
 * [HTML 5](https://www.pildorasinformaticas.es/course/html-5) - Juan Díaz (Píldoras Informáticas)
@@ -224,7 +206,6 @@
 * [PHP MySql Módulo 1](https://www.pildorasinformaticas.es/course/php-mysql) - Juan Díaz (Píldoras Informáticas)
 * [PHP MySql Módulo 2](https://www.pildorasinformaticas.es/course/php-mysql/php-mysql-modulo-2) - Juan Díaz (Píldoras Informáticas)
 * [Tecnologías Web (2010)](https://ocw.ua.es/es/ingenieria-y-arquitectura/tecnologias-web-2010.html)
-* [Windows Phone. Introducción al desarrollo de aplicaciones móviles](https://miriadax.net/web/introduccion-al-desarrollo-de-aplicaciones-moviles-con-windows-phone-2-edicion-)
 * [XML, marcado de textos y bibliotecas digitales (2007)](https://ocw.ua.es/es/ingenieria-y-arquitectura/xml-marcado-de-textos-y-bibliotecas-digitales-2007.html)
 
 
@@ -249,20 +230,17 @@
 
 * [Comunicaciones Espaciales (2010)](http://ocw.bib.upct.es/course/view.php?id=94)
 * [Diseña, fabrica y programa tu propio robot](https://www.edx.org/course/disena-fabrica-y-programa-tu-propio-upvalenciax-dyor101x)
-* [Internet de las Cosas.Desarrollar soluciones en 'FIWARE'](https://miriadax.net/web/internet-de-las-cosas-como-desarrollar-soluciones-en-fiware)
 * [Ondas Electromagnéticas (2014)](http://ocw.bib.upct.es/course/view.php?id=136)
 * [Robots autónomos (2006)](https://ocw.ua.es/es/ingenieria-y-arquitectura/robots-autonomos-2006.html)
 
 
 ### Seguridad
 
-* [Ciberseguridad. Entender ataques para desplegar contramedidas](https://miriadax.net/web/ciberseguridad-entender-los-ataques-para-desplegar-contramedidas-2-edicion-)
 * [Derecho e Internet (2011)](http://ocw.uv.es/ciencias-sociales-y-juridicas/plant/Course_listing)
 * [Garantía y seguridad en sistemas y redes (2016)](https://ocw.unican.es/course/view.php?id=16)
 * [Seguridad en Redes de Comunicación (2015)](https://ocw.unican.es/course/view.php?id=28)
 * [Seguridad en Redes de Comunicaciones (2011)](http://ocw.bib.upct.es/course/view.php?id=102)
 * [Seguridad en Sistemas Informáticos (2009)](http://ocw.uv.es/ingenieria-y-arquitectura/seguridad/Course_listing)
-* [Seguridad informática práctica](https://miriadax.net/web/seguridad-informatica-practica)
 * [Seguridad informática y competencias profesionales](https://ocw.uca.es/course/view.php?id=55)
 * [Seguridad, privacidad y protección de datos I (2012)](http://ocw.uv.es/ciencias-sociales-y-juridicas/seguridad-privacidad-y-proteccion-de-datos-i/Course_listing)
 
@@ -281,7 +259,6 @@
 
 * [Codificación de audio: más allá del MP3](https://www.edx.org/es/course/codificacion-de-audio-mas-alla-del-mp3-upvalenciax-mp3201x-0)
 * [Compresión de vídeo (2017)](https://ocw.unican.es/course/view.php?id=13) - Univ. de Cantabria
-* [Conectando el futuro con fibra óptica](https://miriadax.net/web/conectando-el-futuro-con-fibra-optica-5-edicion-_prueba)
 * [Desarrollo de sistemas de información (2013)](https://ocw.unican.es/course/view.php?id=99)
 * [Sistemas de Información y ordenadores, Parte 1: Sistemas de información para la empresa](https://www.edx.org/course/sistemas-de-informacion-y-ordenadores-upvalenciax-sic101-1x)
 * [Sistemas de Información y ordenadores, Parte 2: Hardware](https://www.edx.org/course/sistemas-de-informacion-y-ordenadores-upvalenciax-sic101-2x)
@@ -296,19 +273,10 @@
 
 * [Desarrollador de videojuegos - Capacitate para el empleo](https://capacitateparaelempleo.org/pages.php?r=.tema&tagID=6226) - Carlos Slim Foundation (cuenta requerida)
 * [Desarrollo de Apps sin saber programación](https://campusvirtual.ull.es/ocw/course/view.php?id=128)
-* [Diseño, organización y evaluación de videojuegos y gamificación](https://miriadax.net/web/diseno-organizacion-y-evaluacion-de-videojuegos-y-gamificacion-3-edicion-_201604220800)
-* [Introducción a la gamificación sobre casos prácticos](https://miriadax.net/web/introduccion-a-la-gamificacion-a-traves-de-casos-practicos)
 * [Introducción al desarrollo de videojuegos con Unity](https://www.edx.org/course/introduccion-al-desarrollo-de-upvalenciax-uny201-x-1)
-* [Introducción al diseño de videojuegos](https://miriadax.net/web/introduccion-al-diseno-de-videojuegos-2-edicion-)
-* [Robots y videojuegos en las aulas: Scratch y Arduino](https://miriadax.net/web/robots-videojuegos-aulas-scratch-arduino-profesores-3ed)
 * [Scratch. Una introducción a la programación](https://www.coursera.org/learn/a-programar)
 
 
 ### Web & Webmaster
 
-* [Búsqueda y Gestión de la Información en la Web](https://miriadax.net/web/busqueda-y-gestion-de-la-informacion-en-la-web-3-edicion-)
 * [Como crear y administrar un curso en MOODLE - TecNMx](https://mooc.tecnm.mx/courses/course-v1:TecNMx+CCACM-2+2020_T2/about)
-* [Encontrando tesoros en la red](https://miriadax.net/web/encontrando-tesoros-en-la-red-4-edicion-)
-* [Publicidad en línea. Campañas en Facebook y Adwords](https://miriadax.net/web/publicidad-en-linea-campanas-en-facebook-y-adwords-2-edicion-)
-* [Redacción en Internet](https://miriadax.net/web/redaccion-en-internet-2-edicion-)
-* [SEO. Posicionamiento natural en buscadores](https://miriadax.net/web/seo-posicionamiento-natural-en-buscadores-2-edicion-)

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -55,6 +55,7 @@
 
 * [Introducción al uso de datos en la investigación](https://miriadax.net/curso/introduccion-al-uso-de-datos-en-la-investigacion-2-a-edicion/)
 
+
 ### Ciencias de la Computación
 
 * [Arquitéctura e ingeniería de computadores](https://ocw.unican.es/course/view.php?id=162)

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -53,7 +53,7 @@
 
 ### Big Data
 
-* [Introducción al uso de datos en la investigación](https://miriadax.net/curso/introduccion-al-uso-de-datos-en-la-investigacion-2-a-edicion/)
+* [Introducción al uso de datos en la investigación](https://miriadax.net/curso/introduccion-al-uso-de-datos-en-la-investigacion-2-a-edicion/) (Miriadax)
 
 
 ### Ciencias de la Computación
@@ -86,7 +86,7 @@
 
 ### Flujos de Trabajo
 
-* [Agilidad y Lean. Gestionando los proyectos y negocios del Siglo XXI](https://miriadax.net/curso/agilidad-y-lean-gestionando-los-proyectos-y-negocios-del-s-xxi-14-a-edicion/)
+* [Agilidad y Lean. Gestionando los proyectos y negocios del Siglo XXI](https://miriadax.net/curso/agilidad-y-lean-gestionando-los-proyectos-y-negocios-del-s-xxi-14-a-edicion/) (Miriadax)
 * [Cómo implantar grupos de mejora de procesos](https://www.edx.org/course/como-implantar-grupos-de-mejora-de-upvalenciax-gm201x-0)
 * [Gestión de proyectos software (2015)](https://ocw.unican.es/course/view.php?id=23)
 * [Gestión Participativa: motivación y liderazgo organizacional](https://www.edx.org/course/gestion-participativa-high-involvement-upvalenciax-gp201x-0)
@@ -280,4 +280,4 @@
 
 ### Web & Webmaster
 
-* [Como crear y administrar un curso en MOODLE - TecNMx](https://mooc.tecnm.mx/courses/course-v1:TecNM+CCACM-003+2022-3/about)
+* [Como crear y administrar un curso en MOODLE - TecNMx](https://mooc.tecnm.mx/courses/course-v1:TecNM+CCACM-003+2022-3/about) (TecNMx)

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -3,7 +3,6 @@
 * [Android](#android)
 * [Arduino](#arduino)
 * [Bases de Datos](#bases-de-datos)
-* [Big Data](#big-data)
 * [Ciencias de la Computación](#ciencias-de-la-computaci&#x00F3;n)
 * [Control de Versiones](#control-de-versiones)
 * [Flujos de trabajo](#flujos-de-trabajo)
@@ -49,11 +48,6 @@
 * [Fundamentos de las bases de datos (2011)](https://ocw.ua.es/es/ingenieria-y-arquitectura/fundamentos-de-las-bases-de-datos-2011.html)
 * [Manual práctico de SQL](https://www.lawebdelprogramador.com/cursos/archivos/ManualPracticoSQL.pdf) - Álvaro E. García (PDF)
 * [Principios de SQL](https://programadorwebvalencia.com/cursos/sql/introducci%C3%B3n/) - Andros Fenollosa (Programador Web Valencia)
-
-
-### Big Data
-
-* [Introducción al uso de datos en la investigación](https://miriadax.net/curso/introduccion-al-uso-de-datos-en-la-investigacion-2-a-edicion) (Miriadax)
 
 
 ### Ciencias de la Computación

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -53,7 +53,7 @@
 
 ### Big Data
 
-* [Introducción al uso de datos en la investigación](https://miriadax.net/curso/introduccion-al-uso-de-datos-en-la-investigacion-2-a-edicion/) (Miriadax)
+* [Introducción al uso de datos en la investigación](https://miriadax.net/curso/introduccion-al-uso-de-datos-en-la-investigacion-2-a-edicion) (Miriadax)
 
 
 ### Ciencias de la Computación
@@ -86,7 +86,7 @@
 
 ### Flujos de Trabajo
 
-* [Agilidad y Lean. Gestionando los proyectos y negocios del Siglo XXI](https://miriadax.net/curso/agilidad-y-lean-gestionando-los-proyectos-y-negocios-del-s-xxi-14-a-edicion/) (Miriadax)
+* [Agilidad y Lean. Gestionando los proyectos y negocios del Siglo XXI](https://miriadax.net/curso/agilidad-y-lean-gestionando-los-proyectos-y-negocios-del-s-xxi-14-a-edicion) (Miriadax)
 * [Cómo implantar grupos de mejora de procesos](https://www.edx.org/course/como-implantar-grupos-de-mejora-de-upvalenciax-gm201x-0)
 * [Gestión de proyectos software (2015)](https://ocw.unican.es/course/view.php?id=23)
 * [Gestión Participativa: motivación y liderazgo organizacional](https://www.edx.org/course/gestion-participativa-high-involvement-upvalenciax-gp201x-0)

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -85,7 +85,7 @@
 
 ### Flujos de Trabajo
 
-* [Agilidad y Lean. Gestionando los proyectos y negocios del Siglo XXI](https://miriadax.net/web/agilidad-y-lean-gestionando-los-proyectos-y-negocios-del-s-xxi-6-edicion-)
+* [Agilidad y Lean. Gestionando los proyectos y negocios del Siglo XXI](https://miriadax.net/curso/agilidad-y-lean-gestionando-los-proyectos-y-negocios-del-s-xxi-14-a-edicion/)
 * [Cómo implantar grupos de mejora de procesos](https://www.edx.org/course/como-implantar-grupos-de-mejora-de-upvalenciax-gm201x-0)
 * [Gestión de proyectos software (2015)](https://ocw.unican.es/course/view.php?id=23)
 * [Gestión Participativa: motivación y liderazgo organizacional](https://www.edx.org/course/gestion-participativa-high-involvement-upvalenciax-gp201x-0)

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -279,4 +279,4 @@
 
 ### Web & Webmaster
 
-* [Como crear y administrar un curso en MOODLE - TecNMx](https://mooc.tecnm.mx/courses/course-v1:TecNMx+CCACM-2+2020_T2/about)
+* [Como crear y administrar un curso en MOODLE - TecNMx](https://mooc.tecnm.mx/courses/course-v1:TecNM+CCACM-003+2022-3/about)

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -53,7 +53,7 @@
 
 ### Big Data
 
-
+* [Introducción al uso de datos en la investigación](https://miriadax.net/curso/introduccion-al-uso-de-datos-en-la-investigacion-2-a-edicion/)
 
 ### Ciencias de la Computación
 


### PR DESCRIPTION
## What does this PR do?
Fixes broken links in Spanish courses reported in #6942. 

* Seems like Miriadax removed a lot of the courses. I only found one whose location changed. The rest were either removed or not free anymore (I searched one by one on their website).
* I added the name of the MOOC platform at the end of the link, as mentioned on the CONTRIBUTING page.
* As all of the courses from Big Data were from Miriadax, I had to remove that section.

## For resources
### Description
N/A

### Why is this valuable (or not)?
N/A

### How do we know it's really free?
N/A

### For book lists, is it a book? For course lists, is it a course? etc.
N/A

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
