### PR TITLE
Add two Smalltalk books in pt-BR

### DIFF
--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -44,6 +44,7 @@
 * [SEO](#seo)
 * [Shell](#shell)
 * [Sistemas Embarcados](#sistemas-embarcados)
+* [Smalltalk](#smalltalk)
 * [Swift](#swift)
 * [TypeScript](#typescript)
     * [Angular](#angular)
@@ -393,6 +394,13 @@
 ### Sistemas Embarcados
 
 * [Fundamentos de Sistemas Embarcados](https://www.youtube.com/playlist?list=PLqvo6YdcIqXXGY1dLbf_xA-JLMBumTyzG) - Renato Sampaio
+
+
+### Smalltalk
+
+* [Conhecendo o SmallTalk](https://www.researchgate.net/publication/262882317_Conhecendo_o_Smalltalk_-_Todos_os_Detalhes_da_Melhor_Linguagem_de_Programacao_Orientada_a_Objetos) - Daniel Duarte Abdala e
+Aldo von Wangenheim (PDF)
+* [Introdução à Programação Orientada a Objetos com Smalltalk](https://dcc.ufrj.br/~jonathan/smalltalk/Introd-a-POO-com-Smalltalk-1994.pdf) - Miguel Jonathan (PDF)
 
 
 ### Swift

--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -398,8 +398,7 @@
 
 ### Smalltalk
 
-* [Conhecendo o SmallTalk](https://www.researchgate.net/publication/262882317_Conhecendo_o_Smalltalk_-_Todos_os_Detalhes_da_Melhor_Linguagem_de_Programacao_Orientada_a_Objetos) - Daniel Duarte Abdala e
-Aldo von Wangenheim (PDF)
+* [Conhecendo o SmallTalk](https://www.researchgate.net/publication/262882317_Conhecendo_o_Smalltalk_-_Todos_os_Detalhes_da_Melhor_Linguagem_de_Programacao_Orientada_a_Objetos) - Daniel Duarte Abdala, Aldo von Wangenheim (PDF)
 * [Introdução à Programação Orientada a Objetos com Smalltalk](https://dcc.ufrj.br/~jonathan/smalltalk/Introd-a-POO-com-Smalltalk-1994.pdf) - Miguel Jonathan (PDF)
 
 


### PR DESCRIPTION
## What does this PR do?
Add resources.

## For resources
### Description
Two books on Smalltalk in Brazilian Portuguese.

### Why is this valuable (or not)?
There are no Smalltalk books in Brazilian Portuguese in the current list.

### How do we know it's really free?
The books were made available by the authors (one through ResearchGate and the other by the university where the author works).

### For book lists, is it a book? For course lists, is it a course? etc.
They are two different books, unrelated to each other.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
