### PR TITLE
Removed Zen of Assembly Language by Michael Abrash because it no longer works.

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -348,7 +348,6 @@ Books on general-purpose programming that don't focus on a specific language are
 * [x86-64 Assembly Language Programming with Ubuntu](http://www.egr.unlv.edu/~ed/x86.html) - Ed Jorgensen (PDF)
 * [x86 Assembly](https://en.wikibooks.org/wiki/X86_Assembly) - Wikibooks
 * [x86 Disassembly](https://en.wikibooks.org/wiki/X86_Disassembly) - Wikibooks
-* [Zen of Assembly Language: Volume I, Knowledge (1990)](http://www.jagregory.com/abrash-zen-of-asm/) - Michael Abrash
 
 
 #### Non-X86


### PR DESCRIPTION
## What does this PR do?
Remove resource

### Description
Removed Zen of Assembly Language: Volume I because it no longer works anymore. 

Should I just add the link to their [github project](https://github.com/jagregory/abrash-zen-of-asm?tab=readme-ov-file) page because that still exist?

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
