### PR TITLE
Updated CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,7 @@ By contributing you agree to respect the [Code of Conduct](CODE_OF_CONDUCT.md) o
 
     - *Books* : PDF, HTML, ePub, a gitbook.io based site, a Git repo, etc.
     - *Courses* : A course is a learning material which is not a book. [This is a course](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-006-introduction-to-algorithms-fall-2011/).
-    - *Interactive Tutorials* : An interactive website which lets the user type code or commands and evaluates the result (by "evaluate" we don't mean "grade"). e.g.: [Try Haskell](http://tryhaskell.org), [Try GitHub](http://try.github.io).
+    - *Interactive Tutorials* : An interactive website which lets the user type code or commands and evaluates the result (by "evaluate" we don't mean "grade"). e.g.: [Try Haskell](http://tryhaskell.org), [Try Git](https://learngitbranching.js.org).
     - *Playgrounds* : are online and interactive websites, games or desktop software for learning programming. Write, compile (or run), and share code snippets. Playgrounds often allow you to fork and get your hands dirty by playing with code.
     - *Podcasts and Screencasts* : Podcasts and screencasts.
     - *Problem Sets & Competitive Programming* : A website or software which lets you assess your programming skills by solving simple or complex problems, with or without code review, with or without comparing the results with other users.


### PR DESCRIPTION
Replaced [Try GitHub](http://try.github.io) with [Try Git](https://learngitbranching.js.org) in [CONTRIBUTING.md](http://contributing.md/)

## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## For resources
I have added [Try Git](https://learngitbranching.js.org)

We can also try other alternative like :
[Basic Git Workflow](https://learngitbranching.js.org)

### Description

### Why is this valuable (or not)?
This improves the “In a nutshell” for Interactive Tutorials section of [CONTRIBUTING.md](http://contributing.md/) as it prominently links to Try Git at https://try.github.com/, but the interactive tutorial is no longer available there.

### How do we know it's really free?
Made available for free on Internet by the Publisher

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!


