### PR TITLE
Add missing creators in free-courses-fr.md

### DIFF
--- a/courses/free-courses-fr.md
+++ b/courses/free-courses-fr.md
@@ -79,8 +79,8 @@
 * [HTML/CSS - Exercices](https://www.youtube.com/playlist?list=PLrSOXFDHBtfHEFVqv0pjGkPHv6PhWZQBb) - Formation Video
 * [HTML/CSS - Tutoriels](https://www.youtube.com/playlist?list=PLrSOXFDHBtfG1_4HrfPttdwF8aLpgdsRL) - Formation Video
 * [Le préprocesseur SASS](https://www.youtube.com/playlist?list=PLjwdMgw5TTLWVp8WUGheSrGnmEWIMk9H6) - Grafikart
-* [Tutoriel CSS](http://fr.html.net/tutorials/css/)
-* [Tutoriel HTML](http://fr.html.net/tutorials/html/)
+* [Tutoriel CSS](http://fr.html.net/tutorials/css/) - HTML.net, `trl.:` Jean Jacques Solari
+* [Tutoriel HTML](http://fr.html.net/tutorials/html/) - HTML.net, `trl.:` Jean Jacques Solari
 * [TUTOS HTML et CSS](https://www.youtube.com/playlist?list=PLEagTQfI6nPObScwsDmTCbLuZXRYfiUM-) - PrimFX
 
 

--- a/courses/free-courses-fr.md
+++ b/courses/free-courses-fr.md
@@ -133,7 +133,7 @@
 * [Apprendre Symfony 4 par l'exemple](https://www.youtube.com/playlist?list=PLjwdMgw5TTLX7wmorGgfrqI9TcA8nMb29) - Grafikart
 * [Cours complet de Pierre Giraud sur le développement PHP avec MySQL](https://www.pierre-giraud.com/php-mysql-apprendre-coder-cours/) - Pierre Giraud
 * [Tester sur Symfony](https://www.youtube.com/playlist?list=PLjwdMgw5TTLWtWmdMzPaoc45Iztu7tVQ8) - Grafikart
-* [Tutoriel HTML](http://fr.html.net/tutorials/php/)
+* [Tutoriel PHP](http://fr.html.net/tutorials/php/) - HTML.net, `trl.:` Jean Jacques Solari
 * [TUTOS PHP](https://www.youtube.com/playlist?list=PLEagTQfI6nPN2sdrLWhX_hO1pMOmC9JGU) - PrimFX
 
 

--- a/courses/free-courses-fr.md
+++ b/courses/free-courses-fr.md
@@ -79,8 +79,8 @@
 * [HTML/CSS - Exercices](https://www.youtube.com/playlist?list=PLrSOXFDHBtfHEFVqv0pjGkPHv6PhWZQBb) - Formation Video
 * [HTML/CSS - Tutoriels](https://www.youtube.com/playlist?list=PLrSOXFDHBtfG1_4HrfPttdwF8aLpgdsRL) - Formation Video
 * [Le préprocesseur SASS](https://www.youtube.com/playlist?list=PLjwdMgw5TTLWVp8WUGheSrGnmEWIMk9H6) - Grafikart
-* [Tutoriel CSS](http://fr.html.net/tutorials/css/) - HTML.net, `trl.:` Jean Jacques Solari
-* [Tutoriel HTML](http://fr.html.net/tutorials/html/) - HTML.net, `trl.:` Jean Jacques Solari
+* [Tutoriel CSS](http://fr.html.net/tutorials/css/) - `trl.:` Jean Jacques Solari
+* [Tutoriel HTML](http://fr.html.net/tutorials/html/) - `trl.:` Jean Jacques Solari
 * [TUTOS HTML et CSS](https://www.youtube.com/playlist?list=PLEagTQfI6nPObScwsDmTCbLuZXRYfiUM-) - PrimFX
 
 
@@ -116,7 +116,7 @@
 
 ### Linux
 
-* [Linux et Ubuntu - Administration Réseau](https://www.tutoriels-video.fr/category/ubuntu/) - Tutoriels-video.fr (Alexis Madrzejewski)
+* [Linux et Ubuntu - Administration Réseau](https://www.tutoriels-video.fr/category/ubuntu/) - Alexis Madrzejewski
 
 
 ### Python
@@ -133,7 +133,7 @@
 * [Apprendre Symfony 4 par l'exemple](https://www.youtube.com/playlist?list=PLjwdMgw5TTLX7wmorGgfrqI9TcA8nMb29) - Grafikart
 * [Cours complet de Pierre Giraud sur le développement PHP avec MySQL](https://www.pierre-giraud.com/php-mysql-apprendre-coder-cours/) - Pierre Giraud
 * [Tester sur Symfony](https://www.youtube.com/playlist?list=PLjwdMgw5TTLWtWmdMzPaoc45Iztu7tVQ8) - Grafikart
-* [Tutoriel PHP](http://fr.html.net/tutorials/php/) - HTML.net, `trl.:` Jean Jacques Solari
+* [Tutoriel PHP](http://fr.html.net/tutorials/php/) - `trl.:` Jean Jacques Solari
 * [TUTOS PHP](https://www.youtube.com/playlist?list=PLEagTQfI6nPN2sdrLWhX_hO1pMOmC9JGU) - PrimFX
 
 
@@ -151,4 +151,4 @@
 
 ### SysAdmin
 
-* [Développement Web - Administration Réseau](https://www.tutoriels-video.fr/category/webdev/) - Tutoriels-video.fr (Alexis Madrzejewski)
+* [Développement Web - Administration Réseau](https://www.tutoriels-video.fr/category/webdev/) - Alexis Madrzejewski

--- a/courses/free-courses-fr.md
+++ b/courses/free-courses-fr.md
@@ -151,4 +151,4 @@
 
 ### SysAdmin
 
-* [Développement Web - Administration Réseau](https://www.tutoriels-video.fr/category/webdev/) (Tutoriels Videos)
+* [Développement Web - Administration Réseau](https://www.tutoriels-video.fr/category/webdev/) - Tutoriels-video.fr (Alexis Madrzejewski)

--- a/courses/free-courses-fr.md
+++ b/courses/free-courses-fr.md
@@ -116,7 +116,7 @@
 
 ### Linux
 
-* [Linux et Ubuntu - Administration Réseau](https://www.tutoriels-video.fr/category/ubuntu/) (Tutoriels Videos)
+* [Linux et Ubuntu - Administration Réseau](https://www.tutoriels-video.fr/category/ubuntu/) - Tutoriels-video.fr (Alexis Madrzejewski)
 
 
 ### Python


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

- Add the website name (it includes the caps - [source](http://html.net/about/)) and the translator for fr.html.net links.
- Update "(Tutoriels Videos)" (it includes a capital letter and is format like a domain name - [source](https://www.tutoriels-video.fr/a-propos/)) and add the author for Tutoriels-video.fr links.
- Fix typo (Tutoriel HTML --> Tutoriel PHP).

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
