### PR TITLE
[Fix]: Miriadax Course Link

### DIFF
--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -91,7 +91,7 @@
 
 ### Flujos de Trabajo
 
-* [Agilidad y Lean. Gestionando los proyectos y negocios del Siglo XXI](https://miriadax.net/curso/agilidad-y-lean-gestionando-los-proyectos-y-negocios-del-s-xxi-14-a-edicion) (Miriadax)
+* [Agilidad y Lean. Gestionando los proyectos y negocios del Siglo XXI](https://miriadax.net/curso/agilidad-y-lean-gestionando-los-proyectos-y-negocios-del-s-xxi-16-a-edicion) (Miriadax)
 * [Cómo implantar grupos de mejora de procesos](https://www.edx.org/course/como-implantar-grupos-de-mejora-de-upvalenciax-gm201x-0)
 * [Gestión de proyectos software (2015)](https://ocw.unican.es/course/view.php?id=23)
 * [Gestión Participativa: motivación y liderazgo organizacional](https://www.edx.org/course/gestion-participativa-high-involvement-upvalenciax-gp201x-0)


### PR DESCRIPTION
## What does this PR do?
This PR fix the correct link of the Miriadax Course.

Fixes #10796 

## For resources
### Description
Link of the Miriadax Course has updated in the origin website, while free-programming-books link was expired/changed. So I can fix the URL of the Miriadax Course link.

### Why is this valuable (or not)?
Yes

### How do we know it's really free?
It is real, I am just fix the URL link.

### For course lists, is it a course?
Yes

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
