### PR TITLE
Mark AngularJS as deprecated on free-programming-books-langs.md

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1196,7 +1196,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 #### AngularJS
 
-> :information_source: See also &#8230; [Angular](#angular)
+> :information_source: AngularJS is deprecated since 2022, rather use [Angular](#angular)
 
 * [Angular 1 Style Guide](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md) - John Papa (HTML)
 * [Angular Testing Succinctly](https://www.syncfusion.com/succinctly-free-ebooks/angular-testing-succinctly) - Joseph D. Booth (HTML)

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1196,7 +1196,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 #### AngularJS
 
-> :information_source: AngularJS is deprecated since 2022, rather use [Angular](#angular)
+> :information_source: (deprecated since 2022) see [Angular](#angular)
 
 * [Angular 1 Style Guide](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md) - John Papa (HTML)
 * [Angular Testing Succinctly](https://www.syncfusion.com/succinctly-free-ebooks/angular-testing-succinctly) - Joseph D. Booth (HTML)


### PR DESCRIPTION
Hello. Since AngularJS was deprecated in 2022, I think it should be marked so people who don't know much about Angular (like me), know that they should learn Angular 2 instead of deprecated and discontinued AngularJS.