### PR TITLE
Add Emacs Lisp Elements book

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1556,6 +1556,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [An Introduction to Programming in Emacs Lisp](https://www.gnu.org/software/emacs/manual/eintr.html)
 * [Elisp Programming](https://caiorss.github.io/Emacs-Elisp-Programming/Elisp_Programming.html)
 * [GNU Emacs Lisp Reference Manual](http://www.gnu.org/software/emacs/manual/elisp.html)
+* [Emacs Lisp Elements](https://protesilaos.com/emacs/emacs-lisp-elements) - Protesilaos Stavrou (HTML)
 
 
 #### PicoLisp

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1555,8 +1555,8 @@ Books on general-purpose programming that don't focus on a specific language are
 
 * [An Introduction to Programming in Emacs Lisp](https://www.gnu.org/software/emacs/manual/eintr.html)
 * [Elisp Programming](https://caiorss.github.io/Emacs-Elisp-Programming/Elisp_Programming.html)
-* [GNU Emacs Lisp Reference Manual](http://www.gnu.org/software/emacs/manual/elisp.html)
 * [Emacs Lisp Elements](https://protesilaos.com/emacs/emacs-lisp-elements) - Protesilaos Stavrou (HTML)
+* [GNU Emacs Lisp Reference Manual](http://www.gnu.org/software/emacs/manual/elisp.html)
 
 
 #### PicoLisp


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## For resources
### Description
Add `Emacs Lisp Elements` book
This is a book for explaining Emacs Lisp, unlike `An Introduction to Programming in Emacs Lisp` is not an introduction to programming with elisp, but only an introduction to using Emacs Lisp

### Why is this valuable (or not)?
There are very few Emacs Lisp resources for reading, the only book that I know dedicated only to Elisp is `An Introduction to Programming in Emacs Lisp`

### How do we know it's really free?
All available online, no paywalls, can read it directly from HTML or through the GitHub repo.
Legally speaking, it's licensed under the `GNU Free Documentation License`

### For book lists, is it a book? For course lists, is it a course? etc.
The author considers it a book

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
