### PR TITLE
Add interactive tutorial page in German and Python course - changes made

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ This project lists books and other resources grouped by genres:
 
 + [Chinese / 中文](more/free-programming-interactive-tutorials-zh.md)
 + [English](more/free-programming-interactive-tutorials-en.md)
++ [German](more/free-programming-interactive-tutorials-de.md)
 + [Japanese / 日本語](more/free-programming-interactive-tutorials-ja.md)
 + [Portuguese (Brazil)](more/free-programming-interactive-tutorials-pt_BR.md)
 + [Russian / Русский язык](more/free-programming-interactive-tutorials-ru.md)

--- a/more/free-programming-interactive-tutorials-de.md
+++ b/more/free-programming-interactive-tutorials-de.md
@@ -1,0 +1,8 @@
+### Index
+
+* [Python](#python)
+
+
+### Python
+
+* [CS Circles - Interaktiv Python lernen!](https://cscircles.cemc.uwaterloo.ca/de/) - University of Waterloo & Bundesweite Informatikwettbewerbe (HTML)


### PR DESCRIPTION
## Add interactive tutorial page in German and Python course

* Add 'free-programming-interactive-tutorials-de.md'
* Add 'CS Circles - Interaktiv Python lernen!'

### Free?
Free interactive course (CC 3.0). No registration and login needed.