### PR TITLE
Update french and german resources for "sagebook"

### DIFF
--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -170,11 +170,6 @@
 * [Linux - Das umfassende Handbuch](https://openbook.rheinwerk-verlag.de/linux/) - Johannes Plötner, Steffen Wendzel (HTML)
 
 
-### Mathematik
-
-* [Calcul mathématique avec SAGE](http://www.loria.fr/~zimmerma/sagebook/CalculDeutsch.pdf) - Paul Zimmermann, et al. (PDF)
-
-
 ### Meta-Lists
 
 * [Galileo Computing - openbook](https://www.rheinwerk-verlag.de/openbook)
@@ -238,6 +233,11 @@
 ### Rust
 
 * [Die Programmiersprache Rust](https://rust-lang-de.github.io/rustbook-de/) - Steve Klabnik, Carol Nichols, Übersetzung durch die Rust-Gemeinschaft (HTML)
+
+
+### Sage
+
+* [Rechnen mit SageMath](https://www.loria.fr/~zimmerma/sagebook/CalculDeutsch.pdf) - Paul Zimmermann, et al. (PDF)
 
 
 ### Scilab

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -224,11 +224,6 @@
 * [Traité de programmation en Common Lisp](http://dept-info.labri.fr/~strandh/Teaching/Programmation-Symbolique/Common/Book/HTML/programmation.html) - Robert Strandh, Irène Durand
 
 
-### Mathématiques
-
-* [Calcul mathématique avec Sage](https://web.archive.org/web/20210715234128/http://sagebook.gforge.inria.fr/) - Paul Zimmermann, et al. *(:card_file_box: archived)*
-
-
 ### Lua
 
 * [Introduction à la programmation Lua](http://www.luteus.biz/Download/LoriotPro_Doc/LUA/LUA_Training_FR/Introduction_Programmation.html)
@@ -301,7 +296,7 @@
 
 ### Sage
 
-* [Calcul mathématique avec Sage](https://hal.inria.fr/inria-00540485/file/sagebook-web-20130530.pdf) - A. Casamayou, N. Cohen, G. Connan, T. Dumont, L. Fousse, F. Maltey, M. Meulien, M. Mezzarobba, C. Pernet, N. M. Thiéry, P. Zimmermann (PDF)
+* [Calcul mathématique avec Sage](https://hal.inria.fr/inria-00540485/file/sagebook-web-20130530.pdf) - P. Zimmermann, et al. (PDF)
 
 
 ### Scilab


### PR DESCRIPTION
## What does this PR do?

Remove one resource and update two.  All resources relates to "sagebook"

## For resources

By "sagebook" I mean the book referred to in https://www.sagemath.org/sagebook/; It was initially written in French and has been translated to English and German.

### Description

### Why is this valuable (or not)?

French page has duplicated entries for "sagebook", one of them refers to an obsolete archived version distributed with HTTP, not HTTPS.

German page has the French title in its link and it's not placed in the "Sage" section like in the English and French pages.

### How do we know it's really free?

"sagebook" is distributed with a Creative commons license.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
