### PR TITLE
Fix linter summary output

### DIFF
--- a/scripts/rtl_ltr_linter.py
+++ b/scripts/rtl_ltr_linter.py
@@ -588,7 +588,7 @@ def main():
             pass
 
     # Print a debug message to stderr summarizing the linting process
-    print(f"::notice ::Processed {total} files, found {errs} issues.")
+    print(f"::notice ::Processed {total} files, found {errs} issues.", file=sys.stderr)
 
     # Exit code: 1 only if there are annotated errors/warnings on changed lines
     sys.exit(1 if annotated_errs else 0)


### PR DESCRIPTION
The linter summary now prints to error output (stderr) instead of normal output.