### PR TITLE
Update problem-sets-competitive-programming.md

### DIFF
--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -9,7 +9,6 @@
 
 ### Competitive Programming
 
-* [4Clojure](http://www.4clojure.com)
 * [A Way to Practice Competitive Programming](https://github.com/E869120/Competitive-Programming/blob/master/%5BTutorial%5D%20A%20Way%20to%20Practice%20Competitive%20Programming.pdf) - Masataka Yoneda (PDF)
 * [A2 Online Judge](https://a2oj.netlify.app)
 * [Algorithms for Competitive Programming](https://cp-algorithms.com)


### PR DESCRIPTION
removed a game site link form the lists of problem-sets-competitive-programming.md

noticed a game site link in the lists of problem sets for CP
removed the game site link

### Description-https://www.linkedin.com/in/ansuman-swain-704122228

do not need a game site link in a lists of problem sets for CP.

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
