### PR TITLE
Fix broken links in podcasts

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -283,7 +283,7 @@
 * [.NET Rocks!](https://www.dotnetrocks.com) - Carl Franklin, Richard Campbell (podcast)
 * [Open Source System Podcast](https://opensourcesystempodcast.vf.io) - Vlad Filippov, Kyle Robinson Young, Tim Branyen, Darcy Clarke, Mike Taylor, Alex Sexton, Jason Etcovitch (podcast)
 * [Programming Throwdown](https://www.programmingthrowdown.com) - Jason Gauci, Patrick Wheeler (podcast)
-* [Reactive](https://reactive.audio) - Kahlil Lechelt, Raquel Vélez, Henning Glatter-Götz (podcast)
+* [Reactive](https://podcasts.apple.com/us/podcast/reactive/id1020286000) - Kahlil Lechelt, Raquel Vélez, Henning Glatter-Götz (podcast)
 * [Security Now](https://www.grc.com/securitynow.htm) - Steve Gibson, Leo Laporte (podcast)
 * [Shop Talk Show](https://shoptalkshow.com) - Dave Rupert, Chris Coyier (podcast)
 * [Smashing podcast](https://podcast.smashingmagazine.com) - Drew McLellan, Smashing Magazine Team (podcast)

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -291,7 +291,7 @@
 * [Software Engineering Daily](https://softwareengineeringdaily.com) - Jeff Meyerson, Alex DeBrie, Lee Atchison, Jocelyn Byrne Houle, Mike Bifulco, Sean Falconer, et al. (podcast)
 * [Software Engineering Radio](https://www.se-radio.net) - Robert Blumen, Jeff Doolittle, Felienne Hermans, Gavin Henry, Jeremy Jung, Nikhil Krishna, Priyanka Raghavan, Kanchan Shringi, Philip Winston (podcast)
 * [Syscast Podcast](https://podcast.sysca.st) - Mattias Geniar (podcast)
-* [Talking Code](https://www.talkingcode.com) - Josh Smith, Venkat Dinavahi (podcast)
+* [Talking Code](https://podcasts.apple.com/us/podcast/talking-code/id988073177) - Josh Smith, Venkat Dinavahi (podcast)
 * [Talks at Google](https://www.youtube.com/playlist?list=PLGGpadyh0wS7XnpWK8ofxWhL7F72KcDRj) - Google (screencast)
 * [Testing In The Pub](https://testingpodcast.com/category/testing-in-the-pub/) - Stephen Janaway, Dan Ashby (podcast)
 * [The Big Web Show](https://bigwebshow.fireside.fm) - Jeffrey Zeldman (podcast)

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -306,7 +306,6 @@
 * [The Podcast from DZone.com: "For Developers, by Developers"](https://soundcloud.com/john-esposito-23072673) - John Esposito (podcast)
 * [The Silver Bullet Security Podcast with Gary McGraw](http://www.computer.org/web/computingnow/silverbullet) - Gary McGraw (podcast)
 * [The Stack Overflow Podcast](https://stackoverflow.blog/podcast/) - The Stack Overflow team (podcast)
-* [The Web Ahead](https://5by5.tv/webahead) - Jen Simmons (podcast)
 * [The Web Platform](https://thewebplatform.libsyn.com) - Erik Isaksen, Justin Ribeiro, Danny Blue, Amal Hussein, Leon Revill, et al. (podcast)
 * [Thinking with Tanay](https://anchor.fm/tanaypratap) - Tanay Pratap (podcast)
 * [This Developer's Life](https://thisdeveloperslife.com) - Rob Conery, Scott Hanselman (podcast)


### PR DESCRIPTION
## What does this PR do?
Addresses broken links from the podcasts page, as reported in #6942.

* Talking Code and Reactive websites seem to be gone for good, so pointed them to their Apple Podcasts page, as the content is still available here.
* 5by5 removed The Web Ahead podcast from their site, which is also gone from Apple Podcasts, so I removed it.

## For resources
### Description
N/A

### Why is this valuable (or not)?
N/A

### How do we know it's really free?
N/A

### For book lists, is it a book? For course lists, is it a course? etc.
N/A

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
