### PR TITLE
Issue: #11838 Spring Boot - Unavailable URL

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1119,7 +1119,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 #### Spring Boot
 
-* [Building modern Web Apps with Spring Boot and Vaadin](https://vaadin.com/docs/v14/flow/tutorial/overview) - Vaadin
+* [Building modern Web Apps with Spring Boot and Vaadin](https://vaadin.com/docs/v14/flow/tutorial/overview) - Vaadin (HTML)
 * [Spring Boot Reference Guide](https://docs.spring.io/spring-boot/docs/current/reference/html/) - Phillip Webb, et al. ([PDF](https://docs.spring.io/spring-boot/docs/current/reference/pdf/spring-boot-reference.pdf))
 
 


### PR DESCRIPTION
## What does this PR do?
Change a Spring Boot book resource to a valid URL.

## For resources
### Description
I have changed an unavailable URL to a valid URL in a Spring Boot book resource called _Building modern Web Apps with Spring Boot and Vaadin_. 
### Why is this valuable (or not)?
There will be a valid URL for a resource. 
### How do we know it's really free?
It is documentation for Vaadin and it is open source. 
### For book lists, is it a book? For course lists, is it a course? etc.
Yes it is a book(ish) in documentation format.
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
