### PR TITLE
Added HeadFIrst JavaScript

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1108,6 +1108,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Essential Javascript](https://www.programming-books.io/essential/javascript/) - Krzysztof Kowalczyk, StackOverflow Contributors
 * [Exploring ES6](http://exploringjs.com/es6/) - Dr. Axel Rauschmayer (HTML)
 * [Google JavaScript Style Guide](https://google.github.io/styleguide/javascriptguide.xml) - Aaron Whyte, Bob Jervis, Dan Pupius, Erik Arvidsson, Fritz Schneider, Robby Walker (HTML)
+* [Head First JavaScript](https://dump.nrgs.org/bakerscollege/drmfree/General%20Programming/Head%20First/headfirstjavascriptprogramming_ebook.pdf) - Eric Freeman, Elisabeth Robson (PDF)
 * [Human JavaScript](http://read.humanjavascript.com/ch01-introduction.html) - Henrik Joreteg (HTML)
 * [JavaScript (ES2015+) Enlightenment](https://frontendmasters.com/guides/javascript-enlightenment/) - Cody Lindley (HTML)
 * [JavaScript Allongé](https://leanpub.com/javascript-allonge/read) - Reginald Braithwaite (HTML)


### PR DESCRIPTION
Added a pdf link of "HeadFirst JavaScript" available for free

## What does this PR do?
Add resource(s)

## For resources
### Description
Head First JavaScript 
### Why is this valuable (or not)?
It's a widely acknowledged book to explain concepts of Javascript in a simple and concise fashion. I myself have been reading a hard copy of this book
### How do we know it's really free?
It's available for free on a org's website which you can confirm yourself
### For book lists, is it a book? For course lists, is it a course? etc.
Yes, It's a book
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
