### PR TITLE
Fix broken link in the free-programming-books-langs.md

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1068,7 +1068,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [Introduction to Programming in Java](http://introcs.cs.princeton.edu/java/home/) - Robert Sedgewick, Kevin Wayne
 * [Introduction to Programming Using Java](http://math.hws.edu/javanotes) - David J. Eck (HTML, PDF, ePUB + exercises) (CC BY)
 * [Introduction to Programming Using Java (5th Edition - final version, 2010 Jun)](https://math.hws.edu/eck/cs124/javanotes5) - David J. Eck (HTML, PDF, ePUB + exercises)
-* [Java 23 - Key Concepts in Brief](https://petrucci.dev/java23.html) - Sergio Petrucci (PDF)
+* [Java 23 - Key Concepts in Brief](https://web.archive.org/web/20241213171851/https://petrucci.dev/java23.html) - Sergio Petrucci (PDF) (CC BY) *( :card_file_box: archived)*
 * [Java Application Development on Linux (2005)](https://ptgmedia.pearsoncmg.com/images/013143697X/downloads/013143697X_book.pdf) - Carl Albing, Michael Schwarz (PDF)
 * [Java, Java, Java Object-Oriented Problem Solving](https://archive.org/details/JavaJavaJavaObject-orientedProblemSolving/page/n0) - R. Morelli, R.Walde
 * [Java Language and Virtual Machine Specifications](https://docs.oracle.com/javase/specs/) - James Gosling, et al.


### PR DESCRIPTION
#12315

## What does this PR do?
Add info

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
This PR updates the book *Java 23 - Key Concepts in Brief* with a working archived link and adds the license information. The original link was broken.

### Why is this valuable (or not)?
The update ensures users can access the book even though the original link is dead, and clarifies that the content is under a free/open license (CC BY), keeping the repo accurate and usable.

### How do we know it's really free?
The book itself states:  
> "This work is licensed under a Creative Commons Attribution 4.0 International License."

### For book lists, is it a book? For course lists, is it a course? etc.
Book

## Checklist:
- [x] Search for duplicates
- [x] Include author(s) and platform where appropriate: Sergio Petrucci
- [x] Put lists in alphabetical order, correct spacing
- [x] Add needed indications (PDF, access notes, under construction)
- [x] Used an informative name for this pull request

## Follow-up
- Check the status of GitHub Actions and resolve any reported warnings!

**Issue reference:**  
Fixes #12315
