### PR TITLE
Add algorithm engineering course

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -137,6 +137,7 @@
 
 * [Advanced Data Structures](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-851-advanced-data-structures-spring-2012/) - Erik Demaine
 * [Advanced Data Structures](https://www.youtube.com/playlist?list=PLv9sD0fPjvSHqIOLTIvHJWjkdH0IdzmXT) - Uzair Javed Akhtar
+* [Algorithm Engineering](https://ocw.mit.edu/courses/6-5060-algorithm-engineering-spring-2023/) - Charles Leiserson, Julian Shun
 * [Algorithms](https://www.youtube.com/playlist?list=PLDN4rrl48XKpZkf03iYFl-O29szjTrs_O) - Abdul Bari
 * [Algorithms and Data Structures Tutorial - Full Course for Beginners](https://www.youtube.com/watch?v=8hly31xKli0) - Pasan Premaratne, Jay McGavren (freeCodeCamp)
 * [Analysis of Algorithms (CSE 373)](https://www3.cs.stonybrook.edu/~skiena/373/videos) - Steven Skiena


### PR DESCRIPTION
Adding the free Algorithm Engineering course from Spring 2023 to the Algorithm section

## What does this PR do?
This PR adds the MIT Algorithm Engineering course from Spring 2023 to the list of courses

## For resources
### Description

### Why is this valuable (or not)?
This Algorithm Course is from 2023. It's from a reputable source (MIT) and covers both Algorithms and data structures. 

### How do we know it's really free?
You don't need to sign up to access the content

### For book lists, is it a book? For course lists, is it a course? etc.
It's a course

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
