### PR TITLE
Added "Head First Programming"

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -717,6 +717,7 @@ Kerridge (PDF) (email address *requested*, not required)
 ### Programming Paradigms
 
 * [Flow based Programming](http://jpaulmorrison.com/fbp/) - J Paul Morrison
+* [Head First Programming](https://doc.lagout.org/programmation/Head%20First%20-%20Programming.pdf) - Paul Barry, David Griffiths (PDF)
 * [Introduction to Functional Programming](http://www.cl.cam.ac.uk/teaching/Lectures/funprog-jrh-1996/) - J. Harrison
 * [Making Sense of Stream Processing](https://assets.confluent.io/m/2a60fabedb2dfbb1/original/20190307-EB-Making_Sense_of_Stream_Processing_Confluent.pdf) - Martin Kleppmann (PDF)
 * [Mostly Adequate Guide to Functional Programming](https://mostly-adequate.gitbooks.io/mostly-adequate-guide/content/) - Mostly Adequate Core Team


### PR DESCRIPTION
Added a pdf resource for "Head First Programming"

## What does this PR do?
Add resource(s)

## For resources
### Description
Head FIrst Programming PDF 
### Why is this valuable (or not)?
It's considered very helpful to beginners-to-intermediate programmers to understand programming principles and concepts
### How do we know it's really free?
It's hosted for free on the website which can be verified 
### For book lists, is it a book? For course lists, is it a course? etc.
Yes, It's a book
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
