### PR TITLE
Improve lua and Meteor book section fr

### DIFF
--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -235,7 +235,7 @@
 ### Lua
 
 * [Introduction à la programmation Lua](https://web.archive.org/web/20240109085639/https://www.luteus.biz/Download/LoriotPro_Doc/LUA/LUA_Training_FR/Introduction_Programmation.html) (HTML) *( :card_file_box: archived)*
-* [Lua : le tutoriel](http://wxlua.developpez.com/tutoriels/lua/general/cours-complet/) - Claude Urban
+* [Lua : le tutoriel](http://wxlua.developpez.com/tutoriels/lua/general/cours-complet/) - Claude Urban, `edt.:` Alexandre Laurent, ALT, Max (HTML, PDF)
 
 
 ### Meteor

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -234,7 +234,7 @@
 
 ### Lua
 
-* [Introduction à la programmation Lua](http://www.luteus.biz/Download/LoriotPro_Doc/LUA/LUA_Training_FR/Introduction_Programmation.html)
+* [Introduction à la programmation Lua](https://web.archive.org/web/20240109085639/https://www.luteus.biz/Download/LoriotPro_Doc/LUA/LUA_Training_FR/Introduction_Programmation.html) (HTML) *( :card_file_box: archived)*
 * [Lua : le tutoriel](http://wxlua.developpez.com/tutoriels/lua/general/cours-complet/) - Claude Urban
 
 

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -240,7 +240,7 @@
 
 ### Meteor
 
-* [Apprendre Meteor](https://mquandalle.gitbooks.io/apprendre-meteor/content/) - Maxime Quandalle
+* [Apprendre Meteor](https://mquandalle.gitbooks.io/apprendre-meteor/content/) - Maxime Quandalle (HTML) (CC BY-NC-SA) *( :construction: in process)*
 
 
 ### Perl

--- a/books/free-programming-books-fr.md
+++ b/books/free-programming-books-fr.md
@@ -235,7 +235,7 @@
 ### Lua
 
 * [Introduction à la programmation Lua](https://web.archive.org/web/20240109085639/https://www.luteus.biz/Download/LoriotPro_Doc/LUA/LUA_Training_FR/Introduction_Programmation.html) (HTML) *( :card_file_box: archived)*
-* [Lua : le tutoriel](http://wxlua.developpez.com/tutoriels/lua/general/cours-complet/) - Claude Urban, `edt.:` Alexandre Laurent, ALT, Max (HTML, PDF)
+* [Lua : le tutoriel](https://wxlua.developpez.com/tutoriels/lua/general/cours-complet/) - Claude Urban, `edt.:` Alexandre Laurent, ALT, Max (HTML, PDF)
 
 
 ### Meteor


### PR DESCRIPTION
## What does this PR do?
Add info

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description

- I archived the "Introduction à la programmation Lua" book, the link redirected to an unrelated website. I also added its format and the "archived" notation. 
- I added _editors_ (see [MARC Code List for Relators](https://loc.gov/marc/relators/relaterm.html)) mentions in the Acknowledgements section ([here](https://wxlua.developpez.com/tutoriels/lua/general/cours-complet/#LXIV)) of "Lua : le tutoriel", and its alternative PDF format.
- Added format, license, HTTPS, and "in process" notation for "Apprendre Meteor"


## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
