### PR TITLE
Update free-podcasts-screencasts-en.md

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -174,7 +174,7 @@
 
 ### JavaScript
 
-* [devMode.fm](https://devmode.fm) - Andrew Welch, Ryan Ire­lan, Patrick Harrington, Jonathan Melville, Michael Rog, Earl John­ston, Mar­i­on Newlevant, Lau­ren Dorman, Matt Stein, Jen­nifer Blumberg (podcast)
+* [20 Min JS Podcast](https://20minjs.com/) - Agustinus Theodorus, Chris Bongers, Mark Volkmann, and others (podcast)* [devMode.fm](https://devmode.fm) - Andrew Welch, Ryan Ire­lan, Patrick Harrington, Jonathan Melville, Michael Rog, Earl John­ston, Mar­i­on Newlevant, Lau­ren Dorman, Matt Stein, Jen­nifer Blumberg (podcast)
 * [FiveJS](https://fivejs.codeschool.com) - CodeSchool (podcast)
 * [Front End Happy Hour](https://frontendhappyhour.com) - Ryan Burgess, Jem Young, Stacy London, Augustus Yuan, Mars Jullian, Shirley Wu (podcast)
 * [Frontend First](https://player.fm/series/frontend-first) - Sam Selikoff, Ryan Toronto (podcast)
@@ -194,7 +194,6 @@
 * [Syntax](https://syntax.fm) - Wes Bos, Scott Tolinski (podcast)
 * [The JavaScript Show](http://javascriptshow.com) - Peter Cooper, Jason Seifer (podcast)
 * [The Vanilla JS Podcast](http://javascriptshow.com) - Chris Ferdinandi. (podcast)
-* [20 Min JS Podcast](https://20minjs.com/) - Agustinus Theodorus, Chris Bongers, Mark Volkmann, and others (podcast)
 * [Web Rush](https://webrush.simplecast.com) - John Papa, Ward Bell, Craig Shoemaker, Dan Wahlin (podcast)
 
 

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -174,7 +174,8 @@
 
 ### JavaScript
 
-* [20 Min JS Podcast](https://20minjs.com/) - Agustinus Theodorus, Chris Bongers, Mark Volkmann, and others (podcast)* [devMode.fm](https://devmode.fm) - Andrew Welch, Ryan Ire­lan, Patrick Harrington, Jonathan Melville, Michael Rog, Earl John­ston, Mar­i­on Newlevant, Lau­ren Dorman, Matt Stein, Jen­nifer Blumberg (podcast)
+* [20 Min JS Podcast](https://20minjs.com/) - Agustinus Theodorus, Chris Bongers, Mark Volkmann, and others (podcast)
+* [devMode.fm](https://devmode.fm) - Andrew Welch, Ryan Ire­lan, Patrick Harrington, Jonathan Melville, Michael Rog, Earl John­ston, Mar­i­on Newlevant, Lau­ren Dorman, Matt Stein, Jen­nifer Blumberg (podcast)
 * [FiveJS](https://fivejs.codeschool.com) - CodeSchool (podcast)
 * [Front End Happy Hour](https://frontendhappyhour.com) - Ryan Burgess, Jem Young, Stacy London, Augustus Yuan, Mars Jullian, Shirley Wu (podcast)
 * [Frontend First](https://player.fm/series/frontend-first) - Sam Selikoff, Ryan Toronto (podcast)

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -174,7 +174,6 @@
 
 ### JavaScript
 
-* [20 Min JS Podcast](https://20minjs.com/) - Agustinus Theodorus, Chris Bongers, Mark Volkmann, and others (podcast)
 * [devMode.fm](https://devmode.fm) - Andrew Welch, Ryan Ire­lan, Patrick Harrington, Jonathan Melville, Michael Rog, Earl John­ston, Mar­i­on Newlevant, Lau­ren Dorman, Matt Stein, Jen­nifer Blumberg (podcast)
 * [FiveJS](https://fivejs.codeschool.com) - CodeSchool (podcast)
 * [Front End Happy Hour](https://frontendhappyhour.com) - Ryan Burgess, Jem Young, Stacy London, Augustus Yuan, Mars Jullian, Shirley Wu (podcast)

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -194,6 +194,7 @@
 * [Syntax](https://syntax.fm) - Wes Bos, Scott Tolinski (podcast)
 * [The JavaScript Show](http://javascriptshow.com) - Peter Cooper, Jason Seifer (podcast)
 * [The Vanilla JS Podcast](http://javascriptshow.com) - Chris Ferdinandi. (podcast)
+* [20 Min JS Podcast](https://20minjs.com/) - Agustinus Theodorus, Chris Bongers, Mark Volkmann, and others (podcast)
 * [Web Rush](https://webrush.simplecast.com) - John Papa, Ward Bell, Craig Shoemaker, Dan Wahlin (podcast)
 
 

--- a/courses/free-courses-ne.md
+++ b/courses/free-courses-ne.md
@@ -5,7 +5,6 @@
     * [React](#react)
 * [Flutter](#flutter)
 * [SQL](#sql)
-* [Svelte](#Svelte)
 * [C](#c)
 * [WordPress](#wordpress)
 
@@ -33,11 +32,6 @@
 #### SQL
 
 * [SQL Full Course In Nepali](https://www.youtube.com/watch?v=Lt52pYaoSR8&list=PL2OJkQtHPRicxyldFGNJRRG4WwNe0Kjqe&index=2) - Technology Channel
-
-
-#### Svelte
-
-* [Svelte - Crash Course](https://www.udemy.com/cart/subscribe/course/5049082) - Demian Kostelny, Udemy
 
               
 #### C

--- a/courses/free-courses-ne.md
+++ b/courses/free-courses-ne.md
@@ -39,7 +39,7 @@
 
 * [Svelte - Crash Course](https://www.udemy.com/cart/subscribe/course/5049082) - Demian Kostelny, Udemy
 
-
+              
 #### C
 
 * [C Programming Full Course In Nepali](https://www.youtube.com/watch?v=7WH8C48UNDU&list=PL2OJkQtHPRicxyldFGNJRRG4WwNe0Kjqe&index=3) - Technology Channel

--- a/courses/free-courses-ne.md
+++ b/courses/free-courses-ne.md
@@ -39,6 +39,9 @@
 
 * [Svelte - Crash Course](https://www.udemy.com/cart/subscribe/course/5049082) - Demian Kostelny, Udemy
 
+
+### C
+
 * [C Programming Full Course In Nepali](https://www.youtube.com/watch?v=7WH8C48UNDU&list=PL2OJkQtHPRicxyldFGNJRRG4WwNe0Kjqe&index=3) - Technology Channel
 
 

--- a/courses/free-courses-ne.md
+++ b/courses/free-courses-ne.md
@@ -5,6 +5,7 @@
     * [React](#react)
 * [Flutter](#flutter)
 * [SQL](#sql)
+* [Svelte](#Svelte)
 * [C](#c)
 * [WordPress](#wordpress)
 
@@ -34,7 +35,9 @@
 * [SQL Full Course In Nepali](https://www.youtube.com/watch?v=Lt52pYaoSR8&list=PL2OJkQtHPRicxyldFGNJRRG4WwNe0Kjqe&index=2) - Technology Channel
 
 
-#### C
+#### Svelte
+
+* [Svelte - Crash Course](https://www.udemy.com/cart/subscribe/course/5049082) - Demian Kostelny, Udemy
 
 * [C Programming Full Course In Nepali](https://www.youtube.com/watch?v=7WH8C48UNDU&list=PL2OJkQtHPRicxyldFGNJRRG4WwNe0Kjqe&index=3) - Technology Channel
 

--- a/courses/free-courses-ne.md
+++ b/courses/free-courses-ne.md
@@ -40,7 +40,7 @@
 * [Svelte - Crash Course](https://www.udemy.com/cart/subscribe/course/5049082) - Demian Kostelny, Udemy
 
 
-### C
+#### C
 
 * [C Programming Full Course In Nepali](https://www.youtube.com/watch?v=7WH8C48UNDU&list=PL2OJkQtHPRicxyldFGNJRRG4WwNe0Kjqe&index=3) - Technology Channel
 


### PR DESCRIPTION
A podcast covering the JavaScript language and more broadly web and frontend technologies, with guests from the open-source community. It's hosted by OpenReplay, an open-source session replay tool for developers. The podcast is available on the Apple platform, Spotify, and Amazon Music. The Podcast is totally free and is for programmers of all levels and experience.

## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
