### PR TITLE
Add Atareao con Linux podcast in Spanish

### DIFF
--- a/casts/free-podcasts-screencasts-es.md
+++ b/casts/free-podcasts-screencasts-es.md
@@ -59,6 +59,7 @@
 
 ### Software Libre
 
+* [Atareao con Linux](https://atareao.es/podcast) - Lorenzo Carbonell (podcast)
 * [Compilando Podcast](https://compilando.audio) - Paco Estrada (podcast)
 * [Mangocast](https://www.mangocast.net) - Lucho Benitez, Pablo Santa Cruz, Miguel Balsevich, Luis Corvalán, Rolando Natalizia (podcast)
 * [Podcast Linux](https://podcastlinux.com) - Juan Febles (podcast)


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description
Atareao is a Spanish podcast about Linux, open source software and programming.
### Why is this valuable (or not)?
The podcast has been broadcasting for six seasons with more than 500 episodes and a fixed frequency. It also has an important community on Telegram.
### How do we know it's really free?
The content is shared under CC4 licence.
### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
