### PR TITLE
Update resources list with Stanford Code in Place link

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1568,7 +1568,7 @@
 * [Python Tutorials](https://www.youtube.com/playlist?list=PL-osiE80TeTt2d9bfVyTiXJA-UTHn6WwU) - Corey Schafer
 * [Python Tutorials](https://www.youtube.com/playlist?list=PLWKjhJtqVAbnqBxcdjVGgT3uVR10bzTEB) - freeCodeCamp.org
 * [SoloLearn](https://www.sololearn.com/Course/Python/)
-* [Stanford's Code in Place: CS106A Equivalent (Intro to Python)](https://codeinplace.stanford.edu/)
+* [Stanford's Code in Place: CS106A Equivalent (Intro to Python)](https://codeinplace.stanford.edu) - Free introductory Python course offered by Stanford University.
 * [The Python Tutorial](https://docs.python.org/3/tutorial/)
 * [Using Python for Research](https://www.edx.org/course/using-python-for-research) (edX Harvard)
 


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR?  
  No.

## For resources
### Description
Added **Stanford's Code in Place: CS106A Equivalent (Intro to Python)** — a free online course offered by Stanford University that teaches Python programming using the same content as their well-known CS106A course.

### Why is this valuable (or not)?
This course is taught by Stanford instructors and follows one of the most popular computer science introduction.  
It offers interactive exercises, lectures, and projects, making it ideal for beginners who want a strong foundation in Python.

### How do we know it's really free?
The entire course content (videos, exercises, and assignments) is freely available on the [Code in Place](https://codeinplace.stanford.edu/) website with no payment.

### For book lists, is it a book? For course lists, is it a course?
It’s a **course**.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up
- Checked GitHub Actions status and verified there are no warnings.
