### PR TITLE
Add GPL-3.0-or-later license to 'Matters Computational' book entry

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -543,7 +543,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [Learn C++ Programming Language](http://www.tutorialspoint.com/cplusplus/cpp_tutorial.pdf) - Tutorials Point (PDF)
 * [LearnCpp.com](https://www.learncpp.com) (HTML)
 * [Learning C++ eBook](https://riptutorial.com/Download/cplusplus.pdf) - Compiled from StackOverflow Documentation (PDF)
-* [Matters Computational: Ideas, Algorithms, Source Code](http://www.jjj.de/fxt/fxtbook.pdf) - Jorg Arndt (PDF)
+* [Matters Computational: Ideas, Algorithms, Source Code](http://www.jjj.de/fxt/fxtbook.pdf) - Jorg Arndt (PDF) - License: GPL-3.0-or-later
 * [Modern C++ Tutorial: C++11/14/17/20 On the Fly](https://www.changkun.de/modern-cpp/pdf/modern-cpp-tutorial-en-us.pdf) - Changkun Ou (PDF) (CC BY-NC-ND)
 * [More C++ Idioms](https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms) - Sumant Tambe, et al. (WikiBooks)
 * [Open Data Structures (In C++)](http://opendatastructures.org/ods-cpp.pdf) - Pat Morin (PDF)


### PR DESCRIPTION
### What does this PR do?
Adds license information to the "Matters Computational: Ideas, Algorithms, Source Code" book entry in the C++ section.

### For resources
**Description:**  
The entry for "Matters Computational: Ideas, Algorithms, Source Code" has been updated to include its license information, which is **GNU General Public License (GPL), version 3 or later**.

### Why is this valuable (or not)?
Adding license information improves transparency and helps users understand the usage rights associated with the book.

### How do we know it's really free?
The license information was extracted from the preface section of the book, which explicitly states the terms under the GPL-3.0-or-later license.

### For book lists, is it a book? For course lists, is it a course? etc.
Yes, this is a book.

### Checklist:
- [x] Read the [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] Checked for duplicates using the [search tool](https://ebookfoundation.github.io/free-programming-books-search/).
- [x] Included author(s) and platform where appropriate.
- [x] Put lists in alphabetical order with correct spacing.
- [x] Added needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

### Follow-up
- Check the status of GitHub Actions and resolve any reported warnings!
