### PR TITLE
Fix The Coding Train Learning Processing Link

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1444,7 +1444,7 @@
 
 ### Processing
 
-* [Learning Processing: A Beginner's Guide to Programming Images, Animation, and Interaction](https://www.youtube.com/c/TheCodingTrain/playlists?view=50&sort=dd&shelf_id=10) - The Coding Train
+* [Learning Processing: A Beginner's Guide to Programming Images, Animation, and Interaction](https://thecodingtrain.com/tracks/learning-processing) - The Coding Train
 
 
 ### Python


### PR DESCRIPTION
Several free online learning programming courses.

## What does this PR do?
**Improve repo**

## For resources
### Description
This website course track link is directly from "The Coding Train". This track provides the entire full course for Learning Processing.

### Why is this valuable (or not)? 

It provides a free learning tutorial for beginners on using Processing, an artist-friendly programming language to be creative in "making art, animations, and interactive experiences."

### How do we know it's really free?

The website link provides the full-course YouTube video and additional info such as passenger showcases, descriptions, links, and credits.

### For book lists, is it a book? For course lists, is it a course? etc.  

It is a full course.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
