### PR TITLE
security: `set-output` cmd deprecated. Use `$GITHUB_OUTPUT` env file

### DIFF
--- a/.github/actions/awesomebot-gh-summary-action/action.yml
+++ b/.github/actions/awesomebot-gh-summary-action/action.yml
@@ -86,12 +86,11 @@ runs:
           }
         }
 
-        # HACK to single line strings (https://trstringer.com/github-actions-multiline-strings/)
-        #$text = $text -replace "`%","%25"
-        #$text = $text -replace "`n","%0A"
-        #$text = $text -replace "`r","%25"
-        # set output
-        echo "text=$text" >> $env:GITHUB_OUTPUT
+        # set multiline output
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        echo "text<<$EOF" >> $env:GITHUB_OUTPUT
+        echo "$text" >> $env:GITHUB_OUTPUT
+        echo "$EOF" >> $env:GITHUB_OUTPUT
 
 
     - name: Write output

--- a/.github/actions/awesomebot-gh-summary-action/action.yml
+++ b/.github/actions/awesomebot-gh-summary-action/action.yml
@@ -86,8 +86,13 @@ runs:
           }
         }
 
-        # set multiline output
+        # set multiline output (the way of prevent script injection)
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        # https://github.com/orgs/community/discussions/26288#discussioncomment-3876281
+        delimiter="$(openssl rand -hex 8)"
+        echo "1=$EOF"
+        echo "2=$env:EOF"
+        echo "3=$delimiter"
         echo "text<<$EOF" >> $env:GITHUB_OUTPUT
         echo "$text" >> $env:GITHUB_OUTPUT
         echo "$EOF" >> $env:GITHUB_OUTPUT

--- a/.github/actions/awesomebot-gh-summary-action/action.yml
+++ b/.github/actions/awesomebot-gh-summary-action/action.yml
@@ -87,9 +87,9 @@ runs:
         }
 
         # HACK to single line strings (https://trstringer.com/github-actions-multiline-strings/)
-        $text = $text -replace "`%","%25"
-        $text = $text -replace "`n","%0A"
-        $text = $text -replace "`r","%25"
+        #$text = $text -replace "`%","%25"
+        #$text = $text -replace "`n","%0A"
+        #$text = $text -replace "`r","%25"
         # set output
         echo "text=$text" >> $env:GITHUB_OUTPUT
 

--- a/.github/actions/awesomebot-gh-summary-action/action.yml
+++ b/.github/actions/awesomebot-gh-summary-action/action.yml
@@ -86,16 +86,13 @@ runs:
           }
         }
 
-        # set multiline output (the way of prevent script injection)
+        # set multiline output (the way of prevent script injection is with random delimiters)
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         # https://github.com/orgs/community/discussions/26288#discussioncomment-3876281
         $delimiter = (openssl rand -hex 8) | Out-String
-        echo "1=$EOF"
-        echo "2=$env:EOF"
-        echo "3=$delimiter"
-        echo "text<<$env:EOF" >> $env:GITHUB_OUTPUT
+        echo "text<<$delimiter" >> $env:GITHUB_OUTPUT
         echo "$text" >> $env:GITHUB_OUTPUT
-        echo "$env:EOF" >> $env:GITHUB_OUTPUT
+        echo "$delimiter" >> $env:GITHUB_OUTPUT
 
 
     - name: Write output

--- a/.github/actions/awesomebot-gh-summary-action/action.yml
+++ b/.github/actions/awesomebot-gh-summary-action/action.yml
@@ -91,7 +91,7 @@ runs:
         $text = $text -replace "`n","%0A"
         $text = $text -replace "`r","%25"
         # set output
-        echo "::set-output name=text::$text"
+        echo "text=$text" >> $env:GITHUB_OUTPUT
 
 
     - name: Write output

--- a/.github/actions/awesomebot-gh-summary-action/action.yml
+++ b/.github/actions/awesomebot-gh-summary-action/action.yml
@@ -89,13 +89,13 @@ runs:
         # set multiline output (the way of prevent script injection)
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         # https://github.com/orgs/community/discussions/26288#discussioncomment-3876281
-        delimiter="$(openssl rand -hex 8)"
+        $delimiter = (openssl rand -hex 8) | Out-String
         echo "1=$EOF"
         echo "2=$env:EOF"
         echo "3=$delimiter"
-        echo "text<<$EOF" >> $env:GITHUB_OUTPUT
+        echo "text<<$env:EOF" >> $env:GITHUB_OUTPUT
         echo "$text" >> $env:GITHUB_OUTPUT
-        echo "$EOF" >> $env:GITHUB_OUTPUT
+        echo "$env:EOF" >> $env:GITHUB_OUTPUT
 
 
     - name: Write output

--- a/.github/workflows/check-urls.yml
+++ b/.github/workflows/check-urls.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Determine workflow parameters
         id: init-params
         run: |
