### PR TITLE
Fix the brackets surrounding the link from full-width to half-width(ja)

### DIFF
--- a/docs/CODE_OF_CONDUCT-ja.md
+++ b/docs/CODE_OF_CONDUCT-ja.md
@@ -39,7 +39,7 @@
 守らなければなりません。
 
 この行動規範は、[貢献者規約][ホームページ]から引用したものです、
-バージョン1.3.0(https://contributor-covenant.org/version/1/3/0/)から引用したものです。
+バージョン1.3.0(https://contributor-covenant.org/version/1/3/0/) から引用したものです。
 
 [ホームページ]: https://contributor-covenant.org
 

--- a/docs/CODE_OF_CONDUCT-ja.md
+++ b/docs/CODE_OF_CONDUCT-ja.md
@@ -39,7 +39,7 @@
 守らなければなりません。
 
 この行動規範は、[貢献者規約][ホームページ]から引用したものです、
-バージョン1.3.0（https://contributor-covenant.org/version/1/3/0/）から引用したものです。
+バージョン1.3.0(https://contributor-covenant.org/version/1/3/0/)から引用したものです。
 
 [ホームページ]: https://contributor-covenant.org
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Changed the brackets surrounding the link from full-width to half-width in japanese.

### Why is this valuable (or not)?

Because the text after the closing parenthesis was also part of the link.

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
