### PR TITLE
Remove GoLang Web Programming Introduction (not supported e-book)

### DIFF
--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -98,7 +98,6 @@
 * [가장 빨리 만나는 Go 언어](http://www.pyrasis.com/private/2015/06/01/publish-go-for-the-really-impatient-book)
 * [효과적인 Go 프로그래밍](https://gosudaweb.gitbooks.io/effective-go-in-korean/content/)
 * [Go 문서 한글 번역](https://github.com/golang-kr/golang-doc/wiki)
-* [Go 언어 웹 프로그래밍 철저 입문](https://thebook.io/006806/)
 * [The Little Go Book. 리틀 고 책입니다](https://github.com/byounghoonkim/the-little-go-book/) - Karl Seguin, `trl.:` Byounghoon Kim ([HTML](https://github.com/byounghoonkim/the-little-go-book/blob/master/ko/go.md))
 * [The Ultimate Go Study Guide 한글 번역](https://github.com/ultimate-go-korean/translation)
 


### PR DESCRIPTION
## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo
Remove resource(s)

## For resources
### Description
This PR removes "Go 언어 웹 프로그래밍 철저 입문" from the Korean Go programming books list as it is no longer available as a free e-book.

### Why is this valuable (or not)?
This removal is necessary to maintain the accuracy and integrity of the free programming books list. The book is no longer freely accessible, so keeping it in the list would mislead users who expect all listed resources to be available at no cost.

### How do we know it's really free?
The book is no longer free - it has been confirmed that "Go 언어 웹 프로그래밍 철저 입문" is no longer available as a free e-book and now requires purchase, making it ineligible for inclusion in this free resources list.

### For book lists, is it a book? For course lists, is it a course? etc.
This PR removes a book from the book list.

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
