### PR TITLE
Fix link Symfony 5 and add link Symfony 6

### DIFF
--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -254,7 +254,8 @@
 
 #### Symfony
 
-* [En route pour Symfony 5](https://symfony.com/doc/5.0/the-fast-track/fr/index.html) - Fabien Potencier
+* [En route pour Symfony 5.4]([https://symfony.com/doc/5.0/the-fast-track/fr/index.html](https://symfony.com/doc/5.4/the-fast-track/fr/index.html)) - Fabien Potencier
+* [En route pour Symfony 6.2](https://symfony.com/doc/current/the-fast-track/fr/index.html) - Fabien Potencier
 
 
 ### Processing


### PR DESCRIPTION
## What does this PR do?
Add resource(s) & Remove resource(s) & Improve repo

## For resources
### Description

Fix link Symfony 5 and add link Symfony 6

### Why is this valuable (or not)?

Add the correct link for version 5 and also add the link for version 6

### How do we know it's really free?

The official website allows you to read online free of charge

### For book lists, is it a book? For course lists, is it a course? etc.

It is an online book

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
