### PR TITLE
Link in free-courses-bg.md doesn't contain the course any more

### DIFF
--- a/courses/free-courses-bg.md
+++ b/courses/free-courses-bg.md
@@ -1,12 +1,6 @@
 ### Index
 
-* [Android](#android)
 * [PHP](#php)
-
-
-### Android
-
-* [Въведение в Андроид](https://www.youtube.com/playlist?list=PLjsqymUqgpSTXtlngZCXRHEp8-FmDHHfL) - Иван Ванков
 
 
 ### PHP


### PR DESCRIPTION
## What does this PR do?
Remove resource(s)
Make changes in #10383

### Description
The link doesn't contains the Android course in Bulgarian language any more, hence deleted.

### Why is this valuable (or not)?
It will not irritate our users.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).

