### PR TITLE
fix: update angular material link

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2526,7 +2526,7 @@ That section got so big, we decided to split it into its own file, the [BY SUBJE
 * [Angular 2 Style Guide](https://github.com/johnpapa/angular-styleguide/blob/master/a2/README.md) - John Papa (HTML)
 * [Angular 2+ Notes for Professionals](https://goalkicker.com/Angular2Book/) - Compiled from StackOverflow documentation ([PDF](https://goalkicker.com/Angular2Book/Angular2NotesForProfessionals.pdf))
 * [Angular Docs](https://angular.io/docs) (HTML)
-* [Angular Material](https://material.angular.io/guide) (HTML)
+* [Angular Material](https://material.angular.io/guides) (HTML)
 * [Angular Tutorial](https://angular.io/tutorial) (HTML)
 * [Build a Full-Stack Web Application Using Angular & Firebase](https://www.c-sharpcorner.com/ebooks/build-a-full-stack-web-application-using-angular-and-firebase) - Ankit Sharma (PDF, [:package: code samples](https://github.com/AnkitSharma-007/blogging-app-with-Angular-CloudFirestore))
 


### PR DESCRIPTION
- angular 'guide' has been replaced with a collection of guides
- link updated to suit new landing page
- corrects existing 404

## What does this PR do?
Improve repo

## For resources
Corrects broken link

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
