### PR TITLE
Update the url to the LaTeX books from the Fernuni Hagen

### DIFF
--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -161,8 +161,8 @@
 
 ### LaTeX
 
-* [LaTeX - eine Einführung und ein bisschen mehr ...](http://www.fernuni-hagen.de/imperia/md/content/zmi_2010/a026_latex_einf.pdf) - Manuela Jürgens, Thomas Feuerstack (PDF)
-* [LaTeX - Forteschrittene Anwendungen (oder: Neues von den Hobbits)](http://www.fernuni-hagen.de/imperia/md/content/zmi_2010/a027_latex_fort.pdf) - Manuela Jürgens (PDF)
+* [LaTeX - eine Einführung und ein bisschen mehr ...](https://www.fernuni-hagen.de/zdi/docs/a026_latex_einf.pdf) - Manuela Jürgens, Thomas Feuerstack (PDF)
+* [LaTeX - Forteschrittene Anwendungen (oder: Neues von den Hobbits)](https://www.fernuni-hagen.de/zdi/docs/a027_latex_fort.pdf) - Manuela Jürgens (PDF)
 * [LaTeX : Referenz der Umgebungen, Makros, Längen und Zähler](http://www.lehmanns.de/page/latexreferenz) - Herbert Voß (PDF)
 
 


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description

Updating broken URLs

### Why is this valuable (or not)?

Because the old ones would just 404.

### How do we know it's really free?

Its the same as the old ones, they just the url scheme.

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
