### PR TITLE
Removing all resources from katacoda as it is no longer free for public use

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -692,7 +692,6 @@
 
 * [Kubernetes Core Concepts](https://kube.academy/paths/kubernetes-core-concepts) - KubeAcademy (VMware)
 * [Kubernetes Tutorial for Beginners](https://www.youtube.com/playlist?list=PLy7NrYWoggjziYQIDorlXjTvvwweTYoNC) - TechWorld with Nana
-* [Learn Kubernetes](https://www.katacoda.com/courses/kubernetes) - Katacoda
 
 
 ### Linux

--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -100,7 +100,6 @@
 
 ### Docker
 
-* [Katakoda](https://www.katacoda.com/courses/docker/playground)
 * [Play with Docker](https://labs.play-with-docker.com)
 
 
@@ -191,7 +190,6 @@
 
 ### Kubernetes
 
-* [Katakoda](https://www.katacoda.com/courses/kubernetes/playground)
 * [Play with Kubernetes](https://labs.play-with-k8s.com)
 
 


### PR DESCRIPTION
## What does this PR do?
Remove Katacoda resources as it is no longer free for public use. [Read more](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html)

## For resources
### Description
Solved a problem in #6942 

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
