### PR TITLE
Fix: Initialize is_link_only_item to prevent undefined variable

### DIFF
--- a/scripts/rtl_ltr_linter.py
+++ b/scripts/rtl_ltr_linter.py
@@ -271,6 +271,10 @@ def lint_file(path, cfg):
         # Extract the text content of the list item and remove leading/trailing whitespace
         text = list_item.group(1).strip()
 
+
+        # Always define is_link_only_item to avoid UnboundLocalError later
+        is_link_only_item = False
+        
         # Extract item parts (title, author, metadata) if it matches the book format
         book_item = BOOK_ITEM_RE.match(text)
 
@@ -290,9 +294,6 @@ def lint_file(path, cfg):
 
             # Initialize title, author, and meta with empty strings
             title, author, meta = text, '', ''
-
-            # Set is_link_only_item to False
-            is_link_only_item = False
 
         # Specific check: RTL author followed by LTR metadata (e.g., اسم المؤلف (PDF))
         if  active_block_direction_ctx == 'rtl' and \


### PR DESCRIPTION
## What does this PR do?
Ensures that the variable is_link_only_item is always defined in rtl_linter.py when processing Markdown list items.

## Summary of changes
Added a fallback initialization before checking for book items:


## IMPORTANT
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
