### PR TITLE
Add CUDA Course (changes made)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -497,7 +497,7 @@
 ### Cuda
 
 * [CUDA Crash Course](https://www.youtube.com/playlist?list=PLxNPSjHT5qvtYRVdNN1yDcdSl39uHV_sU) - CoffeeBeforeArch
-* [CUDA Programming Course – High-Performance Computing with GPUs (12 hours)](https://youtu.be/86FAWCzIe_4?si=nNR5hvJKqT2-M2m9) - Elliot Arledge (FreeCodeCamp)
+* [CUDA Programming Course – High-Performance Computing with GPUs](https://www.youtube.com/watch?v=86FAWCzIe_4&t=2s) - Elliot Arledge (FreeCodeCamp)
 * [CUDA Tutorials](https://www.youtube.com/playlist?list=PLKK11Ligqititws0ZOoGk3SW-TZCar4dK) - Creel
 * [Intro to Parallel Programming Using CUDA to Harness the Power of GPUs](https://www.udacity.com/course/intro-to-parallel-programming--cs344) (Udacity)
 

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -501,6 +501,7 @@
 * [CUDA Tutorials](https://www.youtube.com/playlist?list=PLKK11Ligqititws0ZOoGk3SW-TZCar4dK) - Creel
 * [Intro to Parallel Programming Using CUDA to Harness the Power of GPUs](https://www.udacity.com/course/intro-to-parallel-programming--cs344) (Udacity)
 
+
 ### Dart
 
 * [Dart Course for Beginners](https://www.udemy.com/course/dartlang) (Udemy)

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -497,7 +497,7 @@
 ### Cuda
 
 * [CUDA Crash Course](https://www.youtube.com/playlist?list=PLxNPSjHT5qvtYRVdNN1yDcdSl39uHV_sU) - CoffeeBeforeArch
-* [CUDA Programming Course – High-Performance Computing with GPUs](https://youtu.be/86FAWCzIe_4?si=nNR5hvJKqT2-M2m9) - Elliot Arledge (FreeCodeCamp)
+* [CUDA Programming Course – High-Performance Computing with GPUs (12 hours)](https://youtu.be/86FAWCzIe_4?si=nNR5hvJKqT2-M2m9) - Elliot Arledge (FreeCodeCamp)
 * [CUDA Tutorials](https://www.youtube.com/playlist?list=PLKK11Ligqititws0ZOoGk3SW-TZCar4dK) - Creel
 * [Intro to Parallel Programming Using CUDA to Harness the Power of GPUs](https://www.udacity.com/course/intro-to-parallel-programming--cs344) (Udacity)
 

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -497,9 +497,9 @@
 ### Cuda
 
 * [CUDA Crash Course](https://www.youtube.com/playlist?list=PLxNPSjHT5qvtYRVdNN1yDcdSl39uHV_sU) - CoffeeBeforeArch
+* [CUDA Programming Course – High-Performance Computing with GPUs](https://youtu.be/86FAWCzIe_4?si=nNR5hvJKqT2-M2m9) - Elliot Arledge (FreeCodeCamp)
 * [CUDA Tutorials](https://www.youtube.com/playlist?list=PLKK11Ligqititws0ZOoGk3SW-TZCar4dK) - Creel
 * [Intro to Parallel Programming Using CUDA to Harness the Power of GPUs](https://www.udacity.com/course/intro-to-parallel-programming--cs344) (Udacity)
-* [CUDA Programming Course – High-Performance Computing with GPUs](https://youtu.be/86FAWCzIe_4?si=nNR5hvJKqT2-M2m9) - Elliot Arledge (FreeCodeCamp)
 
 ### Dart
 

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -499,7 +499,7 @@
 * [CUDA Crash Course](https://www.youtube.com/playlist?list=PLxNPSjHT5qvtYRVdNN1yDcdSl39uHV_sU) - CoffeeBeforeArch
 * [CUDA Tutorials](https://www.youtube.com/playlist?list=PLKK11Ligqititws0ZOoGk3SW-TZCar4dK) - Creel
 * [Intro to Parallel Programming Using CUDA to Harness the Power of GPUs](https://www.udacity.com/course/intro-to-parallel-programming--cs344) (Udacity)
-
+* [CUDA Programming Course – High-Performance Computing with GPUs](https://youtu.be/86FAWCzIe_4?si=nNR5hvJKqT2-M2m9) - Elliot Arledge (FreeCodeCamp)
 
 ### Dart
 


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description: It is a CUDA course for Parallel and High Performance Computing by FreeCodeCamp of duration 12 hours.

### Why is this valuable (or not)?
It offers accessible, up-to-date content on GPU programming, allowing learners to harness the power of parallel computing for performance-intensive tasks, which is essential for fields like AI, gaming, and scientific computing.

### How do we know it's really free?
YouTube is free!

### For book lists, is it a book? For course lists, is it a course? etc.
It is a course.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
