### PR TITLE
Updated link for the Java Guide Book in the HE section

### DIFF
--- a/books/free-programming-books-he.md
+++ b/books/free-programming-books-he.md
@@ -6,7 +6,6 @@
 * [Assembly](#assembly)
 * [C](#c)
 * [C#](#csharp)
-* [Java](#java)
 * [Python](#python)
 
 
@@ -40,12 +39,6 @@
 ### Deep-Learning
 
 * [ספר על למידת מכונה ולמידה עמוקה](https://github.com/AvrahamRaviv/Deep-Learning-in-Hebrew) – אברהם רביב ומייק ארליסון
-
-
-### Java
-
-* [המדריך הישראלי לג׳אווה](https://github.com/3R1Dev/Chaim-Michael-Guide-to-Java) – חיים מיכאל
-
 
 ### Python
 

--- a/books/free-programming-books-he.md
+++ b/books/free-programming-books-he.md
@@ -44,7 +44,7 @@
 
 ### Java
 
-* [המדריך הישראלי לג׳אווה](https://javabook.co.il/wordpress/?page_id=10) – חיים מיכאל
+* [המדריך הישראלי לג׳אווה](https://github.com/3R1Dev/Chaim-Michael-Guide-to-Java) – חיים מיכאל
 
 
 ### Python

--- a/books/free-programming-books-he.md
+++ b/books/free-programming-books-he.md
@@ -40,6 +40,7 @@
 
 * [ספר על למידת מכונה ולמידה עמוקה](https://github.com/AvrahamRaviv/Deep-Learning-in-Hebrew) – אברהם רביב ומייק ארליסון
 
+
 ### Python
 
 * [תכנות בשפת פייתון](https://data.cyber.org.il/python/python_book.pdf) – ברק גונן, המרכז לחינוך סייבר (PDF)


### PR DESCRIPTION
## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo
This PR updates the existing link that is currently redirecting to a 404 page.
The link is for the Java Guide PDF book, I noticed the issue was opened a few months ago and it appears the link was to be removed. It was not removed and I am only making a PR to update the link that is currently present.

My Goal is to help with issues like this one and others if possible to make the free resources more accessible to those who need it.

## For resources
https://github.com/EbookFoundation/free-programming-books/issues/9338

### Description
In short it is only a restoration of the files, I am not the author of the book I am simply making it easier for someone to download the files by hosting the files on a repo on my Github.

### Why is this valuable (or not)?
This is to help with a closed issue 9338
I was able to restore the content and host it on my GitHub repo, this way the original book can be available. It is valuable due to the low amount of free books listed for Hebrew.

### How do we know it's really free?
It was made free before, and it can still be accessed via the archive.org site, I am only making it easier to access.

### For book lists, is it a book? For course lists, is it a course? etc.
It is a book/guide broken up by the original author in PDF format.

## Checklist:
- [ Y] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ Y] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ Y] Include author(s) and platform where appropriate.
- [ Y] Put lists in alphabetical order, correct spacing.
- [ Y] Add needed indications (PDF, access notes, under construction).
- [ Y] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
