### PR TITLE
removed book Fundamentals of Data Visualization from free-programming-books-langs.md

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1899,7 +1899,6 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [From Python to NumPy](https://www.labri.fr/perso/nrougier/from-python-to-numpy/) - Nicolas P. Rougier (3.6)
 * [Full Stack Python](https://www.fullstackpython.com) - Matt Makai
 * [Functional Programming in Python](https://www.oreilly.com/ideas/functional-programming-in-python) - David Mertz
-* [Fundamentals of Data Visualization](https://clauswilke.com/dataviz/) - Claus O. Wilke
 * [Fundamentals of Python Programming](https://web.archive.org/web/20191005170430/http://python.cs.southern.edu/pythonbook/pythonbook.pdf) - Richard L. Halterman (PDF) (:construction: *in process*)
 * [Google's Python Class](https://developers.google.com/edu/python/) (2.4 - 2.x)
 * [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)


### PR DESCRIPTION
wrongly categorized under a programming language

## What does this PR do?
Removed book Fundamentals of Data Visualization in `free-programming-books-langs.md`

## For resources

### Why is this valuable (or not)?
This book is not related to a specific programming language and generally discusses the fundamentals of data visualization.
Hence this book needs to be under the `free-programming-books-subjects.md` and it is already added under the Data Science subject category.

