### PR TITLE
Add Java me sdk 3.4 official tutorial

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -86,7 +86,6 @@ Books on general-purpose programming that don't focus on a specific language are
 * [J](#j)
 * [Java](#java)
     * [Codename One](#codename-one)
-    * [Java ME](#java-me)
     * [Java Reporting](#java-reporting)
     * [Spring](#spring)
     * [Spring Boot](#spring-boot)


### PR DESCRIPTION
## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
This adds Java ME sdk 3.4 official tutorial.
### Why is this valuable (or not)?

SDK 3.4 is the last version to support Java ME, AKA J2ME. This is the most comprehensive and authoritative source on it.

### How do we know it's really free?
Freely available on Oracle website
### For book lists, is it a book? For course lists, is it a course? etc.
Book
## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
