### PR TITLE
Fixed broken link at line 483

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -480,8 +480,9 @@
 * [Platform Game Development w/ Construct 2](https://www.youtube.com/playlist?list=PL6gx4Cwl9DGAp287UuTE0-K7Ty-b8rGAX) - thenewboston
 * [Pygame (Python Game Development)](https://www.youtube.com/playlist?list=PL6gx4Cwl9DGAjkwJocj7vlc_mFU-4wXJq) - thenewboston
 * [Run Bunny, Run! Creating a 2D game in Unity](https://www.youtube.com/playlist?list=PLvUqRm2B9RRBgJipfDmFR7sFhEwBn7aGT) - Rabidgremlin
-* [Unity Beginner Fundamentals](https://learn.unity.com/course/unity-beginner-fundamentals) - Pluralsight Company (Unity Learn)
 * [Unity Beginner Tutorials](https://www.youtube.com/playlist?list=PLPV2KyIb3jR5QFsefuO2RlAgWEz6EvVi6) (Brackeys)
+* [Unity Essentials](https://learn.unity.com/pathway/unity-essentials) - Unity Learn
+* [Unity Game Dev: Fundamentals](https://www.pluralsight.com/paths/unity-game-development-core-skills) - Pluralsight
 * [Unity User Manual](https://docs.unity3d.com/Manual/)
 
 

--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -182,6 +182,8 @@
 
 ### IDE and editors
 
+* [CodePen: Online Code Editor and Front End Web Developer Community](https://codepen.io) - CodePen
+* [IDE | GeeksforGeeks | A computer science portal for geeks](https://ide.geeksforgeeks.org/) - GeeksforGeeks
 * [Interactive Vim Tutorial](http://www.openvim.com/tutorial.html) - Henrik Huttunen
 
 


### PR DESCRIPTION
Fixed broken link at line 483
The game dev course at line 483 was outdated and removed by Unity. The same course is available via the new link: 
https://www.pluralsight.com/paths/unity-game-development-core-skills
Also, the new link as updated by Unity has been added as well: https://learn.unity.com/pathway/unity-essentials


<img width="911" alt="chrome_oDYlM0TVrm" src="https://user-images.githubusercontent.com/100609826/194901605-7162036d-9583-44f3-9ae5-3a278827a07a.png">