### PR TITLE
Add Dive into Deep Learning (free ML book) to Machine Learning section

### DIFF
--- a/books/free-programming-books-en.md
+++ b/books/free-programming-books-en.md
@@ -10,4 +10,6 @@
   (The list of books in English is here for historical reasons.)
 
 ### Machine Learning
+
 * [Dive into Deep Learning](https://d2l.ai/) - Aston Zhang, Zachary C. Lipton, Mu Li, Alexander J. Smola (HTML, PDF, Jupyter Notebooks) (CC BY-SA)
+

--- a/books/free-programming-books-en.md
+++ b/books/free-programming-books-en.md
@@ -8,3 +8,6 @@
 * [English, By Programming Language](free-programming-books-langs.md)
 * [English, By Subject](free-programming-books-subjects.md)
   (The list of books in English is here for historical reasons.)
+
+### Machine Learning
+* [Dive into Deep Learning](https://d2l.ai/) - Aston Zhang, Zachary C. Lipton, Mu Li, Alexander J. Smola (HTML, PDF, Jupyter Notebooks) (CC BY-SA)


### PR DESCRIPTION
Added "Dive into Deep Learning" (https://d2l.ai/) by Aston Zhang, Zachary C. Lipton, Mu Li, Alexander J. Smola.

- Free HTML, PDF, and Jupyter Notebooks available.
- License: CC BY-SA.
- Placed alphabetically under the Machine Learning section.
