### PR TITLE
Update Spanish casts' Codely.TV screencasts location

### DIFF
--- a/casts/free-podcasts-screencasts-es.md
+++ b/casts/free-podcasts-screencasts-es.md
@@ -67,7 +67,7 @@
 ### Variados
 
 * [Code on the Rocks](http://codeontherocks.fm) - Jorge Barroso, Jorge Lería, Davide Mendolia (podcast)
-* [Codely.TV screencasts](https://codely.tv/blog/screencasts/) - Codely.TV (screencasts)
+* [Codely.TV screencasts](https://codely.com/blog/category/screencasts) - Codely.TV (screencasts)
 * [Cosas de Internet](https://cosasdeinternet.fm/episodios) - Santiago Espinosa, Laura Rojas Aponte (podcast)
 * [Día30](https://www.dia30.mx) - Víctor Velázquez, Mariana Ruiz (podcast)
 * [Digital. Innovation. Engineers.](https://anchor.fm/mimacom) - Mimacom (podcast)


### PR DESCRIPTION
## What does this PR do?
Update resource location. The location of Codely.TV screencast has been changed, so updated it to reflect its current location.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
