### PR TITLE
[README.md] fix: French translation of CoC title

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ Volunteers have translated many of our Contributing, How-to, and Code of Conduct
   - [Contributing](CONTRIBUTING-fil.md)
   - [How-to](HOWTO-fil.md)
 - French / français
-  - [Code de Contrat](CODE_OF_CONDUCT-fr.md)
+  - [Code de Conduite](CODE_OF_CONDUCT-fr.md)
   - [Contributing](CONTRIBUTING-fr.md)
   - [How-to](HOWTO-fr.md)
 - German / Deutsch


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
README.md

### Description

Fix of wrong and inconsistant French translation of `conduct` word in README.md document.
