### PR TITLE
Removed old and redundant statistics from the Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This page is available as an easy-to-read website. Access it by clicking on [![h
 
 This list was originally a clone of [StackOverflow - List of Freely Available Programming Books](https://web.archive.org/web/20140606191453/http://stackoverflow.com/questions/194812/list-of-freely-available-programming-books/392926) with contributions from Karan Bhangui and George Stocker.
 
-The list was moved to GitHub by Victor Felder for collaborative updating and maintenance. It has grown to become one of [GitHub's most popular repositories](https://octoverse.github.com/), with 271,000+ stars, about 9,700 watchers, more than 8,300 commits, 2,400+ contributors, and 54,000+ forks.
+The list was moved to GitHub by Victor Felder for collaborative updating and maintenance. It has grown to become one of [GitHub's most popular repository](https://octoverse.github.com/).
 
 <div align="center" markdown="1">
 


### PR DESCRIPTION
## What does this PR do?
Remove redundant information.

## For resources
### Description
The repository stats provided by GitHub always tell the current stats and are updated automatically. This removes the necessity to update the data on a regular basis. Keeping the same in the readme is not correct.

### Why is this valuable (or not)?
The data in written form was redundant and required updates after every sometime. The GitHub stats tell the current data always.