### PR TITLE
Fix URL for "GUI development with Relm4" + edit author's name

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -330,7 +330,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 ### Graphical User Interfaces
 
 * [Event-Driven GTK by Example — 2021 Edition](https://mmstick.github.io/gtkrs-tutorials/) - Michael Murphy
-* [GUI development with Relm4](https://relm4.org/book/stable/) - Relm4
+* [GUI development with Relm4](https://relm4.org/book/stable) - Relm4
 * [GUI development with Rust and GTK 4](https://gtk-rs.org/gtk4-rs/stable/latest/book/) - Julian Hofer
 * [Programming with gtkmm 4](https://developer.gnome.org/gtkmm-tutorial/stable/)
 * [Search User Interfaces](https://searchuserinterfaces.com/book/) - Marti A. Hearst

--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -330,7 +330,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 ### Graphical User Interfaces
 
 * [Event-Driven GTK by Example — 2021 Edition](https://mmstick.github.io/gtkrs-tutorials/) - Michael Murphy
-* [GUI development with Relm4](https://aaronerhardt.github.io/relm4-book/book/) - Aaron Erhardt
+* [GUI development with Relm4](https://relm4.org/book/stable/) - Relm4
 * [GUI development with Rust and GTK 4](https://gtk-rs.org/gtk4-rs/stable/latest/book/) - Julian Hofer
 * [Programming with gtkmm 4](https://developer.gnome.org/gtkmm-tutorial/stable/)
 * [Search User Interfaces](https://searchuserinterfaces.com/book/) - Marti A. Hearst


### PR DESCRIPTION
## What does this PR do?

Fix URL & author name for 1 resource. **This fixes #10403** 


## For resources

- "GUI development with Relm4" in "/books/free-programming-books-subjects.md"


### Description

- The previously provided was no longer available and gave a 404 page. It has been changed with the latest link for the book: https://relm4.org/book/stable/
- Also, changed author's name from "Aaron Erhardt" to "Relm4"


### Why is this valuable (or not)?

It fixes a URL which can be useful.


### How do we know it's really free?

It is available on [GitHub](https://github.com/Relm4/book) under an MIT license.


### For book lists, is it a book? For course lists, is it a course? etc.

It is a book (e-book / gitbook.io based site).


## Checklist:

- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.
