### PR TITLE
Fix : Missing GraphQL Cheatsheet link

### DIFF
--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -157,7 +157,7 @@
 
 ### GraphQL
 
-* [GraphQL Cheatsheet]([https://devhints.io/go](https://devhints.io/graphql)) - devhints, Rico Santa Cruz (HTML)
+* [GraphQL Cheatsheet](https://devhints.io/graphql) - devhints, Rico Santa Cruz (HTML)
 
 
 ### HTML and CSS


### PR DESCRIPTION
The link to the GraphQL Cheatsheet was missing due to an incorrectly formatted md file. Added the link to the cheatsheet - [https://devhints.io/graphql](https://devhints.io/graphql)