### PR TITLE
fix React Native course title

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1150,7 +1150,7 @@
 * [Introduction to React Native](https://fullstackopen.com/en/part10/introduction_to_react_native) - Full Stack Open
 * [React Native for Beginners](https://www.youtube.com/playlist?list=PL4cUxeGkcC9ixPU-QkScoRBVxtPPzVjrQ) - The Net Ninja
 * [React Native Tutorial (2021)](https://www.youtube.com/playlist?list=PL8kfZyp--gEXs4YsSLtB3KqDtdOFHMjWZ) - Programming with Mash, MAhdi SHarifimehr
-* [React Tutorial for Beginners](https://www.youtube.com/playlist?list=PLC3y8-rFHvwgg3vaYJgHGnModB54rxOk3) - codevolution
+* [React Native Tutorial for Beginners](https://www.youtube.com/playlist?list=PLC3y8-rFHvwgg3vaYJgHGnModB54rxOk3) - codevolution
 
 
 #### Redux


### PR DESCRIPTION
## What does this PR do?
It correct the course name in React Native course section 

## For resources

### Description
from React to React Native

### Why is this valuable (or not)?
Yeah , it's valuable someone can think what is React course doing in React Native

### How do we know it's really free?
It is on publicly upload on Youtube 

### For book lists, is it a book? For course lists, is it a course? etc.
It's for course list and for React Native course 

## Checklist:
- [yes ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ yes] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ yes] Include author(s) and platform where appropriate.
- [ yes] Put lists in alphabetical order, correct spacing.
- [ yes] Add needed indications (PDF, access notes, under construction).
- [ yyes] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
