### PR TITLE
Enhance README: Add “Go to Top” Links for Better Navigation (#12231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-# List of Free Learning Resources In Many Languages
 <a name="top"></a>
+
+# List of Free Learning Resources In Many Languages
+
+## Table of Contents
+- [Intro](#intro)
+- [How To Contribute](#how-to-contribute)
+- [How To Share](#how-to-share)
+- [Resources](#resources)
+- [Translations](#translations)
+- [License](#license)
 
 <div align="center" markdown="1">
 
@@ -20,8 +29,6 @@ This page is available as an easy-to-read website. Access it by clicking on [![h
     <input type="submit" id="submit" name="submit" value="Search" />
   </form>
 </div>
-
----
 
 ## Intro
 
@@ -44,8 +51,6 @@ The [Free Ebook Foundation](https://ebookfoundation.org) now administers the rep
 
 [⬆️ Go to Top](#top)
 
----
-
 ## How To Contribute
 
 Please read [CONTRIBUTING](docs/CONTRIBUTING.md). If you're new to GitHub, [welcome](docs/HOWTO.md)! Remember to abide by our adapted from ![Contributor Covenant 1.3](https://img.shields.io/badge/Contributor%20Covenant-1.3-4baaaa.svg) [Code of Conduct](docs/CODE_OF_CONDUCT.md) too ([translations](#translations) also available).
@@ -65,8 +70,6 @@ Click on these badges to see how you might be able to help:
 
 [⬆️ Go to Top](#top)
 
----
-
 ## How To Share
 
 <div align="left" markdown="1">
@@ -79,27 +82,171 @@ Click on these badges to see how you might be able to help:
 
 [⬆️ Go to Top](#top)
 
----
-
 ## Resources
 
 This project lists books and other resources grouped by genres:
 
 ### Books
-... *(content unchanged)*
+
+[English, By Programming Language](books/free-programming-books-langs.md)
+
+[English, By Subject](books/free-programming-books-subjects.md)
+
+#### Other Languages
+
++ [Arabic / al arabiya / العربية](books/free-programming-books-ar.md)
++ [Armenian / Հայերեն](books/free-programming-books-hy.md)
++ [Azerbaijani / Азәрбајҹан дили / آذربايجانجا ديلي](books/free-programming-books-az.md)
++ [Bengali / বাংলা](books/free-programming-books-bn.md)
++ [Bulgarian / български](books/free-programming-books-bg.md)
++ [Burmese / မြန်မာဘာသာ](books/free-programming-books-my.md)
++ [Chinese / 中文](books/free-programming-books-zh.md)
++ [Czech / čeština / český jazyk](books/free-programming-books-cs.md)
++ [Catalan / catalan/ català](books/free-programming-books-ca.md)
++ [Danish / dansk](books/free-programming-books-da.md)
++ [Dutch / Nederlands](books/free-programming-books-nl.md)
++ [Estonian / eesti keel](books/free-programming-books-et.md)
++ [Finnish / suomi / suomen kieli](books/free-programming-books-fi.md)
++ [French / français](books/free-programming-books-fr.md)
++ [German / Deutsch](books/free-programming-books-de.md)
++ [Greek / ελληνικά](books/free-programming-books-el.md)
++ [Hebrew / עברית](books/free-programming-books-he.md)
++ [Hindi / हिन्दी](books/free-programming-books-hi.md)
++ [Hungarian / magyar / magyar nyelv](books/free-programming-books-hu.md)
++ [Indonesian / Bahasa Indonesia](books/free-programming-books-id.md)
++ [Italian / italiano](books/free-programming-books-it.md)
++ [Japanese / 日本語](books/free-programming-books-ja.md)
++ [Korean / 한국어](books/free-programming-books-ko.md)
++ [Latvian / Latviešu](books/free-programming-books-lv.md)
++ [Malayalam / മലയാളം](books/free-programming-books-ml.md)
++ [Norwegian / Norsk](books/free-programming-books-no.md)
++ [Persian / Farsi (Iran) / فارسى](books/free-programming-books-fa_IR.md)
++ [Polish / polski / język polski / polszczyzna](books/free-programming-books-pl.md)
++ [Portuguese (Brazil)](books/free-programming-books-pt_BR.md)
++ [Portuguese (Portugal)](books/free-programming-books-pt_PT.md)
++ [Romanian (Romania) / limba română / român](books/free-programming-books-ro.md)
++ [Russian / Русский язык](books/free-programming-books-ru.md)
++ [Serbian / српски језик / srpski jezik](books/free-programming-books-sr.md)
++ [Slovak / slovenčina](books/free-programming-books-sk.md)
++ [Spanish / español / castellano](books/free-programming-books-es.md)
++ [Swedish / Svenska](books/free-programming-books-sv.md)
++ [Tamil / தமிழ்](books/free-programming-books-ta.md)
++ [Telugu / తెలుగు](books/free-programming-books-te.md)
++ [Thai / ไทย](books/free-programming-books-th.md)
++ [Turkish / Türkçe](books/free-programming-books-tr.md)
++ [Ukrainian / Українська](books/free-programming-books-uk.md)
++ [Vietnamese / Tiếng Việt](books/free-programming-books-vi.md)
+
+### Cheat Sheets
+
++ [All Languages](more/free-programming-cheatsheets.md)
+
+### Free Online Courses
+
++ [Arabic / al arabiya / العربية](courses/free-courses-ar.md)
++ [Bengali / বাংলা](courses/free-courses-bn.md)
++ [Bulgarian / български](courses/free-courses-bg.md)
++ [Burmese / မြန်မာဘာသာ](courses/free-courses-my.md)
++ [Chinese / 中文](courses/free-courses-zh.md)
++ [English](courses/free-courses-en.md)
++ [Finnish / suomi / suomen kieli](courses/free-courses-fi.md)
++ [French / français](courses/free-courses-fr.md)
++ [German / Deutsch](courses/free-courses-de.md)
++ [Greek / ελληνικά](courses/free-courses-el.md)
++ [Hebrew / עברית](courses/free-courses-he.md)
++ [Hindi / हिंदी](courses/free-courses-hi.md)
++ [Indonesian / Bahasa Indonesia](courses/free-courses-id.md)
++ [Italian / italiano](courses/free-courses-it.md)
++ [Japanese / 日本語](courses/free-courses-ja.md)
++ [Kannada/ಕನ್ನಡ](courses/free-courses-kn.md)
++ [Kazakh / қазақша](courses/free-courses-kk.md)
++ [Khmer / ភាសាខ្មែរ](courses/free-courses-km.md)
++ [Korean / 한국어](courses/free-courses-ko.md)
++ [Malayalam / മലയാളം](courses/free-courses-ml.md)
++ [Marathi / मराठी](courses/free-courses-mr.md)
++ [Nepali / नेपाली](courses/free-courses-ne.md)
++ [Norwegian / Norsk](courses/free-courses-no.md)
++ [Persian / Farsi (Iran) / فارسى](courses/free-courses-fa_IR.md)
++ [Polish / polski / język polski / polszczyzna](courses/free-courses-pl.md)
++ [Portuguese (Brazil)](courses/free-courses-pt_BR.md)
++ [Portuguese (Portugal)](courses/free-courses-pt_PT.md)
++ [Russian / Русский язык](courses/free-courses-ru.md)
++ [Sinhala / සිංහල](courses/free-courses-si.md)
++ [Spanish / español / castellano](courses/free-courses-es.md)
++ [Swedish / svenska](courses/free-courses-sv.md)
++ [Tamil / தமிழ்](courses/free-courses-ta.md)
++ [Telugu / తెలుగు](courses/free-courses-te.md)
++ [Thai / ภาษาไทย](courses/free-courses-th.md)
++ [Turkish / Türkçe](courses/free-courses-tr.md)
++ [Ukrainian / Українська](courses/free-courses-uk.md)
++ [Urdu / اردو](courses/free-courses-ur.md)
++ [Vietnamese / Tiếng Việt](courses/free-courses-vi.md)
+
+
+### Interactive Programming Resources
+
++ [Chinese / 中文](more/free-programming-interactive-tutorials-zh.md)
++ [English](more/free-programming-interactive-tutorials-en.md)
++ [German / Deutsch](more/free-programming-interactive-tutorials-de.md)
++ [Japanese / 日本語](more/free-programming-interactive-tutorials-ja.md)
++ [Russian / Русский язык](more/free-programming-interactive-tutorials-ru.md)
+
+
+### Problem Sets and Competitive Programming
+
++ [Problem Sets](more/problem-sets-competitive-programming.md)
+
+
+### Podcast - Screencast
+
+Free Podcasts and Screencasts:
+
++ [Arabic / al Arabiya / العربية](casts/free-podcasts-screencasts-ar.md)
++ [Burmese / မြန်မာဘာသာ](casts/free-podcasts-screencasts-my.md)
++ [Chinese / 中文](casts/free-podcasts-screencasts-zh.md)
++ [Czech / čeština / český jazyk](casts/free-podcasts-screencasts-cs.md)
++ [Dutch / Nederlands](casts/free-podcasts-screencasts-nl.md)
++ [English](casts/free-podcasts-screencasts-en.md)
++ [Finnish / Suomi](casts/free-podcasts-screencasts-fi.md)
++ [French / français](casts/free-podcasts-screencasts-fr.md)
++ [German / Deutsch](casts/free-podcasts-screencasts-de.md)
++ [Hebrew / עברית](casts/free-podcasts-screencasts-he.md)
++ [Indonesian / Bahasa Indonesia](casts/free-podcasts-screencasts-id.md)
++ [Persian / Farsi (Iran) / فارسى](casts/free-podcasts-screencasts-fa_IR.md)
++ [Polish / polski / język polski / polszczyzna](casts/free-podcasts-screencasts-pl.md)
++ [Portuguese (Brazil)](casts/free-podcasts-screencasts-pt_BR.md)
++ [Portuguese (Portugal)](casts/free-podcasts-screencasts-pt_PT.md)
++ [Russian / Русский язык](casts/free-podcasts-screencasts-ru.md)
++ [Sinhala / සිංහල](casts/free-podcasts-screencasts-si.md)
++ [Spanish / español / castellano](casts/free-podcasts-screencasts-es.md)
++ [Swedish / Svenska](casts/free-podcasts-screencasts-sv.md)
++ [Turkish / Türkçe](casts/free-podcasts-screencasts-tr.md)
++ [Ukrainian / Українська](casts/free-podcasts-screencasts-uk.md)
+
+
+### Programming Playgrounds
+
+Write, compile, and run your code within a browser. Try it out!
+
++ [Chinese / 中文](more/free-programming-playgrounds-zh.md)
++ [English](more/free-programming-playgrounds.md)
++ [German / Deutsch](more/free-programming-playgrounds-de.md)
 
 [⬆️ Go to Top](#top)
-
----
 
 ## Translations
 
 Volunteers have translated many of our Contributing, How-to, and Code of Conduct documents into languages covered by our lists.
-... *(content unchanged)*
+
++ English
+  + [Code of Conduct](docs/CODE_OF_CONDUCT.md)
+  + [Contributing](docs/CONTRIBUTING.md)
+  + [How-to](docs/HOWTO.md)
++ ... *[More languages](docs/README.md#translations)* ...
+
+You might notice that there are [some missing translations here](docs/README.md#translations) - perhaps you would like to help out by [contributing a translation](docs/CONTRIBUTING.md#help-out-by-contributing-a-translation)?
 
 [⬆️ Go to Top](#top)
-
----
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # List of Free Learning Resources In Many Languages
+<a name="top"></a>
 
 <div align="center" markdown="1">
 
@@ -20,6 +21,8 @@ This page is available as an easy-to-read website. Access it by clicking on [![h
   </form>
 </div>
 
+---
+
 ## Intro
 
 This list was originally a clone of [StackOverflow - List of Freely Available Programming Books](https://web.archive.org/web/20140606191453/http://stackoverflow.com/questions/194812/list-of-freely-available-programming-books/392926) with contributions from Karan Bhangui and George Stocker.
@@ -39,6 +42,9 @@ The list was moved to GitHub by Victor Felder for collaborative updating and mai
 
 The [Free Ebook Foundation](https://ebookfoundation.org) now administers the repo, a not-for-profit organization devoted to promoting the creation, distribution, archiving, and sustainability of free ebooks. [Donations](https://ebookfoundation.org/contributions.html) to the Free Ebook Foundation are tax-deductible in the US.
 
+[⬆️ Go to Top](#top)
+
+---
 
 ## How To Contribute
 
@@ -57,6 +63,10 @@ Click on these badges to see how you might be able to help:
 
 </div>
 
+[⬆️ Go to Top](#top)
+
+---
+
 ## How To Share
 
 <div align="left" markdown="1">
@@ -67,169 +77,32 @@ Click on these badges to see how you might be able to help:
 <a href="https://twitter.com/intent/tweet?text=https://github.com/EbookFoundation/free-programming-books%0AFree%20Programming%20Books">Share on 𝕏 (Twitter)</a><br>
 </div>
 
+[⬆️ Go to Top](#top)
+
+---
+
 ## Resources
 
 This project lists books and other resources grouped by genres:
 
 ### Books
+... *(content unchanged)*
 
-[English, By Programming Language](books/free-programming-books-langs.md)
+[⬆️ Go to Top](#top)
 
-[English, By Subject](books/free-programming-books-subjects.md)
-
-#### Other Languages
-
-+ [Arabic / al arabiya / العربية](books/free-programming-books-ar.md)
-+ [Armenian / Հայերեն](books/free-programming-books-hy.md)
-+ [Azerbaijani / Азәрбајҹан дили / آذربايجانجا ديلي](books/free-programming-books-az.md)
-+ [Bengali / বাংলা](books/free-programming-books-bn.md)
-+ [Bulgarian / български](books/free-programming-books-bg.md)
-+ [Burmese / မြန်မာဘာသာ](books/free-programming-books-my.md)
-+ [Chinese / 中文](books/free-programming-books-zh.md)
-+ [Czech / čeština / český jazyk](books/free-programming-books-cs.md)
-+ [Catalan / catalan/ català](books/free-programming-books-ca.md)
-+ [Danish / dansk](books/free-programming-books-da.md)
-+ [Dutch / Nederlands](books/free-programming-books-nl.md)
-+ [Estonian / eesti keel](books/free-programming-books-et.md)
-+ [Finnish / suomi / suomen kieli](books/free-programming-books-fi.md)
-+ [French / français](books/free-programming-books-fr.md)
-+ [German / Deutsch](books/free-programming-books-de.md)
-+ [Greek / ελληνικά](books/free-programming-books-el.md)
-+ [Hebrew / עברית](books/free-programming-books-he.md)
-+ [Hindi / हिन्दी](books/free-programming-books-hi.md)
-+ [Hungarian / magyar / magyar nyelv](books/free-programming-books-hu.md)
-+ [Indonesian / Bahasa Indonesia](books/free-programming-books-id.md)
-+ [Italian / italiano](books/free-programming-books-it.md)
-+ [Japanese / 日本語](books/free-programming-books-ja.md)
-+ [Korean / 한국어](books/free-programming-books-ko.md)
-+ [Latvian / Latviešu](books/free-programming-books-lv.md)
-+ [Malayalam / മലയാളം](books/free-programming-books-ml.md)
-+ [Norwegian / Norsk](books/free-programming-books-no.md)
-+ [Persian / Farsi (Iran) / فارسى](books/free-programming-books-fa_IR.md)
-+ [Polish / polski / język polski / polszczyzna](books/free-programming-books-pl.md)
-+ [Portuguese (Brazil)](books/free-programming-books-pt_BR.md)
-+ [Portuguese (Portugal)](books/free-programming-books-pt_PT.md)
-+ [Romanian (Romania) / limba română / român](books/free-programming-books-ro.md)
-+ [Russian / Русский язык](books/free-programming-books-ru.md)
-+ [Serbian / српски језик / srpski jezik](books/free-programming-books-sr.md)
-+ [Slovak / slovenčina](books/free-programming-books-sk.md)
-+ [Spanish / español / castellano](books/free-programming-books-es.md)
-+ [Swedish / Svenska](books/free-programming-books-sv.md)
-+ [Tamil / தமிழ்](books/free-programming-books-ta.md)
-+ [Telugu / తెలుగు](books/free-programming-books-te.md)
-+ [Thai / ไทย](books/free-programming-books-th.md)
-+ [Turkish / Türkçe](books/free-programming-books-tr.md)
-+ [Ukrainian / Українська](books/free-programming-books-uk.md)
-+ [Vietnamese / Tiếng Việt](books/free-programming-books-vi.md)
-
-### Cheat Sheets
-
-+ [All Languages](more/free-programming-cheatsheets.md)
-
-### Free Online Courses
-
-+ [Arabic / al arabiya / العربية](courses/free-courses-ar.md)
-+ [Bengali / বাংলা](courses/free-courses-bn.md)
-+ [Bulgarian / български](courses/free-courses-bg.md)
-+ [Burmese / မြန်မာဘာသာ](courses/free-courses-my.md)
-+ [Chinese / 中文](courses/free-courses-zh.md)
-+ [English](courses/free-courses-en.md)
-+ [Finnish / suomi / suomen kieli](courses/free-courses-fi.md)
-+ [French / français](courses/free-courses-fr.md)
-+ [German / Deutsch](courses/free-courses-de.md)
-+ [Greek / ελληνικά](courses/free-courses-el.md)
-+ [Hebrew / עברית](courses/free-courses-he.md)
-+ [Hindi / हिंदी](courses/free-courses-hi.md)
-+ [Indonesian / Bahasa Indonesia](courses/free-courses-id.md)
-+ [Italian / italiano](courses/free-courses-it.md)
-+ [Japanese / 日本語](courses/free-courses-ja.md)
-+ [Kannada/ಕನ್ನಡ](courses/free-courses-kn.md)
-+ [Kazakh / қазақша](courses/free-courses-kk.md)
-+ [Khmer / ភាសាខ្មែរ](courses/free-courses-km.md)
-+ [Korean / 한국어](courses/free-courses-ko.md)
-+ [Malayalam / മലയാളം](courses/free-courses-ml.md)
-+ [Marathi / मराठी](courses/free-courses-mr.md)
-+ [Nepali / नेपाली](courses/free-courses-ne.md)
-+ [Norwegian / Norsk](courses/free-courses-no.md)
-+ [Persian / Farsi (Iran) / فارسى](courses/free-courses-fa_IR.md)
-+ [Polish / polski / język polski / polszczyzna](courses/free-courses-pl.md)
-+ [Portuguese (Brazil)](courses/free-courses-pt_BR.md)
-+ [Portuguese (Portugal)](courses/free-courses-pt_PT.md)
-+ [Russian / Русский язык](courses/free-courses-ru.md)
-+ [Sinhala / සිංහල](courses/free-courses-si.md)
-+ [Spanish / español / castellano](courses/free-courses-es.md)
-+ [Swedish / svenska](courses/free-courses-sv.md)
-+ [Tamil / தமிழ்](courses/free-courses-ta.md)
-+ [Telugu / తెలుగు](courses/free-courses-te.md)
-+ [Thai / ภาษาไทย](courses/free-courses-th.md)
-+ [Turkish / Türkçe](courses/free-courses-tr.md)
-+ [Ukrainian / Українська](courses/free-courses-uk.md)
-+ [Urdu / اردو](courses/free-courses-ur.md)
-+ [Vietnamese / Tiếng Việt](courses/free-courses-vi.md)
-
-
-### Interactive Programming Resources
-
-+ [Chinese / 中文](more/free-programming-interactive-tutorials-zh.md)
-+ [English](more/free-programming-interactive-tutorials-en.md)
-+ [German / Deutsch](more/free-programming-interactive-tutorials-de.md)
-+ [Japanese / 日本語](more/free-programming-interactive-tutorials-ja.md)
-+ [Russian / Русский язык](more/free-programming-interactive-tutorials-ru.md)
-
-
-### Problem Sets and Competitive Programming
-
-+ [Problem Sets](more/problem-sets-competitive-programming.md)
-
-
-### Podcast - Screencast
-
-Free Podcasts and Screencasts:
-
-+ [Arabic / al Arabiya / العربية](casts/free-podcasts-screencasts-ar.md)
-+ [Burmese / မြန်မာဘာသာ](casts/free-podcasts-screencasts-my.md)
-+ [Chinese / 中文](casts/free-podcasts-screencasts-zh.md)
-+ [Czech / čeština / český jazyk](casts/free-podcasts-screencasts-cs.md)
-+ [Dutch / Nederlands](casts/free-podcasts-screencasts-nl.md)
-+ [English](casts/free-podcasts-screencasts-en.md)
-+ [Finnish / Suomi](casts/free-podcasts-screencasts-fi.md)
-+ [French / français](casts/free-podcasts-screencasts-fr.md)
-+ [German / Deutsch](casts/free-podcasts-screencasts-de.md)
-+ [Hebrew / עברית](casts/free-podcasts-screencasts-he.md)
-+ [Indonesian / Bahasa Indonesia](casts/free-podcasts-screencasts-id.md)
-+ [Persian / Farsi (Iran) / فارسى](casts/free-podcasts-screencasts-fa_IR.md)
-+ [Polish / polski / język polski / polszczyzna](casts/free-podcasts-screencasts-pl.md)
-+ [Portuguese (Brazil)](casts/free-podcasts-screencasts-pt_BR.md)
-+ [Portuguese (Portugal)](casts/free-podcasts-screencasts-pt_PT.md)
-+ [Russian / Русский язык](casts/free-podcasts-screencasts-ru.md)
-+ [Sinhala / සිංහල](casts/free-podcasts-screencasts-si.md)
-+ [Spanish / español / castellano](casts/free-podcasts-screencasts-es.md)
-+ [Swedish / Svenska](casts/free-podcasts-screencasts-sv.md)
-+ [Turkish / Türkçe](casts/free-podcasts-screencasts-tr.md)
-+ [Ukrainian / Українська](casts/free-podcasts-screencasts-uk.md)
-
-
-### Programming Playgrounds
-
-Write, compile, and run your code within a browser. Try it out!
-
-+ [Chinese / 中文](more/free-programming-playgrounds-zh.md)
-+ [English](more/free-programming-playgrounds.md)
-+ [German / Deutsch](more/free-programming-playgrounds-de.md)
+---
 
 ## Translations
 
 Volunteers have translated many of our Contributing, How-to, and Code of Conduct documents into languages covered by our lists.
+... *(content unchanged)*
 
-+ English
-  + [Code of Conduct](docs/CODE_OF_CONDUCT.md)
-  + [Contributing](docs/CONTRIBUTING.md)
-  + [How-to](docs/HOWTO.md)
-+ ... *[More languages](docs/README.md#translations)* ...
+[⬆️ Go to Top](#top)
 
-You might notice that there are [some missing translations here](docs/README.md#translations) - perhaps you would like to help out by [contributing a translation](docs/CONTRIBUTING.md#help-out-by-contributing-a-translation)?
-
+---
 
 ## License
 
 Each file included in this repository is licensed under the [CC BY License](LICENSE).
+
+[⬆️ Go to Top](#top)


### PR DESCRIPTION
## What does this PR do?
- [x] Improve repo  

**Summary:**  
Adds “Go to Top” links at the end of each major section in the README for easier navigation and better user experience.

---

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).  
- [ ] Is this a revision of a previously submitted PR? **No.**

---

## For resources
### Description
Inserted anchor at the top of the README (`<a name="top"></a>`) and `[⬆️ Go to Top](#top)` links at the end of every major section (Intro, How To Contribute, How To Share, Resources, Translations, License).

### Why is this valuable (or not)?
- Improves navigation in a very long README.
- Enhances readability on desktop and mobile.
- Encourages deeper exploration of the content by making it easier to jump back to the top.

### How do we know it's really free?
N/A – this change only modifies the README for navigation purposes.

### For book lists, is it a book? For course lists, is it a course? etc.
N/A – README improvement only.

---

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates. **N/A**  
- [x] Include author(s) and platform where appropriate. **N/A**  
- [x] Put lists in alphabetical order, correct spacing. **N/A**  
- [x] Add needed indications (PDF, access notes, under construction). **N/A**  
- [x] Used an informative name for this pull request. **Enhance README with “Go to Top” links**

---

## Follow-up
- Check the status of GitHub Actions and resolve any reported warnings if needed.