### PR TITLE
Add prompt engineering course

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -7,6 +7,7 @@
 * [APL](#apl)
 * [Artificial Intelligence](#artificial-intelligence)
     * [Generative AI](#generative-ai)
+    * [Prompt Engineering](#prompt-engineering)
 * [Assembly](#assembly)
 * [AutoIt](#autoit)
 * [Ballerina](#ballerina)

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -296,6 +296,7 @@
 
 * [Prompt Engineering Guide](https://learnprompting.org/docs) - Learn Prompting
 
+
 ### Assembly
 
 * [Assembly Language complete course](https://www.youtube.com/playlist?list=PLMa5a9Dh6SlhJq4wCH_CLSdfRaAbuJTzb) - Exceptional Programmers

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -291,6 +291,10 @@
 * [Understanding Large Language Models — Foundations and Safety (CS 194/294-267)](https://www.youtube.com/playlist?list=PLJ66BAXN6D8H_gRQJGjmbnS5qCWoxJNfe) - Responsible Decentralized Intelligence (UC Berkeley EECS)
 
 
+#### Prompt Engineering
+
+* [Prompt Engineering Guide](https://learnprompting.org/docs) - Learn Prompting
+
 ### Assembly
 
 * [Assembly Language complete course](https://www.youtube.com/playlist?list=PLMa5a9Dh6SlhJq4wCH_CLSdfRaAbuJTzb) - Exceptional Programmers


### PR DESCRIPTION
## What does this PR do?
Added a prompt engineering table of contents to the course, but noticed the outline was missing. Also, added a link to a free course on it. **Please, this is for Hacktoberfest, remember to add the Hacktoberfest tag.**

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
It is a prompt engineering course that ranges across beginner, intermediate, and advanced levels. It is made by learn prompting, an Ed-tech that helps people to learn and apply artificial intelligence-related concepts in solving real-life problems. Learners can also get certified in it.

### Why is this valuable (or not)?
In a world where AI is now being integrated into every aspect of our lives, prompt engineering is important for everybody. They can also compete, collaborate, and network with learners around the world.

### How do we know it's really free?
The linked URL takes you directly to the course; you do not need to sign in or pay any money.

### For book lists, is it a book? For course lists, is it a course? etc.
It is a course.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
