### PR TITLE
Added the Apollo Graph Developer - Associate & Professional Certification

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1502,8 +1502,8 @@
 * [Apollo Graph Developer - Associate Certification](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) - Odyssey Apollo
 * [Apollo Graph Developer - Professional Certification](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional) - Odyssey Apollo
 * [ASP.NET Core Tutorial For Beginners](https://www.youtube.com/playlist?list=PL6n9fhu94yhVkdrusLaQsfERmL_Jh4XmU) - Venkat (Pragim Technologies)
-* [Bun Crash Course 2023 with HTMX example](https://www.youtube.com/watch?v=zNE5H6nOeCI) - Kaizen Codes
 * [Bun Crash Course | JavaScript Runtime, Bundler & Transpiler](https://www.youtube.com/watch?v=U4JVw8K19uY) - Traversy Media
+* [Bun Crash Course 2023 with HTMX example](https://www.youtube.com/watch?v=zNE5H6nOeCI) - Kaizen Codes
 * [Command Line Power User - for web developers](https://commandlinepoweruser.com) - WesBos (email address *required*)
 * [Create a Professional Website with Velo by Wix](https://www.codecademy.com/learn/create-a-professional-website-with-velo-by-wix) - Codecademy
 * [CS50’s Web Programming with Python and JavaScript](https://cs50.harvard.edu/web/) - Brian Yu, David J. Malan (edX Harvard CS50)

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -377,6 +377,7 @@
 #### Azure
 
 * [Azure Administrator Certification](https://www.youtube.com/watch?v=10PbGbTUSAg) - freeCodeCamp
+* [Introduction to the Microsoft Azure Well-Architected Framework](https://learn.microsoft.com/en-us/training/modules/azure-well-architected-introduction/) - Microsoft Learn
 * [Microsoft Azure Fundamentals](https://youtube.com/playlist?list=PLGjZwEtPN7j-Q59JYso3L4_yoCjj2syrM) - Adam Marczak
 * [Microsoft Certified: Azure Fundamentals](https://docs.microsoft.com/en-us/learn/certifications/azure-fundamentals/) - Microsoft
 

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1502,6 +1502,8 @@
 * [Apollo Graph Developer - Associate Certification](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) - Odyssey Apollo
 * [Apollo Graph Developer - Professional Certification](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional) - Odyssey Apollo
 * [ASP.NET Core Tutorial For Beginners](https://www.youtube.com/playlist?list=PL6n9fhu94yhVkdrusLaQsfERmL_Jh4XmU) - Venkat (Pragim Technologies)
+* [Bun Crash Course 2023 with HTMX example](https://www.youtube.com/watch?v=zNE5H6nOeCI) - Kaizen Codes
+* [Bun Crash Course | JavaScript Runtime, Bundler & Transpiler](https://www.youtube.com/watch?v=U4JVw8K19uY) - Traversy Media
 * [Command Line Power User - for web developers](https://commandlinepoweruser.com) - WesBos (email address *required*)
 * [Create a Professional Website with Velo by Wix](https://www.codecademy.com/learn/create-a-professional-website-with-velo-by-wix) - Codecademy
 * [CS50’s Web Programming with Python and JavaScript](https://cs50.harvard.edu/web/) - Brian Yu, David J. Malan (edX Harvard CS50)

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1500,6 +1500,7 @@
 ### Web Development
 
 * [Apollo Graph Developer - Associate Certification](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) - Odyssey Apollo
+* [Apollo Graph Developer - Professional Certification](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional) - Odyssey Apollo
 * [ASP.NET Core Tutorial For Beginners](https://www.youtube.com/playlist?list=PL6n9fhu94yhVkdrusLaQsfERmL_Jh4XmU) - Venkat (Pragim Technologies)
 * [Command Line Power User - for web developers](https://commandlinepoweruser.com) - WesBos (email address *required*)
 * [Create a Professional Website with Velo by Wix](https://www.codecademy.com/learn/create-a-professional-website-with-velo-by-wix) - Codecademy

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -377,6 +377,7 @@
 #### Azure
 
 * [Azure Administrator Certification](https://www.youtube.com/watch?v=10PbGbTUSAg) - freeCodeCamp
+* [Gatsby and Azure Static Web Apps](https://learn.microsoft.com/en-us/training/modules/create-deploy-static-webapp-gatsby-app-service/) - Microsoft
 * [Introduction to the Microsoft Azure Well-Architected Framework](https://learn.microsoft.com/en-us/training/modules/azure-well-architected-introduction/) - Microsoft Learn
 * [Microsoft Azure Fundamentals](https://youtube.com/playlist?list=PLGjZwEtPN7j-Q59JYso3L4_yoCjj2syrM) - Adam Marczak
 * [Microsoft Certified: Azure Fundamentals](https://docs.microsoft.com/en-us/learn/certifications/azure-fundamentals/) - Microsoft

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -659,6 +659,7 @@
 
 ### Git
 
+* [Automate development tasks by using GitHub Actions](https://learn.microsoft.com/en-us/training/modules/github-actions-automate-tasks/) Microsoft Learn
 * [Bento Git Learning Track](https://bento.io/topic/git) (Bento)
 * [Bento GitHub Learning Track](https://bento.io/topic/github) (Bento)
 * [Complete Git and GitHub Tutorial](https://www.youtube.com/watch?v=apGV9Kg7ics) - Kunal Kushwaha

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1522,6 +1522,7 @@
 * [Introduction to Professional Web Development in JavaScript](https://education.launchcode.org/intro-to-professional-web-dev/) - Chris Bay, Jim Flores, Blake Mills, Sally Steuterman, Paul Matthews, Carly Langlois (The LaunchCode Foundation)
 * [Java Web Development](https://education.launchcode.org/java-web-development/) - Chris Bay, Jim Flores, Carly Langlois, Sally Steuterman (The LaunchCode Foundation)
 * [Learn web development](https://developer.mozilla.org/en-US/docs/Learn) - Mozilla Contributors
+* [Learn web development](https://web.dev/learn/) - Google DevRel (web.dev)
 * [Programming & Web Development Crash Course](https://www.youtube.com/playlist?list=PLillGF-RfqbYeckUaD1z6nviTp31GLTH8) - Traversy Media
 * [Python Web Scraping & Crawling using Scrapy](https://www.youtube.com/playlist?list=PLhTjy8cBISEqkN-5Ku_kXG4QW33sxQo0t)
 * [React Fundamentals - The Complete Guide For Beginners](https://www.udemy.com/course/react-fundamentals-the-complete-guide-for-beginners/) - Kerim Abdelmouiz (Udemy)

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1499,6 +1499,7 @@
 
 ### Web Development
 
+* [Apollo Graph Developer - Associate Certification](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) - Odyssey Apollo
 * [ASP.NET Core Tutorial For Beginners](https://www.youtube.com/playlist?list=PL6n9fhu94yhVkdrusLaQsfERmL_Jh4XmU) - Venkat (Pragim Technologies)
 * [Command Line Power User - for web developers](https://commandlinepoweruser.com) - WesBos (email address *required*)
 * [Create a Professional Website with Velo by Wix](https://www.codecademy.com/learn/create-a-professional-website-with-velo-by-wix) - Codecademy


### PR DESCRIPTION
## What does this PR do?
Added the Apollo Graph Developer - Associate & Professional Certification. It's the course from the official GraphQL website. 

## For resources
### Description
Developers who obtain this certification possess a solid foundational knowledge of GraphQL and the Apollo tool suite to design a schema, run an Apollo Server 4, and perform queries with Apollo Client 3 on the frontend.

### Why is this valuable (or not)?
If someone is not familiar with GraphQL Apollo then this course is a perfect fit for them. 

### How do we know it's really free?
It is free, I have personally took this course

### For book lists, is it a book? For course lists, is it a course? etc.
It is a free course with certification.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
