### PR TITLE
Add FastAPI to Python frameworks list

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -91,9 +91,10 @@
 * [PLC - Programmable logic controllers](#plc---programmable-logic-controllers)
 * [Processing](#processing)
 * [Python](#python)
-    * [Django](#django)
-    * [Flask](#flask)
-    * [Jupyter](#jupyter)
+  * [Django](#django)
+  * [FastAPI](#fastapi)
+  * [Flask](#flask)
+  * [Jupyter](#jupyter)
 * [QB64](#qb64)
 * [R](#r)
 * [Redis](#redis)
@@ -1585,6 +1586,11 @@
 * [Python Django Tutorial 2021](https://www.youtube.com/playlist?list=PL-51WBLyFTg1pUMaTJ4WSgnyvWfLGmwDm) - Dennis Ivy
 * [Python Django Web Framework - Full Course for Beginners](https://www.youtube.com/playlist?list=PLBfoYdk-WAlyr3cpOiOI4UXBfVVuF05e6) - freeCodeCamp (Justin Mitchel)
 * [Try Django 3.2 - Python Web Development Tutorial Series](https://www.youtube.com/playlist?list=PLEsfXFp6DpzRMby_cSoWTFw8zaMdTEXgL) - Justin Mitchel, CodingEntrepreneurs
+
+
+#### FastAPI
+
+* [FastAPI - A Python Framework | Full Course](https://www.youtube.com/watch?v=7t2alSnE2-I) - Bitfumes (YouTube)
 
 
 #### Flask


### PR DESCRIPTION
## What does this PR do?

Add resource(s) | Add info | Improve repo

## For resources

### Description

* Added **FastAPI** section under Python frameworks.
* Included a free YouTube full course resource: *FastAPI - A Python Framework | Full Course* by **Bitfumes**.
* Updated the framework index list to include FastAPI in alphabetical order.

### Why is this valuable (or not)?

* FastAPI is one of the fastest-growing Python frameworks for building modern APIs.
* Helps learners access high-quality, free, long-form content in addition to Django and Flask.
* Ensures the repo stays up-to-date with popular Python frameworks.

### How do we know it's really free?

* The course is available on YouTube, fully accessible without subscription or payment.

### For book lists, is it a book? For course lists, is it a course? etc.

This is a **video course (YouTube)**.

## Checklist:

* [x] I have searched for duplicates using [[free-programming-books-search](https://ebookfoundation.github.io/free-programming-books-search/)](https://ebookfoundation.github.io/free-programming-books-search/).
* [x] I have included author(s) and platform where appropriate.
* [x] Lists are in alphabetical order with correct spacing.
* [x] Added platform indicator `(YouTube)`.
* [x] Used an informative name for this pull request.

## Follow-up

* Will check GitHub Actions and resolve any reported warnings.
* Ready for review.