### PR TITLE
Update free-programming-books-fr.md (typo and new math book)

### DIFF
--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -90,7 +90,7 @@
 
 #### Mathématiques
 
-* [Approfondissements de lycée](https://fr.wikibooks.org/wiki/Approfondissements_de_lycée) - Wikibooks contributors, Zhuo Jia Dai, `ctb.:` R3m0t, `ctb.:` Martin Warmer (HTML)
+* [Approfondissements de lycée](https://fr.wikibooks.org/wiki/Approfondissements_de_lycée) - Wikibooks contributors, Zhuo Jia Dai, `ctb.:` R3m0t, `ctb.:` Martin Warmer (HTML) (:construction: *in process*)
 
 
 #### Pédagogie pour les enfants et adolescents

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -6,6 +6,7 @@
     * [IDE et éditeurs de texte](#ide-et-editeurs-de-texte)
     * [Logiciels libres](#logiciels-libres)
     * [Makefile](#makefile)
+    * [Mathématiques](#mathématiques)
     * [Pédagogie pour les enfants et adolescents](#pédagogie-pour-les-enfants-et-adolescents)
     * [Théorie des langages](#théorie-des-langages)
 * [Ada](#ada)
@@ -31,7 +32,6 @@
     * [TeX](#tex)
 * [Lisp](#lisp)
 * [Lua](#lua)
-* [Mathématiques](#math%C3%A9matiques)
 * [Meteor](#meteor)
 * [Perl](#perl)
 * [PHP](#php)
@@ -87,6 +87,9 @@
 * [Concevoir un Makefile](http://icps.u-strasbg.fr/people/loechner/public_html/enseignement/GL/make.pdf) - Vincent Loechner d'après Nicolas Zin (PDF)
 * [Introduction aux Makefile](http://eric.bachard.free.fr/UTBM_LO22/P07/C/Documentation/C/make/intro_makefile.pdf) (PDF)
 
+#### Mathématiques
+
+* [Approfondissements de lycée](https://fr.wikibooks.org/wiki/Approfondissements_de_lycée) - Zhuo Jia Dai (HTML)
 
 #### Pédagogie pour les enfants et adolescents
 

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -19,7 +19,7 @@
 * [Git](#git)
 * [Go](#go)
 * [Haskell](#haskell)
-* [HTML and CSS](#css)
+* [HTML and CSS](#html-and-css)
 * [Java](#java)
 * [JavaScript](#javascript)
 * [jQuery](#jquery)

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -47,7 +47,7 @@
 * [Scratch](#scratch)
 * [SPIP](#spip)
 * [SQL](#sql)
-* [Systèmes d'exploitation](#systemes-d-exploitation)
+* [Systèmes d'exploitation](#systemes-dexploitation)
 * [TEI](#tei)
 
 

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -47,7 +47,7 @@
 * [Scratch](#scratch)
 * [SPIP](#spip)
 * [SQL](#sql)
-* [Systèmes d'exploitation](#systemes-dexploitation)
+* [Systèmes d'exploitation](#systèmes-dexploitation)
 * [TEI](#tei)
 
 
@@ -87,9 +87,11 @@
 * [Concevoir un Makefile](http://icps.u-strasbg.fr/people/loechner/public_html/enseignement/GL/make.pdf) - Vincent Loechner d'après Nicolas Zin (PDF)
 * [Introduction aux Makefile](http://eric.bachard.free.fr/UTBM_LO22/P07/C/Documentation/C/make/intro_makefile.pdf) (PDF)
 
+
 #### Mathématiques
 
 * [Approfondissements de lycée](https://fr.wikibooks.org/wiki/Approfondissements_de_lycée) - Zhuo Jia Dai (HTML)
+
 
 #### Pédagogie pour les enfants et adolescents
 

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -90,7 +90,7 @@
 
 #### Mathématiques
 
-* [Approfondissements de lycée](https://fr.wikibooks.org/wiki/Approfondissements_de_lycée) - Zhuo Jia Dai (HTML)
+* [Approfondissements de lycée](https://fr.wikibooks.org/wiki/Approfondissements_de_lycée) - Wikibooks contributors, Zhuo Jia Dai, `ctb.:` R3m0t, `ctb.:` Martin Warmer (HTML)
 
 
 #### Pédagogie pour les enfants et adolescents


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

- fix 'HTML and CSS' heading link (`#css` --> `#html-and-css`).
- normalize the mathematics heading link (`#math%C3%A9matiques` --> `#mathématiques`), move it to the not programming language-dependant section (`#1---non-dépendant-du-langage`) and add a math book to a Mathematics section (there wasn't any).
- make the OS heading link match (`#systemes-d-exploitation` --> `#systemes-dexploitation`).

### Why is this valuable (or not)?
'Approfondissements de lycée' : This is an in-depth study of high school math skills, with chapters such as Prime numbers, Logic, (...), Matrices. Unfortunately, according to his table of content, all the chapters are not finished. So it probably falls under the "In-process books" category, unless we can link finished chapters.



### How do we know it's really free?
'Approfondissements de lycée' is from wikibooks and under the 'CC BY-SA 4.0 Deed'.
> Les textes sont disponibles sous [licence Creative Commons attribution partage à l’identique](https://creativecommons.org/licenses/by-sa/4.0/deed.fr) ; d’autres termes peuvent s’appliquer.
(https://fr.wikibooks.org/wiki/Approfondissements_de_lycée).

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
- [x] Credit Correctors (Auteurs & Contributeurs section, [here](https://fr.wikibooks.org/wiki/Approfondissements_de_lycée)) and "contributeurs de Wikilivres" ([Citation Page](https://fr.wikibooks.org/w/index.php?title=Sp%C3%A9cial:Citer&page=Approfondissements_de_lyc%C3%A9e&id=387373&wpFormIdentifier=titleform)) as creators.