### PR TITLE
Fix broken Java 23 book link in free-programming-books-langs.md

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1068,7 +1068,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [Introduction to Programming in Java](http://introcs.cs.princeton.edu/java/home/) - Robert Sedgewick, Kevin Wayne
 * [Introduction to Programming Using Java](http://math.hws.edu/javanotes) - David J. Eck (HTML, PDF, ePUB + exercises) (CC BY)
 * [Introduction to Programming Using Java (5th Edition - final version, 2010 Jun)](https://math.hws.edu/eck/cs124/javanotes5) - David J. Eck (HTML, PDF, ePUB + exercises)
-* [Java 23 - Key Concepts in Brief](https://petrucci.dev/java23.html) - Sergio Petrucci (PDF)
+* [Java 23 - Key Concepts in Brief](https://web.archive.org/web/20210401000000/https://petrucci.dev/java23.html) - Sergio Petrucci (PDF)
 * [Java Application Development on Linux (2005)](https://ptgmedia.pearsoncmg.com/images/013143697X/downloads/013143697X_book.pdf) - Carl Albing, Michael Schwarz (PDF)
 * [Java, Java, Java Object-Oriented Problem Solving](https://archive.org/details/JavaJavaJavaObject-orientedProblemSolving/page/n0) - R. Morelli, R.Walde
 * [Java Language and Virtual Machine Specifications](https://docs.oracle.com/javase/specs/) - James Gosling, et al.


### PR DESCRIPTION
Updated the broken Java 23 PDF link to an archived version from the Wayback Machine to ensure it works.

## What does this PR do?
Add resource(s)

## For resources
### Description
Fixed the broken link for "Java 23 - Key Concepts in Brief" by Sergio Petrucci. The new link points to the archived Wayback Machine version.

### Why is this valuable (or not)?
Users can now access the PDF without encountering a blank page.

### How do we know it's really free?
The PDF was originally freely available, and the archived version preserves it.

### For book lists, is it a book? For course lists, is it a course, etc.
Book

## Checklist:
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up
- Check the status of GitHub Actions and resolve any reported warnings!
