### PR TITLE
Remove Unsupported Go Lang & Open Stack E-book and Change Url Path For Scratch Free E-book

### DIFF
--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -156,11 +156,6 @@
 * [기초정수론: 계산과 법연산, 그리고 비밀통신을 강조한](https://wstein.org/ent/ent_ko.pdf) - William Stein (PDF)
 
 
-### OpenStack
-
-* [오픈스택을 다루는 기술](https://thebook.io/006881) - 장현정 (HTML)
-
-
 ### Operation System
 
 * [운영체제: 아주 쉬운 세 가지 이야기](https://github.com/remzi-arpacidusseau/ostep-translations/tree/master/korean) - Remzi Arpacidusseau (PDF)
@@ -239,7 +234,6 @@
 
 ### Rust
 
-* [러스트 코딩인사이트](https://coding-insight.com/docs/category/rust)
 * [러스트 프로그래밍 언어](https://rinthel.github.io/rust-lang-book-ko/) - 스티브 클라브닉, 캐롤 니콜스
 * [예제로 배우는 Rust 프로그래밍](http://rust-lang.xyz)
 * [파이썬과 비교하며 배우는 러스트 프로그래밍](https://indosaram.github.io/rust-python-book/) - 윤인도

--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -20,7 +20,6 @@
 * [Linux](#linux)
 * [Machine Learning](#machine-learning)
 * [Mathematics](#mathematics)
-* [OpenStack](#openstack)
 * [Operation System](#operation-system)
 * [Perl](#perl)
 * [PHP](#php)

--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -98,7 +98,6 @@
 * [가장 빨리 만나는 Go 언어](http://www.pyrasis.com/private/2015/06/01/publish-go-for-the-really-impatient-book)
 * [효과적인 Go 프로그래밍](https://gosudaweb.gitbooks.io/effective-go-in-korean/content/)
 * [Go 문서 한글 번역](https://github.com/golang-kr/golang-doc/wiki)
-* [Go 언어 웹 프로그래밍 철저 입문](https://thebook.io/006806/)
 * [The Little Go Book. 리틀 고 책입니다](https://github.com/byounghoonkim/the-little-go-book/) - Karl Seguin, `trl.:` Byounghoon Kim ([HTML](https://github.com/byounghoonkim/the-little-go-book/blob/master/ko/go.md))
 * [The Ultimate Go Study Guide 한글 번역](https://github.com/ultimate-go-korean/translation)
 

--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -244,7 +244,7 @@
 
 ### Scratch
 
-* [창의컴퓨팅(Creative Computing) 가이드북](http://digital.kyobobook.co.kr/digital/ebook/ebookDetail.ink?barcode=480150000247P)
+* [창의컴퓨팅(Creative Computing) 가이드북](https://ebook-product.kyobobook.co.kr/dig/epd/ebook/480150000247P)
 
 
 ### Sed


### PR DESCRIPTION
## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo
- Add resource(s)
- Remove resource(s)

## For resources
### Description
This PR makes multiple updates to the Korean programming books list:

Removes "Go 언어 웹 프로그래밍 철저 입문" as it is no longer available as a free e-book
Removes the entire OpenStack section as the free e-book is no longer supported
Updates the URL for "창의컴퓨팅(Creative Computing) 가이드북" in the Scratch section due to a changed path

### Why is this valuable (or not)?
These changes are necessary to maintain the accuracy and reliability of the free programming books list. Removing resources that are no longer freely available prevents user frustration and maintains the integrity of the collection. Updating the broken URL ensures users can still access the Creative Computing guide.

### How do we know it's really free?
- The Go programming book and OpenStack book are no longer free and have been confirmed to require purchase or are no longer accessible
- The Scratch Creative Computing guide remains free but has moved to a new URL path, which has been verified to be accessible

### For book lists, is it a book? For course lists, is it a course? etc.
This PR removes books from the book list and updates a book URL in the book list.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
