### PR TITLE
Add book from freeCodeCamp

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -725,6 +725,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Confessions of an IT Manager](https://www.red-gate.com/library/confessions-of-an-it-manager) - Phil Factor (PDF)
 * [Don't Just Roll the Dice](https://www.red-gate.com/library/dont-just-roll-the-dice) - Neil Davidson (PDF)
 * [How to Do What You Love & Earn What You’re Worth as a Programmer](https://leanpub.com/dowhatyoulove/read) - Reginald Braithwaite
+* [How to Learn to Code & Get a Developer Job in 2023](https://www.freecodecamp.org/news/learn-to-code-book) - Quincy Larson
 * [Professional Software Development For Students](https://mixmastamyk.bitbucket.io/pro_soft_dev/intro.html) - Mike G. Miller
 * [Software Engineering at Google](https://abseil.io/resources/swe-book) - Titus Winters, Tom Manshreck, Hyrum Wright
 * [Software Environment Concepts](https://softwareconcepts.vercel.app) - Amr Elmohamady (:construction: *in process*)


### PR DESCRIPTION
## What does this PR do?
Add "How to Learn to Code and Get a Developer Job in 2023" book from freeCodeCamp

## For resources
### Description

### Why is this valuable (or not)?

This book will teach you insights gained by Quincy Larson (author) over the past decade, including his personal journey into coding as a teacher in his 30s, his career as a software developer, and his experience running freeCodeCamp.org.

### How do we know it's really free?

It's now freely available to anyone who wants to learn to code and become a professional developer. You can read the whole thing [here](https://www.freecodecamp.org/news/learn-to-code-book/).

### For book lists, is it a book? For course lists, is it a course? etc.

It's a full-length book.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
