### PR TITLE
Fix dead link by updating to archived version

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -733,7 +733,9 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [Is Parallel Programming Hard, And, If So, What Can You Do About It?](https://www.kernel.org/pub/linux/kernel/people/paulmck/perfbook/perfbook.html) - Paul E. McKenney
 * [Programming on Parallel Machines; GPU, Multicore, Clusters and More](http://heather.cs.ucdavis.edu/parprocbook) - Norm Matloff
 Kerridge (PDF) (email address *requested*, not required)
-* [The OpenCL Programming Book](https://us.fixstars.com/products/opencl/book/OpenCLProgrammingBook/contents/)
+* [The OpenCL Programming Book](https://web.archive.org/web/20210321083327/https://us.fixstars.com/products/opencl/book/OpenCLProgrammingBook/contents/) *(:card_file_box: archived)*
+
+
 
 
 ### Partial Evaluation

--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -733,7 +733,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [Is Parallel Programming Hard, And, If So, What Can You Do About It?](https://www.kernel.org/pub/linux/kernel/people/paulmck/perfbook/perfbook.html) - Paul E. McKenney
 * [Programming on Parallel Machines; GPU, Multicore, Clusters and More](http://heather.cs.ucdavis.edu/parprocbook) - Norm Matloff
 Kerridge (PDF) (email address *requested*, not required)
-* [The OpenCL Programming Book](https://web.archive.org/web/20210321083327/https://us.fixstars.com/products/opencl/book/OpenCLProgrammingBook/contents/) *(:card_file_box: archived)*
+* [The OpenCL Programming Book](https://web.archive.org/web/20210321083327/https://us.fixstars.com/products/opencl/book/OpenCLProgrammingBook/contents) - Takashi Nakamura, Takuro Iizuka, Akihiro Asahara, Satoshi Miki, (HTML) *(:card_file_box: archived)*
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fix dead link to 'The OpenCL Programming Book' by linking to its archived version

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
