### PR TITLE
Update free-podcasts-screencasts-en.md with Persuasive Technology

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -26,6 +26,7 @@
 * [Language Agnostic](#language-agnostic)
 * [Lisp](#lisp)
 * [Machine Learning](#machine-learning)
+* [Persuasive Technology](#persuasive-technology)
 * [PHP](#php)
 * [PostgreSQL](#postgresql)
 * [Python](#python)
@@ -340,6 +341,12 @@
 * [The AI Podcast](https://blogs.nvidia.com/ai-podcast/) - NVIDIA, Noah Kravitz (podcast)
 * [Tic-Tac-Toe the Hard Way](https://pair.withgoogle.com/thehardway/) - Google's People + AI Research team (podcast)
 * [TWIML AI Podcast](https://twimlai.com/shows/) - Sam Charrington (podcast)
+
+
+### Persuasive Technology
+
+* [Your Undivided Attention](https://www.humanetech.com/podcast) - Tristan Harris and Aza Raskin (podcast)
+* [Persuasive Technology and Behavioural Design](https://anchor.fm/digital-mindfulness/episodes/DM-20-BJ-Fogg---Persuasive-Technology--Behavioural-Design-eu6onh) - BJ Fogg (podcast)
 
 
 ### PHP

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -345,8 +345,8 @@
 
 ### Persuasive Technology
 
-* [Your Undivided Attention](https://www.humanetech.com/podcast) - Tristan Harris and Aza Raskin (podcast)
 * [Persuasive Technology and Behavioural Design](https://anchor.fm/digital-mindfulness/episodes/DM-20-BJ-Fogg---Persuasive-Technology--Behavioural-Design-eu6onh) - BJ Fogg (podcast)
+* [Your Undivided Attention](https://www.humanetech.com/podcast) - Tristan Harris and Aza Raskin (podcast)
 
 
 ### PHP


### PR DESCRIPTION
## What does this PR do?
Add resource(s) 

## For resources
### Description
As per #8530 , I have added podcasts on Persuasive Technology and Behavioural Design.

### Why is this valuable (or not)?
In the growing digital age, the podcasts have been made under the base of a popular BJ Fogg book named as "Persuasive Technology: Using computers to change what we think and do" published way back in 2002. The podcasts lays foundation and experiences by technology ethicists.

### How do we know it's really free?
The podcasts are available on spotify and apple podcasts.

### For book lists, is it a book? For course lists, is it a course? etc.
It is a podcast series.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
