### PR TITLE
Added Frontend Masters podcast to free-podcasts-screencasts-en.md

### DIFF
--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -291,6 +291,7 @@
 * [Domain Driven Design Europe](https://dddeurope.com/videos/) (screencast)
     * [Domain Driven Design Europe - 2017](https://2017.dddeurope.com/#videos) (screencast)
 * [FLOSS WEEKLY](https://twit.tv/shows/floss-weekly) - Doc Searls, Aaron Newcomb, Dan Lynch, Simon Phipps, Jonathan Bennett, Shawn Powers, Katherine Druckman (podcast)
+* [Frontend Masters](https://www.youtube.com/playlist?list=PLum3CyP95edxwLIHenKw0nMHlfvr76ZSU) - Marc Grabanski (screencast)
 * [Frontside the Podcast](https://frontside.io/podcast/) - Charles Lowell, Taras Mankovski (podcast)
 * [Full Stack Radio](https://www.fullstackradio.com) - Adam Wathan (podcast)
 * [Functional Geekery](https://www.functionalgeekery.com) - Steven Proctor (podcast)

--- a/casts/free-podcasts-screencasts-en.md
+++ b/casts/free-podcasts-screencasts-en.md
@@ -291,7 +291,7 @@
 * [Domain Driven Design Europe](https://dddeurope.com/videos/) (screencast)
     * [Domain Driven Design Europe - 2017](https://2017.dddeurope.com/#videos) (screencast)
 * [FLOSS WEEKLY](https://twit.tv/shows/floss-weekly) - Doc Searls, Aaron Newcomb, Dan Lynch, Simon Phipps, Jonathan Bennett, Shawn Powers, Katherine Druckman (podcast)
-* [Frontend Masters](https://www.youtube.com/playlist?list=PLum3CyP95edxwLIHenKw0nMHlfvr76ZSU) - Marc Grabanski (screencast)
+* [Frontend Masters](https://www.youtube.com/playlist?list=PLum3CyP95edxwLIHenKw0nMHlfvr76ZSU) - Marc Grabanski, Frontend Masters team (screencast)
 * [Frontside the Podcast](https://frontside.io/podcast/) - Charles Lowell, Taras Mankovski (podcast)
 * [Full Stack Radio](https://www.fullstackradio.com) - Adam Wathan (podcast)
 * [Functional Geekery](https://www.functionalgeekery.com) - Steven Proctor (podcast)


### PR DESCRIPTION
I am adding the Frontend Masters podcast (screencast) to the list.

## What does this PR do?
Add resources

## For resources
### Description
This is a podcast series (screencast) featuring interviews with successful developers and Frontend Masters instructors!

### Why is this valuable (or not)?
These podcasts provide introductions and insights with the Frontend Masters team and other developers.

### How do we know it's really free?
It is available to view on YouTube and also viewable on Spotify and Apple Podcasts.

### For book lists, is it a book? For course lists, is it a course? etc.
This is a series of screencasts.

## Checklist:
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
