### PR TITLE
add link to new rust book in free-proramming-books-zh

### DIFF
--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -694,6 +694,7 @@
 
 * [通过例子学习 Rust](https://github.com/rustcc/rust-by-example/)
 * [Rust 官方教程](https://github.com/KaiserY/rust-book-chinese)
+* [Rust 宏小册](https://zjp-cn.github.io/tlborm/)
 * [Rust 语言学习笔记](https://github.com/photino/rust-notes)
 * [RustPrimer](https://github.com/rustcc/RustPrimer)
 * [Tour of Rust](https://tourofrust.com/00_zh-cn.html)


### PR DESCRIPTION
## What does this PR do?
Add Chinese rust book

## For resources
### Description
Add The Little Book of Rust Macros For Chinese

### Why is this valuable (or not)?
It's an awesome book about rust macro

### How do we know it's really free?
It was publish on GitHub Io with MIT license

### For book lists, is it a book? For course lists, is it a course? etc.
It is a book with chapters and many resources

## Checklist:
- [x ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x ] Include author(s) and platform where appropriate.
- [x ] Put lists in alphabetical order, correct spacing.
- [x ] Add needed indications (PDF, access notes, under construction).
- [x ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
