### PR TITLE
(Revised) - [HacktoberFest2023]: Added cpp.chat and No Diagnostic Required podcast under C++ podcasts section

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -59,6 +59,8 @@
 * [C++ STL by example](https://www.youtube.com/playlist?list=PLZ9NgFYEMxp5oH3mrr4IlFBn03rjS-gN1) - Douglas Schmidt (screencast)
 * [C++ STL: The ONLY Video You Need | Compulsory for DSA/CP](https://www.youtube.com/watch?v=PZogbfU4X5E) - Utkarsh Gupta (screencast)
 * [CppCast](http://cppcast.com) - Conor Hoekstra, Jason Turner, JeanHeyd Meneide, Matt Godbolt, Rob Irving (podcast)
+* [cpp.chat](https://cpp.chat/) - Jon Kalb, Phil Nash (podcast)
+* [No Diagnostic Required](https://nodiagnosticrequired.tv/) - Anastasia Kazakova, Phil Nash (podcast & YouTube show)
 
 
 ### Clojure

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -58,8 +58,8 @@
 * [C++ Standard Library](https://www.youtube.com/playlist?list=PL5jc9xFGsL8G3y3ywuFSvOuNm3GjBwdkb) - Bo Qian (screencast)
 * [C++ STL by example](https://www.youtube.com/playlist?list=PLZ9NgFYEMxp5oH3mrr4IlFBn03rjS-gN1) - Douglas Schmidt (screencast)
 * [C++ STL: The ONLY Video You Need | Compulsory for DSA/CP](https://www.youtube.com/watch?v=PZogbfU4X5E) - Utkarsh Gupta (screencast)
-* [CppCast](http://cppcast.com) - Conor Hoekstra, Jason Turner, JeanHeyd Meneide, Matt Godbolt, Rob Irving (podcast)
 * [cpp.chat](https://cpp.chat) - Jon Kalb, Phil Nash (podcast)
+* [CppCast](http://cppcast.com) - Conor Hoekstra, Jason Turner, JeanHeyd Meneide, Matt Godbolt, Rob Irving (podcast)
 * [No Diagnostic Required](https://nodiagnosticrequired.tv) - Anastasia Kazakova, Phil Nash (podcast)
 
 

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -59,8 +59,8 @@
 * [C++ STL by example](https://www.youtube.com/playlist?list=PLZ9NgFYEMxp5oH3mrr4IlFBn03rjS-gN1) - Douglas Schmidt (screencast)
 * [C++ STL: The ONLY Video You Need | Compulsory for DSA/CP](https://www.youtube.com/watch?v=PZogbfU4X5E) - Utkarsh Gupta (screencast)
 * [CppCast](http://cppcast.com) - Conor Hoekstra, Jason Turner, JeanHeyd Meneide, Matt Godbolt, Rob Irving (podcast)
-* [cpp.chat](https://cpp.chat/) - Jon Kalb, Phil Nash (podcast)
-* [No Diagnostic Required](https://nodiagnosticrequired.tv/) - Anastasia Kazakova, Phil Nash (podcast
+* [cpp.chat](https://cpp.chat) - Jon Kalb, Phil Nash (podcast)
+* [No Diagnostic Required](https://nodiagnosticrequired.tv) - Anastasia Kazakova, Phil Nash (podcast)
 
 
 ### Clojure

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -60,7 +60,7 @@
 * [C++ STL: The ONLY Video You Need | Compulsory for DSA/CP](https://www.youtube.com/watch?v=PZogbfU4X5E) - Utkarsh Gupta (screencast)
 * [CppCast](http://cppcast.com) - Conor Hoekstra, Jason Turner, JeanHeyd Meneide, Matt Godbolt, Rob Irving (podcast)
 * [cpp.chat](https://cpp.chat/) - Jon Kalb, Phil Nash (podcast)
-* [No Diagnostic Required](https://nodiagnosticrequired.tv/) - Anastasia Kazakova, Phil Nash (podcast & YouTube show)
+* [No Diagnostic Required](https://nodiagnosticrequired.tv/) - Anastasia Kazakova, Phil Nash (podcast
 
 
 ### Clojure


### PR DESCRIPTION
## What does this PR do?
Add resources

## For resources
### Description
- Added link to cpp.chat podcast
- Added link to No Diagnostic Required podcast

### Why is this valuable (or not)?
- cpp.chat and No Diagnostic Required are great C++ podcasts which brings some C++ news, interviews with C++ community members etc

### How do we know it's really free?
- Visit websites [cpp.chat](https://cpp.chat/) & [No Diagnostic Required](https://nodiagnosticrequired.tv/)

### For book lists, is it a book? For course lists, is it a course? etc.
- N.A

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