-          echo "::set-output name=fetch_depth::0";
+          echo "fetch_depth=0" >> $GITHUB_OUTPUT
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "::set-output name=fetch_depth::0";
+            echo "fetch_depth=0" >> $GITHUB_OUTPUT
           fi
 
       - uses: actions/checkout@v3

--- a/.github/workflows/detect-conflicting-prs.yml
+++ b/.github/workflows/detect-conflicting-prs.yml
@@ -51,10 +51,12 @@ jobs:
         run: |
           echo "$INPUT_PRS"  \
             | jq --compact-output --raw-output 'to_entries | map({number: .key, dirty: .value})'  \
-            | sed -e 's/^/::set-output name=prs::/'
+            | sed -e 's/^/prs=/'  \
+            >> $GITHUB_OUTPUT
           echo "$INPUT_PRS"  \
             | jq --raw-output 'to_entries | length'  \
-            | sed -e 's/^/::set-output name=prs-len::/'
+            | sed -e 's/^/prs-len=/'  \
+            >> $GITHUB_OUTPUT
         env:
           INPUT_PRS: ${{ steps.pr-labeler.outputs.prDirtyStatuses }}
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -129,17 +129,21 @@ jobs:
         run: |
           echo $INPUT_ISSUES  \
             | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
-            | sed -e 's/^/::set-output name=issues::/'
+            | sed -e 's/^/issues=/'  \
+            >> $GITHUB_OUTPUT
           echo $INPUT_ISSUES  \
             | jq --raw-output '. | length'  \
-            | sed -e 's/^/::set-output name=issues-len::/'
+            | sed -e 's/^/issues-len=/'  \
+            >> $GITHUB_OUTPUT
 
           echo $INPUT_PRS  \
             | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
-            | sed -e 's/^/::set-output name=prs::/'
+            | sed -e 's/^/prs=/'  \
+            >> $GITHUB_OUTPUT
           echo $INPUT_PRS  \
             | jq --raw-output '. | length'  \
-            | sed -e 's/^/::set-output name=prs-len::/'
+            | sed -e 's/^/prs-len=/'  \
+            >> $GITHUB_OUTPUT
         env:
           INPUT_ISSUES: ${{ steps.stale-issues.outputs.staled-issues-prs }}
           INPUT_PRS:    ${{ steps.stale-prs.outputs.staled-issues-prs }}
@@ -148,17 +152,21 @@ jobs:
         run: |
           echo $INPUT_ISSUES  \
             | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
-            | sed -e 's/^/::set-output name=issues::/'
+            | sed -e 's/^/issues=/'  \
+            >> $GITHUB_OUTPUT
           echo $INPUT_ISSUES  \
             | jq --raw-output '. | length'  \
-            | sed -e 's/^/::set-output name=issues-len::/'
+            | sed -e 's/^/issues-len=/'  \
+            >> $GITHUB_OUTPUT
 
           echo $INPUT_PRS  \
             | jq --compact-output --raw-output 'del(.[] | .[to_entries[] | .key | select(startswith("_"))])'  \
-            | sed -e 's/^/::set-output name=prs::/'
+            | sed -e 's/^/prs=/'  \
+            >> $GITHUB_OUTPUT
           echo $INPUT_PRS  \
             | jq --raw-output '. | length'  \
-            | sed -e 's/^/::set-output name=prs-len::/'
+            | sed -e 's/^/prs-len=/'  \
+            >> $GITHUB_OUTPUT
         env:
           INPUT_ISSUES: ${{ steps.stale-issues.outputs.closed-issues-prs }}
           INPUT_PRS:    ${{ steps.stale-prs.outputs.closed-issues-prs }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -81,7 +81,7 @@ jobs:
           stale-pr-label: " "
 
       - name: Print outputs for issues
-        run: echo ${{ join(steps.stale-issues.outputs.*, ',') }}
+        run: echo ${{ format('{0},{1}', toJSON(steps.stale-issues.outputs.staled-issues-prs), toJSON(steps.stale-issues.outputs.closed-issues-prs)) }}
 
       - name: Stale Pull Requests
         uses: actions/stale@v7
@@ -120,7 +120,7 @@ jobs:
           stale-issue-label: " "
 
       - name: Print outputs for PRs
-        run: echo ${{ join(steps.stale-prs.outputs.*, ',') }}
+        run: echo ${{ format('{0},{1}', toJSON(steps.stale-prs.outputs.staled-issues-prs), toJSON(steps.stale-prs.outputs.closed-issues-prs)) }}
 
       ## Removing private properties from each JSON object and compute array length
       ## TODO: Delete these set-* workarounds when resolve actions/stale#806 ?


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

>To avoid untrusted logged data to use `save-state` and `set-output` workflow commands without the intention of the workflow author we have introduced a new set of environment files to manage state and output.

Starting 1st June 2023 workflows using `save-state` or `set-output` commands via stdout will fail with an error.

More info:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

### Why is this valuable (or not)?

![image](https://user-images.githubusercontent.com/3125580/220618267-43d24d36-fe89-4437-9a90-d18f38312724.png)

It patches the deprecation

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
