### PR TITLE
Adding in Calculus books from OpenStax

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -432,6 +432,7 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [Calculus Made Easy](http://www.gutenberg.org/ebooks/33283) - Silvanus P. Thompson (PDF)
 * [Calculus Volume 1](https://openstax.org/details/books/calculus-volume-1) - Edwin Herman, Gilbert Strang (PDF)
 * [Calculus Volume 2](https://openstax.org/details/books/calculus-volume-2) - Edwin Herman, Gilbert Strang (PDF)
+* [Calculus Volume 3](https://openstax.org/details/books/calculus-volume-3) - Edwin Herman, Gilbert Strang (PDF)
 * [Category Theory for the Sciences](https://mitpress.ublish.com/ereader/77/?preview#page/Cover) - David I. Spivak
 * [CK-12 Probability and Statistics - Advanced](http://www.ck12.org/book/Probability-and-Statistics---Advanced-%2528Second-Edition%2529/)
 * [CLP-1 Differential Calculus](https://www.math.ubc.ca/~CLP/CLP1/) - Joel Feldman, Andrew Rechnitzer, Elyse Yeager

--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -430,6 +430,7 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [Calculus I](https://resolver.caltech.edu/CaltechBOOK:1985.001) - Jerrold E. Marsden, Alan Weinstein
 * [Calculus in Context](http://www.math.smith.edu/~callahan/intromine.html) - James Callahan
 * [Calculus Made Easy](http://www.gutenberg.org/ebooks/33283) - Silvanus P. Thompson (PDF)
+* [Calculus Volume 1](https://openstax.org/details/books/calculus-volume-1) - Edwin Herman, et al. (PDF)
 * [Category Theory for the Sciences](https://mitpress.ublish.com/ereader/77/?preview#page/Cover) - David I. Spivak
 * [CK-12 Probability and Statistics - Advanced](http://www.ck12.org/book/Probability-and-Statistics---Advanced-%2528Second-Edition%2529/)
 * [CLP-1 Differential Calculus](https://www.math.ubc.ca/~CLP/CLP1/) - Joel Feldman, Andrew Rechnitzer, Elyse Yeager

--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -430,7 +430,8 @@ Books that cover a specific programming language can be found in the  [BY PROGRA
 * [Calculus I](https://resolver.caltech.edu/CaltechBOOK:1985.001) - Jerrold E. Marsden, Alan Weinstein
 * [Calculus in Context](http://www.math.smith.edu/~callahan/intromine.html) - James Callahan
 * [Calculus Made Easy](http://www.gutenberg.org/ebooks/33283) - Silvanus P. Thompson (PDF)
-* [Calculus Volume 1](https://openstax.org/details/books/calculus-volume-1) - Edwin Herman, et al. (PDF)
+* [Calculus Volume 1](https://openstax.org/details/books/calculus-volume-1) - Edwin Herman, Gilbert Strang (PDF)
+* [Calculus Volume 2](https://openstax.org/details/books/calculus-volume-2) - Edwin Herman, Gilbert Strang (PDF)
 * [Category Theory for the Sciences](https://mitpress.ublish.com/ereader/77/?preview#page/Cover) - David I. Spivak
 * [CK-12 Probability and Statistics - Advanced](http://www.ck12.org/book/Probability-and-Statistics---Advanced-%2528Second-Edition%2529/)
 * [CLP-1 Differential Calculus](https://www.math.ubc.ca/~CLP/CLP1/) - Joel Feldman, Andrew Rechnitzer, Elyse Yeager


### PR DESCRIPTION
## What does this PR do?
Adding in books to the Calculus section 

## For resources
### Description

### Why is this valuable (or not)?
These are free Calculus textbooks from OpenStax for students that are taking calculus class.

### How do we know it's really free?
We don't need an account to access the PDF and they don't require any money to download

### For book lists, is it a book? For course lists, is it a course? etc.
They are books

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
