### PR TITLE
Fixing the url in Data Science Academy Podcast PT_BR

### DIFF
--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -32,7 +32,7 @@
 ### DataScience
 
 * [Data Hackers](https://datahackers.com.br/podcast) (podcast)
-* [Data Science Academy](http://datascienceacademy.com.br/blog/podcast-dsa/) (podcast)
+* [Data Science Academy](https://blog.dsacademy.com.br/podcast-dsa-2/) (podcast)
 * [Let's Data](https://www.youtube.com/playlist?list=PLn_z5E4dh_Lj5eogejMxfOiNX3nOhmhmM) - Bernardo Lago, Felipe Schiavon, Leon Silva (screencast)
 * [Pizza de Dados](https://pizzadedados.com) (podcast)
 * [Programação Dinâmica - Machine Learning em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv5CBxLkdqmou_86syFK7U3Q) (screencast)


### PR DESCRIPTION
## What does this PR do?
Fix resource(s)

## For resources
### Description

The old link was broken and requested a redirect to the new community blog, I have updated with the correct redirect link

### For book lists, is it a book? For course lists, is it a course? etc.

It's a podcast

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
