### PR TITLE
Remove the Stanford Cryptography II course

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -495,7 +495,6 @@
 * [Foundations of Cryptography](https://www.youtube.com/playlist?list=PLgMDNELGJ1CbdGLyn7OrVAP-IKg-0q2U2) - NPTEL  Indian Institute of Science, Bengaluru
 * [Introduction to Cryptography](https://open.ruhr-uni-bochum.de/en/lernangebot/introduction-cryptography) (Christof Paar)
 * [Stanford Cryptography I](https://www.coursera.org/course/crypto) - Dan Boneh
-* [Stanford Cryptography II](https://www.coursera.org/course/crypto2) - Dan Boneh
 
 
 ### Cuda


### PR DESCRIPTION
Assign Under Hacktoberfest

## What does this PR do?
Remove resource

### Description
Course was removed from Coursera. Course is unavailable right now on original site.

## Checklist:
- [+] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [+] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [+] Include author(s) and platform where appropriate.
- [+] Put lists in alphabetical order, correct spacing.
- [+] Add needed indications (PDF, access notes, under construction).
- [+] Used an informative name for this pull request.


