### PR TITLE
Add refactoring is not clickbait screencast

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -291,6 +291,7 @@
 * [Open Source System Podcast](https://opensourcesystempodcast.vf.io) - Vlad Filippov, Kyle Robinson Young, Tim Branyen, Darcy Clarke, Mike Taylor, Alex Sexton, Jason Etcovitch (podcast)
 * [Programming Throwdown](https://www.programmingthrowdown.com) - Jason Gauci, Patrick Wheeler (podcast)
 * [Reactive](https://podcasts.apple.com/us/podcast/reactive/id1020286000) - Kahlil Lechelt, Raquel Vélez, Henning Glatter-Götz (podcast)
+* [Refactoring Is Not Just Clickbait by Kevlin Henney](https://www.youtube.com/watch?v=NMPeAW2RWdc&list=PL03Lrmd9CiGcXoPBhisyxmof9GfH2H6C8&index=61) - Kevlin Henney, NDC London 2023 (screencast)
 * [Security Now](https://www.grc.com/securitynow.htm) - Steve Gibson, Leo Laporte (podcast)
 * [Shop Talk Show](https://shoptalkshow.com) - Dave Rupert, Chris Coyier (podcast)
 * [Smashing podcast](https://podcast.smashingmagazine.com) - Drew McLellan, Smashing Magazine Team (podcast)


### PR DESCRIPTION
## What does this PR do?
Add screencast (conference presentation) about refactoring and why it's not just clickbait via a context menu or shortcut to refactor code.

## For resources
For many people, refactoring is a simple code transformation they click on in a context menu or via a keyboard shortcut. They can extract, inline, replace, move, rename, etc. at will. The widespread availability of automated refactoring should have made oversized classes and long-winded functions a thing of the past. But it hasn't.

Having a tool is only part of the solution: knowing what to do with it and how to use it well is what makes the bigger difference. In this talk, we'll revisit what refactoring is (and isn't), examine what practical and social obstacles refactoring faces, explore the idea that refactoring should be considered a design process and not just a clean-up click, and that most interesting refactorings are not necessarily automated.

### Why is this valuable (or not)?
Screencast is not existant in the ebooks repository.

### How do we know it's really free?
It's a video on youtube

### For book lists, is it a book? For course lists, is it a course? etc.
It's a screencast

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
