### PR TITLE
Fix : The Angular playground resource is incorrectly placed after vlang resources

### DIFF
--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -333,14 +333,14 @@
 * [StackBlitz](https://stackblitz.com/fork/typescript)
 
 
-### V
-
-* [V Playground](https://play.vlang.io) - vlang.io
-
-
 #### Angular
 
 > :information_source: See also &#8230; [AngularJS](#angularjs)
 
 * [Plunker](https://plnkr.co)
 * [StackBlitz](https://stackblitz.com/fork/angular)
+
+
+### V
+
+* [V Playground](https://play.vlang.io) - vlang.io


### PR DESCRIPTION
## What does this PR do?
Fix

## For resources
### Description
Fix : The Angular playground shows up after the vlang resources when it should have been placed right after Typescript resources as a subsection of Typescript. 

### Why is this valuable (or not)?
The incorrect placement can be misleading to beginners as Angular should be a subsection of Typescript.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
