### PR TITLE
Add Linux playground

### DIFF
--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -27,6 +27,7 @@
     * [AngularJS](#angularjs)
 * [Kotlin](#kotlin)
 * [Kubernetes](#kubernetes)
+* [Linux](#linux)
 * [Multiple Languages](#multiple-languages)
 * [.Net](#dotnet)
 * [Nim](#nim)
@@ -140,6 +141,7 @@
 
 ### Docker
 
+* [Online Docker Playground](https://labex.io/tutorials/docker-online-docker-playground-372912)
 * [Play with Docker](https://labs.play-with-docker.com)
 
 
@@ -195,6 +197,7 @@
 * [Learn advanced html and css](https://www.theodinproject.com/paths/full-stack-javascript/courses/advanced-html-and-css) - The Odin Project
 * [Learn Intermediate html and css](https://www.theodinproject.com/paths/full-stack-javascript/courses/intermediate-html-and-css) - The Odin Project
 * [LiveCode](https://livecodes.io) - LiveCode
+* [Online Java Playground](https://labex.io/tutorials/docker-online-docker-playground-372912)
 * [Play Code](https://playcode.io)
 * [SoloLearn](https://code.sololearn.com/web#css)
 * [Tailwind Play](https://play.tailwindcss.com)
@@ -253,6 +256,11 @@
 ### Kubernetes
 
 * [Play with Kubernetes](https://labs.play-with-k8s.com)
+
+
+### Linux
+
+* [Online Linux Terminal and Playground](https://labex.io/tutorials/linux-online-linux-playground-372915)
 
 
 ### Markdown


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description

Added the Linux, Docker, and Java playground provided by LabEx to `more/free-programming-playgrounds.md`;

### Why is this valuable (or not)?

LabEx provides each free user with a daily quota of 3 hours of virtual environment playground usage.

### How do we know it's really free?

![screenshot-20241018-slw48TFV@2x](https://github.com/user-attachments/assets/358441c4-eded-4f20-9e47-3cd69c5c97f1)

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
