### PR TITLE
Add Compiler to podcasts

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -267,6 +267,7 @@
 * [Coder Radio](https://coder.show) - Chris Fisher, Michael Dominick, Wes Payne (podcast)
 * [Coding Blocks](https://www.codingblocks.net) - Michael Outlaw, Joe Zack, Allen Underwood (podcast)
 * [Command Line Heroes](https://www.redhat.com/en/command-line-heroes) - Saron Yitbarek, Red Hat (podcast)
+* [Compiler](https://www.redhat.com/en/compiler-podcast) - Angela Andrews, Brent Simoneaux, Red Hat (podcast)
 * [CTRL+CLICK CAST](https://ctrlclickcast.com) - Lea Alcantara, Emily Lewis, Bright Umbrella (podcast)
 * [Darknet Diaries](https://darknetdiaries.com) - Jack Rhysider, Fiona Guy, Leah Hurvoloy, et al. (podcast)
 * [DevDiscuss](https://dev.to/devdiscuss) - DEV (podcast)


### PR DESCRIPTION
## What does this PR do?
Add resource

## For resources
### Description
Added link to the Compiler podcast

### Why is this valuable (or not)?
It's a great podcast from Red Hat about the tech industry in general

### How do we know it's really free?
Visit [podcast link](https://www.redhat.com/en/compiler-podcast)

### For book lists, is it a book? For course lists, is it a course? etc.
Podcast

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
