### PR TITLE
Some Delphi and Pascal programing resources 

### DIFF
--- a/books/free-programming-books-da.md
+++ b/books/free-programming-books-da.md
@@ -3,6 +3,7 @@
 * [C](#c)
 * [C#](#csharp)
 * [C++](#cpp)
+* [Delphi](#delphi)
 * [Java](#java)
 * [Pascal](#pascal)
 
@@ -21,6 +22,11 @@
 ### <a id="cpp"></a>C++
 
 * [Notes about C++](http://people.cs.aau.dk/~normark/ap/index.html) - Kurt Nørmark (HTML)
+
+
+### Delphi
+
+* [Programmering Med Delphi 7](https://delphi-books.com/en/Programmering-Med-Delphi-7.html) - Ole Witt-Hansen
 
 
 ### Java

--- a/books/free-programming-books-da.md
+++ b/books/free-programming-books-da.md
@@ -26,7 +26,7 @@
 
 ### Delphi
 
-* [Programmering Med Delphi 7](https://delphi-books.com/en/Programmering-Med-Delphi-7.html) - Ole Witt-Hansen
+* [Programmering Med Delphi 7](http://olewitthansen.dk/Datalogi/ProgrammeringMedDelphi.pdf) - Ole Witt-Hansen (PDF)
 
 
 ### Java

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -32,7 +32,6 @@
 * [Lua](#lua)
 * [Mathématiques](#math%C3%A9matiques)
 * [Meteor](#meteor)
-* [Pascal - Object Pascal](#pascal)
 * [Perl](#perl)
 * [PHP](#php)
     * [Symfony](#symfony)
@@ -234,11 +233,6 @@
 ### Meteor
 
 * [Apprendre Meteor](https://mquandalle.gitbooks.io/apprendre-meteor/content/) - Maxime Quandalle
-
-
-### Pascal - Object Pascal
-
-* [J'apprends à programmer en Pascal Objet](https://lazarus.developpez.com/livre/livre-pascal-objet/) - Gilles Vasseur, Jean-Luc Gofflot (PDF, EPUB) (email address required)
 
 
 ### Perl

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -32,6 +32,7 @@
 * [Lua](#lua)
 * [Mathématiques](#math%C3%A9matiques)
 * [Meteor](#meteor)
+* [Pascal - Object Pascal](#pascal)
 * [Perl](#perl)
 * [PHP](#php)
     * [Symfony](#symfony)
@@ -238,6 +239,11 @@
 ### Meteor
 
 * [Apprendre Meteor](https://mquandalle.gitbooks.io/apprendre-meteor/content/) - Maxime Quandalle
+
+
+### Pascal - Object Pascal
+
+* [J'apprends à programmer en Pascal Objet](https://lazarus.developpez.com/livre/livre-pascal-objet/) - Gilles Vasseur, Jean-Luc Gofflot
 
 
 ### Perl

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -243,7 +243,7 @@
 
 ### Pascal - Object Pascal
 
-* [J'apprends à programmer en Pascal Objet](https://lazarus.developpez.com/livre/livre-pascal-objet/) - Gilles Vasseur, Jean-Luc Gofflot
+* [J'apprends à programmer en Pascal Objet](https://lazarus.developpez.com/livre/livre-pascal-objet/) - Gilles Vasseur, Jean-Luc Gofflot (PDF, EPUB) (email address required)
 
 
 ### Perl

--- a/courses/free-courses-fr.md
+++ b/courses/free-courses-fr.md
@@ -6,6 +6,7 @@
 * [C](#c)
 * [C#](#csharp)
 * [C++](#cpp)
+* [Delphi](#delphi)
 * [Git](#git)
 * [HTML and CSS](#html-and-css)
 * [Java](#java)
@@ -54,6 +55,11 @@
 ### <a id="cpp"></a>C++
 
 * [La programmation en C++ moderne](https://zestedesavoir.com/tutoriels/822/la-programmation-en-c-moderne/) - Zeste de savoir informaticienzero mehdidou99
+
+
+### Delphi
+
+* [Apprendre la programmation avec Delphi](https://apprendre-delphi.fr/apprendre-la-programmation-avec-delphi-2020.php) - Patrick Prémartin
 
 
 ### Git


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description

Added 2 free books :
- one in french on Pascal language
- one in danish on Delphi 7 programming, old book from Ole Witt Hanson (lost in lot of links pages from its website)

Added a FR course on Delphi programming, done live during COVID containment in 2020.

### Why is this valuable (or not)?

no resource about Pascal or Delphi programming in the list(s) but more than 3M developers worldwide with a legal updated Delphi license, free Pascal compilers and Delphi Community Edition are available online, having courses and books links is valuable to make a choice in front of (not so good) web technologies and Java/C++

### How do we know it's really free?

available on authors websites

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
