### PR TITLE
Add Hyperksill to MOOC section

### DIFF
--- a/courses/Add Hyperksill free-courses-en.md
+++ b/courses/Add Hyperksill free-courses-en.md
@@ -128,6 +128,7 @@
 * [edX](https://www.edx.org)
 * [freeCodeCamp](https://www.freecodecamp.org)
 * [FutureLearn](https://www.futurelearn.com)
+* [Hyperskill](https://hyperskill.org)
 * [IITBombayX (IITBX)](https://www.iitbombayx.in)
 * [Khan Academy](https://www.khanacademy.org)
 * [LabEx](https://labex.io)


### PR DESCRIPTION
Add Hyperskill to MOOC section

## What does this PR do?
Add resource(s)

## For resources
### Description
Hyperskill is an educational platform designed to help individuals learn programming and develop practical skills through real-world projects. Powered by JetBrains, Hyperskill offers a comprehensive, university-level education with a focus on hands-on learning. They offer free plans (Access to all courses) and premium plans (Access to everything including certificates and extra hands on projects)

### Why is this valuable (or not)?
It offers hands on learning, structured courses, industry relevant skills, and knowledge as well as a community section.

### How do we know it's really free?
It's displayed on their sign up page and the free plan is free forever according to the plans list page, all you need is to register for a free plan.

### For book lists, is it a book? For course lists, is it a course? etc.
Course

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
