### PR TITLE
Update SmashTheStack location

### DIFF
--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -62,7 +62,7 @@
 * [HackThisSite](https://www.hackthissite.org) (email address *requested*)
 * [Overthewire Wargames fungame to practice CTF](https://overthewire.org/wargames/bandit)
 * [Picoctf](https://picoctf.org/resources.html) (email address *requested*)
-* [SmashtheStack](http://www.smashthestack.org/wargames.html)
+* [SmashTheStack](http://www.smashthestack.org/main.html#wargames)
 * [TryHackMe](https://tryhackme.com) (email address *requested*)
 
 


### PR DESCRIPTION
## What does this PR do?

Update SmashTheStack resource from the Problem Sets and Competitive Programming page, as the wargames page is no longer on its own, giving a 404. It's now a section on the main page.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
