### PR TITLE
rename Coq to Rocq Prover

### DIFF
--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -15,7 +15,6 @@
 * [C / C++](#c--c)
 * [Caml / OCaml](#caml--ocaml)
 * [Chaîne de blocs / Blockchain](#chaîne-de-blocs--blockchain)
-* [Coq](#coq)
 * [Fortran](#fortran)
 * [Git](#git)
 * [Go](#go)
@@ -41,6 +40,7 @@
 * [Python](#python)
     * [Django](#django)
 * [R](#r)
+* [Rocq Prover](#rocq-prover)
 * [Ruby](#ruby)
 * [Rust](#rust)
 * [Sage](#sage)
@@ -137,11 +137,6 @@
 
 * [Maîtriser Bitcoin: Programmer la chaîne de blocs publique](https://bitcoin.maitriser.ca) - Andreas M. Antonopoulos, Serafim Dos Santos (asciidoc, HTML)
 * [Maîtriser Ethereum: Développer des contrats intelligents et des DApps](https://ethereum.maitriser.ca) - Andreas M. Antonopoulos, Gavin Wood, Serafim Dos Santos (asciidoc, HTML)
-
-
-### Coq
-
-* [Le Coq'Art (V8)](http://www.labri.fr/perso/casteran/CoqArt/) - Yves Bertot, Pierre Castéran
 
 
 ### Fortran
@@ -294,6 +289,11 @@
 
 * [Introduction à l'analyse d'enquête avec R et RStudio](https://larmarange.github.io/analyse-R/) - Jospeh Lamarange, et al. (PDF version also available)
 * [Introduction à la programmation en R](http://cran.r-project.org/doc/contrib/Goulet_introduction_programmation_R.pdf) - Vincent Goulet (PDF)
+
+
+### Rocq Prover
+
+* [Le Coq'Art (V8)](http://www.labri.fr/perso/casteran/CoqArt/) - Yves Bertot, Pierre Castéran
 
 
 ### Ruby

--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -29,7 +29,6 @@
 * [C++](#cpp)
 * [Clojure](#clojure)
 * [CoffeeScript](#coffeescript)
-* [Coq](#coq)
 * [D](#d)
 * [Elixir](#elixir)
 * [Erlang](#erlang)
@@ -69,6 +68,7 @@
 * [Python](#python)
     * [Flask](#flask)
 * [R](#r)
+* [Rocq Prover](#rocq-prover)
 * [Ruby](#ruby)
 * [Rust](#rust)
 * [Sather](#sather)
@@ -302,11 +302,6 @@
 * [The Little Book on CoffeeScript](https://minghai.github.io/library/coffeescript) - Alex MacCaw, `trl:` Narumi Katoh
 * [基本操作逆引きリファレンス（CoffeeScript）](https://kyu-mu.net/coffeescript/revref) - 飯塚直
 * [正規表現リファレンス（CoffeeScript)](https://kyu-mu.net/coffeescript/regexp) - 飯塚直
-
-
-### Coq
-
-* [ソフトウェアの基礎](http://proofcafe.org/sf) - Benjamin C. Pierce, Chris Casinghino, Michael Greenberg, Vilhelm Sjöberg, Brent Yorgey, `trl:` 梅村晃広, `trl:` 片山功士, `trl:` 水野洋樹, `trl:` 大橋台地, `trl:` 増子萌, `trl:` 今井宜洋
 
 
 ### D
@@ -609,6 +604,11 @@
 * [Rによる統計解析の基礎](https://minato.sip21c.org/statlib/stat.pdf) - 中澤港 (PDF)
 * [Rによる保健医療データ解析演習](http://minato.sip21c.org/msb/medstatbook.pdf) - 中澤港 (PDF)
 * [無料統計ソフトRで心理学](http://blue.zero.jp/yokumura/Rhtml/Haebera2002.html) - 奥村泰之
+
+
+### Rocq Prover
+
+* [ソフトウェアの基礎](http://proofcafe.org/sf) - Benjamin C. Pierce, Chris Casinghino, Michael Greenberg, Vilhelm Sjöberg, Brent Yorgey, `trl:` 梅村晃広, `trl:` 片山功士, `trl:` 水野洋樹, `trl:` 大橋台地, `trl:` 増子萌, `trl:` 今井宜洋
 
 
 ### Ruby

--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -40,7 +40,6 @@ Books on general-purpose programming that don't focus on a specific language are
 * [ColdFusion](#coldfusion)
 * [Component Pascal](#component-pascal)
 * [Cool](#cool)
-* [Coq](#coq)
 * [Crystal](#crystal)
 * [CUDA](#cuda)
 * [D](#d)
@@ -186,6 +185,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [Raku](#raku)
 * [Raspberry Pi](#raspberry-pi)
 * [REBOL](#rebol)
+* [Rocq Prover](#rocq-prover)
 * [Ruby](#ruby)
     * [RSpec](#rspec)
     * [Ruby on Rails](#ruby-on-rails)
@@ -639,8 +639,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 ### Coq
 
-* [Certified Programming with Dependent Types](http://adam.chlipala.net/cpdt/html/toc.html)
-* [Software Foundations](http://www.cis.upenn.edu/~bcpierce/sf/)
+> :information_source: (renamed) see [Rocq Prover](#roq-prover)
 
 
 ### Crystal
@@ -2325,6 +2324,12 @@ Books on general-purpose programming that don't focus on a specific language are
 #### Sinatra
 
 * [Sinatra Book](https://github.com/sinatra/sinatra-book)
+
+
+### Rocq Prover
+
+* [Certified Programming with Dependent Types](http://adam.chlipala.net/cpdt/html/toc.html)
+* [Software Foundations](http://www.cis.upenn.edu/~bcpierce/sf/)
 
 
 ### Rust


### PR DESCRIPTION
## What does this PR do?
The "Coq Proof Assistant" has been renamed to the "Rocq Prover": see [here](https://rocq-prover.org/about#Name).
So I renamed "Coq" to "Rocq Prover", everywhere.

I left the Coq entry in the table of contents, because a lot of material online still refers to it by the old name,
I hope that doesn't result in sth. unintended.

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
