### PR TITLE
Add Japanese resource: "Lisp 一夜漬け"

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -482,6 +482,7 @@
 * [GNU Emacs Lispリファレンスマニュアル](http://www.fan.gr.jp/~ring/doc/elisp_20/elisp.html)
 * [Google Common Lisp スタイルガイド 日本語訳](https://lisphub.jp/doc/google-common-lisp-style-guide/lispguide.xml) - Robert Brown, François-René Rideau, TOYOZUMIKouichi 他(翻訳)
 * [LISP and PROLOG](https://web.archive.org/web/20060526095202/http://home.soka.ac.jp/~unemi/LispProlog) - 畝見達夫
+* [Lisp 一夜漬け](https://www.haun.org/kent/lisp1/) - TAMURA Kent
 * [On Lisp (草稿)](http://www.asahi-net.or.jp/~kc7k-nd) - Paul Graham, 野田開(翻訳)
 * [マンガで分かるLisp(Manga Guide to Lisp)](http://lambda.bugyo.tk/cdr/mwl) - λ組
 


### PR DESCRIPTION
## What does this PR do?
Add resource

## For resources
### Description
Added the Japanese text "Lisp 一夜漬け".

### Why is this valuable (or not)?
This resource provides a comprehensive introduction to Lisp programming in Japanese, making it valuable for Japanese-speaking learners interested in Lisp.

### How do we know it's really free?
The resource "Lisp 一夜漬け" is freely available online with open access and no purchase requirements. It is not behind a paywall, and there are no known copyright restrictions.

### For book lists, is it a book? For course lists, is it a course? etc.
This is a book.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
