### PR TITLE
change french APL video link to playlist

### DIFF
--- a/courses/free-courses-fr.md
+++ b/courses/free-courses-fr.md
@@ -29,7 +29,7 @@
 
 ### APL
 
-* [Découvrez le langage APL](https://www.youtube.com/watch?v=Nxq1BUUXobM&list=PLYKQVqyrAEj_DwkVAvj7xHxr72ite69nW) - Schraf : Maths-info
+* [Découvrez le langage APL](https://www.youtube.com/playlist?list=PLIz4PfDd5D29oOW61VkB4MHxGurtSCmhh) - Schraf : Maths-info
 
 
 ### Bash / Shell


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description
The APL link, linked to the first video of a course available by a playlist. So I corrected it.


## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
