### PR TITLE
Add Azure SDK github link

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -482,6 +482,7 @@ Books on general-purpose programming that don't focus on a specific language are
 ### <a id="csharp"></a>C\#
 
 * [Architect Modern Web Applications with ASP.NET Core and Azure](https://docs.microsoft.com/en-us/dotnet/architecture/modern-web-apps-azure/) - Steve "ardalis" Smith
+* [Azure SDK overview](https://azure.github.io/azure-sdk/) - Microsoft
 * [C# Features Succinctly](https://www.syncfusion.com/succinctly-free-ebooks/c-sharp-features-succinctly) - Dirk Strauss (HTML)
 * [C# Notes for Professionals](http://goalkicker.com/CSharpBook/) - Compiled from StackOverflow documentation (PDF)
 * [C# Programming](https://en.wikibooks.org/wiki/C_Sharp_Programming) - Wikibooks


### PR DESCRIPTION
## What does this PR do?
Provide a link to the Azure SDK github reference site.

### Why is this valuable (or not)?
Valuable because it provides direct link to information of the Azure SDK.

### How do we know it's really free?
You can navigate directly to the site.

### For book lists, is it a book? For course lists, is it a course? etc.
This is not actually a book, more an index of information about the different versions of the SDK provided with examples.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
