### PR TITLE
C++ STL - screencast added

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -54,6 +54,7 @@
 * [C++ Series](https://www.youtube.com/playlist?list=PLlrATfBNZ98dudnM48yfGUldqGD0S4FFb) - The Cherno (screencast)
 * [C++ Standard Library](https://www.youtube.com/playlist?list=PL5jc9xFGsL8G3y3ywuFSvOuNm3GjBwdkb) - Bo Qian (screencast)
 * [C++ STL by example](https://www.youtube.com/playlist?list=PLZ9NgFYEMxp5oH3mrr4IlFBn03rjS-gN1) - Douglas Schmidt (screencast)
+* [C++ STL: The ONLY Video You Need | Compulsory for DSA/CP](https://www.youtube.com/watch?v=PZogbfU4X5E) - Utkarsh Gupta (screencast)
 * [CppCast](http://cppcast.com) - Conor Hoekstra, Jason Turner, JeanHeyd Meneide, Matt Godbolt, Rob Irving (podcast)
 
 


### PR DESCRIPTION
Added almost 1 hour-long video lesson of `STL` (Standard Template Library) in `C++`.
Update free-podcasts-screencasts-en.md

## What does this PR do?
> `Add resource(s)`

## For resources
### Description
> This is the only video you need to `learn STL` or Standard Template Library in C++ `for Competitive Programming` and DSA (Data Structures And Algorithms).
### Why is this valuable (or not)?
> It is a complete long video lesson on Standard Template Library in C++. So, **learners will not need any other video or article for STL after watching this video**.
### How do we know it's really free?
> It is available on YouTube and so, it is `totally free`.
### For book lists, is it a book? For course lists, is it a course? etc.
> It is a long `video lesson`.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
