### PR TITLE
Add PyOpenCl learning resources for English version of free programming resource books

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -174,6 +174,7 @@ Books on general-purpose programming that don't focus on a specific language are
     * [Flask](#flask)
     * [Kivy](#kivy)
     * [Pandas](#pandas)
+    * [PyOpenCl](#pyopencl)
     * [Pyramid](#pyramid)
     * [Tornado](#tornado)
 * [Q#](#q-sharp)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2099,6 +2099,12 @@ Books on general-purpose programming that don't focus on a specific language are
 * [pandas: powerful Python data analysis toolkit](https://pandas.pydata.org/docs) - Wes McKinney, the Pandas Development Team (HTML, PDF)
 
 
+#### PyOpenCl
+
+* [Programming GPUs with Python: PyOpenCL and PyCUDA](http://homepages.math.uic.edu/~jan/mcs572f16/mcs572notes/lec29.html)
+* [PyOpenCl Documentation](https://documen.tician.de/pyopencl/)
+
+
 #### Pyramid
 
 * [Quick Tutorial for Pyramid](http://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/index.html#quick-tutorial)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2101,8 +2101,8 @@ Books on general-purpose programming that don't focus on a specific language are
 
 #### PyOpenCl
 
-* [Programming GPUs with Python: PyOpenCL and PyCUDA](http://homepages.math.uic.edu/~jan/mcs572f16/mcs572notes/lec29.html)
-* [PyOpenCl Documentation](https://documen.tician.de/pyopencl/)
+* [Programming GPUs with Python: PyOpenCL and PyCUDA](http://homepages.math.uic.edu/~jan/mcs572f16/mcs572notes/lec29.html) - Jan Verschelde, University of Illinois Chicago (HTML)
+* [PyOpenCl Documentation](https://documen.tician.de/pyopencl/) - Andreas Kloeckner (HTML)
 
 
 #### Pyramid


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
books/free-programming-books-en.md

### Description
Add links to a couple of websites/documentation that details how to use the PyOpenCl library.

### Why is this valuable (or not)?
This helps people learn about accelerating python code with computation on gpus.

### How do we know it's really free?
Both the resources that were added were publically available on the internet and do not require any sort of sign-in/sign-up.

### For book lists, is it a book? For course lists, is it a course? etc.
The resources that were added were HTML pages. They were added in the book list for english.
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
