### PR TITLE
Adding (CC BY) licenses in GO (PT-BR) section

### DIFF
--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -219,7 +219,7 @@
 * [Construindo Aplicações Web em Golang](https://astaxie.gitbooks.io/build-web-application-with-golang/content/pt-br/) - astaxie (CC BY-SA)
 * [Go - hands on](https://github.com/go-br/estudos) (CC BY-SA)
 * [Go Lang - A linguagem do Google](https://www.ime.usp.br/~gold/cursos/2015/MAC5742/reports/GoLang.pdf) - Suelen Goularte Carvalho (PDF)
-* [Go por Exemplo](http://goporexemplo.golangbr.org) - Mark McGranaghan, Jeremy Ashkenas, golangbr, Daniela Tamy Iwassa (HTML) (CC BY 3.0)
+* [Go por Exemplo](http://goporexemplo.golangbr.org) - Mark McGranaghan, Jeremy Ashkenas, golangbr, Daniela Tamy Iwassa (HTML) (CC BY)
 
 
 ### Haskell

--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -219,7 +219,7 @@
 * [Construindo Aplicações Web em Golang](https://astaxie.gitbooks.io/build-web-application-with-golang/content/pt-br/) - astaxie (CC BY-SA)
 * [Go - hands on](https://github.com/go-br/estudos) (CC BY-SA)
 * [Go Lang - A linguagem do Google](https://www.ime.usp.br/~gold/cursos/2015/MAC5742/reports/GoLang.pdf) - Suelen Goularte Carvalho (PDF)
-* [Go por Exemplo](http://goporexemplo.golangbr.org) - Mark McGranaghan, Jeremy Ashkenas, golangbr, Daniela Tamy Iwassa (HTML)  (CC BY 3.0)
+* [Go por Exemplo](http://goporexemplo.golangbr.org) - Mark McGranaghan, Jeremy Ashkenas, golangbr, Daniela Tamy Iwassa (HTML) (CC BY 3.0)
 
 
 ### Haskell

--- a/books/free-programming-books-pt_BR.md
+++ b/books/free-programming-books-pt_BR.md
@@ -216,10 +216,10 @@
 ### GO
 
 * [Aprenda Go com Testes](https://larien.gitbook.io/aprenda-go-com-testes) - Lauren Ferreira
-* [Construindo Aplicações Web em Golang](https://astaxie.gitbooks.io/build-web-application-with-golang/content/pt-br/) - astaxie
-* [Go - hands on](https://github.com/go-br/estudos)
+* [Construindo Aplicações Web em Golang](https://astaxie.gitbooks.io/build-web-application-with-golang/content/pt-br/) - astaxie (CC BY-SA)
+* [Go - hands on](https://github.com/go-br/estudos) (CC BY-SA)
 * [Go Lang - A linguagem do Google](https://www.ime.usp.br/~gold/cursos/2015/MAC5742/reports/GoLang.pdf) - Suelen Goularte Carvalho (PDF)
-* [Go por Exemplo](http://goporexemplo.golangbr.org) - Mark McGranaghan, Jeremy Ashkenas, golangbr, Daniela Tamy Iwassa (HTML)
+* [Go por Exemplo](http://goporexemplo.golangbr.org) - Mark McGranaghan, Jeremy Ashkenas, golangbr, Daniela Tamy Iwassa (HTML)  (CC BY 3.0)
 
 
 ### Haskell


### PR DESCRIPTION
CC BY licenses added in GO (PT-BR) section.

## What does this PR do?
Add info based on https://github.com/EbookFoundation/free-programming-books/issues/11355

## For resources
### Description
- [Construindo Aplicações Web em Golang](https://astaxie.gitbooks.io/build-web-application-with-golang/content/pt-br/) - astaxie
License (CC BY-SA) found at the bottom of the page

- [Go - hands on](https://github.com/go-br/estudos)
License (CC BY-SA) found at the top of README file

- [Go por Exemplo](http://goporexemplo.golangbr.org) - Mark McGranaghan, Jeremy Ashkenas, golangbr, Daniela Tamy Iwassa (HTML)
License (CC BY 3.0) found on [github page of the project](https://github.com/erikacarvalho/goporexemplo/blob/gh-pages/README.md)

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.
- It's a book
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
