### PR TITLE
Fixed broken link for JavaScript Meteor book (en)

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1302,7 +1302,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 #### Meteor
 
-* [Your First Meteor Application, A Complete Beginner’s Guide to the Meteor JavaScript Framework](http://meteortips.com/book/)
+* [Your First Meteor Application, A Complete Beginner’s Guide to the Meteor JavaScript Framework](https://web.archive.org/web/20230815173101/http://meteortips.com/first-meteor-tutorial/) (HTML) *(:card_file_box: archived)*
 
 
 #### Next.js


### PR DESCRIPTION
Replaced with Archive.org version, marked as archived.

## What does this PR do?
Replaces URL for English Meteor book "Meteor Tutorial: A Complete Beginner's Guide to Meteor.js" with its most recent Wayback Machine snapshot. The existing URL was a dead link.

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
