### PR TITLE
add link to MoonMath book (zk-SNARKs, zero-knowledge proofs)

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -864,6 +864,7 @@ Kerridge (PDF) (email address *requested*, not required)
 * [Programming Differential Privacy](https://programming-dp.com) - Joseph Near, Chiké Abuah (HTML, PDF)
 * [Security Engineering](https://www.cl.cam.ac.uk/~rja14/book.html)
 * [The Joy of Cryptography (2021)](https://joyofcryptography.com/pdf/book.pdf) - Mike Rosulek (PDF)
+* [The MoonMath Manual to zk-SNARKs](https://leastauthority.com/community-matters/moonmath-manual/) - Least Authority
 
 
 ### Software Architecture


### PR DESCRIPTION
## What does this PR do?
Add resource
Closes #11039

## For resources
### Description

The MoonMath Manual is a resource for anyone interested in understanding and unlocking the potential of zk-SNARKs (a form of zero-knowledge proof system), from beginners to experts.

### Why is this valuable (or not)?

Zero-knowledge proving systems are currently a very active area of software development.

### How do we know it's really free?

I  was able to download the book without creating an account or giving personal information of any kind. I don't know if the book will remain free but I see no reason why it wouldn't.

### For book lists, is it a book? For course lists, is it a course? etc.

It is a book.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
