### PR TITLE
add actions write permission to stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   pull-requests: write
+  actions: write
 
 jobs:
   stale:


### PR DESCRIPTION
## What does this PR do?
Improve repo

## For resources
### Description
![image](https://github.com/user-attachments/assets/db1d6cb9-fe99-4e19-bb5e-5038a52ee3b9)
This PR attempts to resolve the above error. 

When the action attempts to update the actions cache, it fails. Based on https://github.com/actions/stale/issues/1131, it seems that issue may be permission related.

I will also be manually deleting the cache to ensure all PRs are processed.

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
