### PR TITLE
Add Ukrainian interactive resources and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ This project lists books and other resources grouped by genres:
 + [German / Deutsch](more/free-programming-interactive-tutorials-de.md)
 + [Japanese / 日本語](more/free-programming-interactive-tutorials-ja.md)
 + [Russian / Русский язык](more/free-programming-interactive-tutorials-ru.md)
++ [Ukrainian / Українська](more/free-programming-interactive-tutorials-uk.md)
 
 
 ### Problem Sets and Competitive Programming

--- a/more/free-programming-interactive-tutorials-uk.md
+++ b/more/free-programming-interactive-tutorials-uk.md
@@ -1,0 +1,8 @@
+# Free Interactive Programming Resources (Ukrainian)
+
+> Interactive tutorials and platforms that are free to use. Items marked "(UI: Ukrainian)" have a Ukrainian interface.
+
+### Language Agnostic
+* [freeCodeCamp](https://www.freecodecamp.org/ukrainian/) — interactive curriculum for web development (HTML, CSS, JavaScript). (UI: Ukrainian)
+* [Scratch](https://scratch.mit.edu/) — block-based programming in the browser; choose Ukrainian from the language menu. (UI: Ukrainian)
+* [CodeCombat](https://codecombat.com/) — learn Python or JavaScript by playing; several levels are free. Set language to Ukrainian in settings. (UI: Ukrainian)


### PR DESCRIPTION
This PR adds a new Ukrainian section for Interactive Programming Resources:

- Created `more/free-programming-interactive-tutorials-uk.md`
- Added the README link under "Interactive Programming Resources"

Included free, interactive platforms with a Ukrainian UI:
- freeCodeCamp (Ukrainian)
- Scratch (Ukrainian interface)
- CodeCombat (free levels, Ukrainian interface)

Happy to adjust formatting or placement if needed.
