### PR TITLE
Remove broken link to phpfiddle - bad certificate

### DIFF
--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -250,7 +250,6 @@
 
 * [Codepad](http://codepad.org/?lang=PHP)
 * [ExtendsClass](https://extendsclass.com/php.html)
-* [PHPFiddle](https://phpfiddle.org)
 * [PHPTester](http://phptester.net)
 * [SoloLearn](https://code.sololearn.com/php)
 


### PR DESCRIPTION
Currently, https://phpfiddle.org/ gives `SSL_ERROR_BAD_CERT_DOMAIN` - looks like it has been replaced with a generic landing page.

## What does this PR do?
Remove resource

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
