### PR TITLE
Replaced Broken Link for Computer Networking Resource

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -698,7 +698,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [Beej's Guide to Network Programming - Using Internet Sockets](https://beej.us/guide/bgnet/) - Brian "Beej Jorgensen" Hall (HTML, PDF)
 * [Bits, Signals, and Packets: An Introduction to Digital Communications and Networks](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-02-introduction-to-eecs-ii-digital-communication-systems-fall-2012/readings/)
 * [Code Connected vol.1](https://hintjens.wdfiles.com/local--files/main%3Afiles/cc1pe.pdf) (PDF) (book on ZeroMQ)
-* [Computer Networking : Principles, Protocols and Practice](https://www.computer-networking.info/) (HTML, ePub, PDF, Kindle)
+* [Computer Networking : Principles, Protocols and Practice](https://www.computer-networking.info) (HTML, ePub, PDF, Kindle)
 * [Computer Networks: A Systems Approach](https://book.systemsapproach.org) - Larry Peterson, Bruce Davie (HTML, epub, mobi, PDF)
 * [Distributed systems for fun and profit](https://book.mixu.net/distsys/single-page.html)
 * [High-Performance Browser Networking](https://hpbn.co) - Ilya Grigorik


### PR DESCRIPTION
## What does this PR do?
The PR fixes a broken link to one of the listed books

## IMPORTANT
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
The link to the book: [Computer Networking : Principles, Protocols and Practice], redirected to an invalid URL (Error 404)
Fixed the issue with the proper link to the referred book

### Why is this valuable (or not)?
Since this is a key resource, replacing the link would ensure proper redirecting for the users

## Checklist:
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
