### PR TITLE
solving issue: Competitive Programming #8288

### DIFF
--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -51,6 +51,7 @@
 * [Topcoder](https://www.topcoder.com)
 * [Toph](https://toph.co)
 * [USACO.guide](https://usaco.guide)
+* [Striver’s CP Sheet](https://takeuforward.org/interview-experience/strivers-cp-sheet/)
 
 
 ### Capture the flag

--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -47,11 +47,11 @@
 * [Newton School](https://my.newtonschool.co/contest/all)
 * [oj.uz](https://oj.uz)
 * [Sphere Online Judge](http://www.spoj.com/contests)
+* [Striver’s CP Sheet](https://takeuforward.org/interview-experience/strivers-cp-sheet/)
 * [Techgig](https://www.techgig.com)
 * [Topcoder](https://www.topcoder.com)
 * [Toph](https://toph.co)
 * [USACO.guide](https://usaco.guide)
-* [Striver’s CP Sheet](https://takeuforward.org/interview-experience/strivers-cp-sheet/)
 
 
 ### Capture the flag


### PR DESCRIPTION
Added `Striver’s CP Sheet` in the Competitive Programming section | issue: Competitive Programming #8288
- Update problem-sets-competitive-programming.md

## What does this PR do?
`Add resource(s)`

## For resources
### Description
> This is a cheat sheet of the `Competitive Programming roadmap`. It covers all the important **Competitive Programming algorithms** with **practice problems** and **video tutorials**.
### Why is this valuable (or not)?
> `Striver’s CP Sheet` (Solely for `preparing for Coding Rounds` of Top Product Based Companies and to `do well in Coding Sites and Competitions`).
### How do we know it's really free?
> This website is `available for everyone`. 
### For book lists, is it a book? For course lists, is it a course? etc.
> It is a Competitive Programming `Cheat Sheet`.
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
