### PR TITLE
Adding Openstack - Update free-courses-en.md

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -18,6 +18,7 @@
     * [AWS](#aws)
     * [Azure](#azure)
     * [IBM](#ibm)
+    * [Openstack](#openstack)
 * [Compilers](#compilers)
 * [Computer Organization and Architecture](#computer-organization-and-architecture)
 * [Computer Science](#computer-science)
@@ -398,6 +399,11 @@
 
 * [Getting started with IBM Cloud](https://cognitiveclass.ai/courses/ibm-cloud-essentials) - Horea Porutiu, Steve Martinelli
 * [IBM Cloud Essentials V3](https://cognitiveclass.ai/courses/ibm-cloud-essentials) - CognitiveClass.ai
+
+### Openstack
+
+* [OpenStack Tutorial – Operate Your Own Private Cloud (Full Course)](https://www.youtube.com/watch?v=_gWfFEuert8) - FreeCodeCamp.org
+* [Openstack CERN Admin guide](https://clouddocs.web.cern.ch/index.html) - CERN
 
 
 ### Compilers


### PR DESCRIPTION
Added in Openstack into the cloud section with the Openstack tutorial by FreeCodeCamp and the Openstack CERN admin guide.

## What does this PR do?
Add resource(s)

## For resources
### Description
Adds in Openstack

### Why is this valuable (or not)?
Openstack is an open source cloud platform that is used in industry for research and scientific computing.

### How do we know it's really free?
Open source

### For book lists, is it a book? For course lists, is it a course? etc.
Courses and a guide

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
