### PR TITLE
Added New jQuery cheat sheet (Changes Made - Omitted `The`)

### DIFF
--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -238,7 +238,7 @@
 
 * [Beginner's essential jQuery Cheat Sheet](https://websitesetup.org/wp-content/uploads/2017/01/wsu-jquery-cheat-sheet.pdf) (PDF)
 * [jQuery CheatSheet](https://htmlcheatsheet.com/jquery/) (HTML)
-* [The jQuery Mega Cheat Sheet](https://makeawebsitehub.com/wp-content/uploads/2015/09/jquery-mega-cheat-sheet-Printable.pdf) - Jamie Spencer (PDF)
+* [jQuery Mega Cheat Sheet](https://makeawebsitehub.com/wp-content/uploads/2015/09/jquery-mega-cheat-sheet-Printable.pdf) - Jamie Spencer (PDF)
 
 
 #### Nest.js

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -238,6 +238,7 @@
 
 * [Beginner's essential jQuery Cheat Sheet](https://websitesetup.org/wp-content/uploads/2017/01/wsu-jquery-cheat-sheet.pdf) (PDF)
 * [jQuery CheatSheet](https://htmlcheatsheet.com/jquery/) (HTML)
+* [The jQuery Mega Cheat Sheet](https://makeawebsitehub.com/wp-content/uploads/2015/09/jquery-mega-cheat-sheet-Printable.pdf) - Jamie Spencer (PDF)
 
 
 #### Nest.js


### PR DESCRIPTION
## What does this PR do?
I added a new CheatSheet `The jQuery Mega Cheat Sheet` by `Jamie Spencer` and is a pdf file  (For **hacktober fest**).

## For resources
### Description
- This CheatSheet is free on `Make A Website Hub` Website and they are also distributing it for free through their [**website download page**](https://makeawebsitehub.com/jquery-mega-cheat-sheet/).
- Hope it helps.

### Why is this valuable (or not)?
- This **Mega CheatSheet** contains 99.9% all the elements of `jQuery` updated till date.
- This will help you incase of a useful keyboard shortcut to forget, a command you will just fail to remember, a newly introduced function that slips your mind or element you cease to think of.

### How do we know it's really free?
- You can check out [Make A Website Hub](https://makeawebsitehub.com/jquery-mega-cheat-sheet/) and as soon as you land, there is an option `Download a printable PDF of this graphic here` 

### For book lists, is it a book? For course lists, is it a course? etc.
- Yes, CheatSheet, The jQuery Mega Cheat Sheet.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Used an informative name for this pull request.
- [x] Add needed indications (PDF, access notes, under construction).

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
