### PR TITLE
fix(books): free-programming-books-pt_BR broken links

### DIFF
--- a/casts/free-podcasts-screencasts-pt_BR.md
+++ b/casts/free-podcasts-screencasts-pt_BR.md
@@ -63,7 +63,7 @@
 ### iOS
 
 * [Build Failed](https://twitter.com/buildfailedcast) (podcast)
-* [CocoaHeads](http://www.cocoaheads.com.br/podcasts) (podcast)
+* [CocoaHeads](https://podcasts-brasileiros.com/podcast/cocoaheads-brasil) (podcast)
 
 
 ### Java


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Updates cocoaheads brasil podcast link.

### Why is this valuable (or not)?
### How do we know it's really free?

Open the site and scroll a little bit for all the free podcasts audio, also there are free links to google podcast platform.

### For book lists, is it a book? For course lists, is it a course? etc.

It is a podcast list links with the same topic as mentioned before **ios**.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
