### PR TITLE
Fix grammatical issue: Capitalize sentence beginnings in Section 4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -264,11 +264,11 @@ Section 4 -- Sui Generis Database Rights.
 Where the Licensed Rights include Sui Generis Database Rights that
 apply to Your use of the Licensed Material:
 
-  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+  a. For the avoidance of doubt, Section 2(a)(1) grants You the right
      to extract, reuse, reproduce, and Share all or a substantial
      portion of the contents of the database;
 
-  b. if You include all or a substantial portion of the database
+  b. If You include all or a substantial portion of the database
      contents in a database in which You have Sui Generis Database
      Rights, then the database in which You have Sui Generis Database
      Rights (but not its individual contents) is Adapted Material; and


### PR DESCRIPTION
This commit corrects a grammatical issue in Section 4 of the document by capitalizing the first word of sentences that previously started with a lowercase letter. Proper capitalization ensures consistency, readability, and adherence to standard English grammar rules.

## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
