### PR TITLE
Remove incorrect Leanpub access notes from D3, Leaflet, PureScript books (batch10)

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1183,7 +1183,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [JavaScript Wikibook](https://en.wikibooks.org/wiki/JavaScript) - Wikibooks (HTML, PDF)
 * [JavaScript with Classes](https://diogoeichert.github.io/JSwC.epub) - Diogo Eichert (EPUB)
 * [JS Robots](https://web.archive.org/web/20201029045339/http://markdaggett.com/images/ExpertJavaScript-ch6.pdf) - Mark Daggett (PDF) *( :card_file_box: archived)*
-* [Leaflet Tips and Tricks: Interactive Maps Made Easy](https://leanpub.com/leaflet-tips-and-tricks/read) - Malcolm Maclean (HTML) *(Leanpub account or valid email requested)*
+* [Leaflet Tips and Tricks: Interactive Maps Made Easy](https://leanpub.com/leaflet-tips-and-tricks/read) - Malcolm Maclean (HTML)
 * [Learn JavaScript](https://javascript.sumankunwar.com.np/en) - Suman Kumar, Github Contributors (HTML, PDF)
 * [Learning JavaScript Design Patterns](http://addyosmani.com/resources/essentialjsdesignpatterns/book/) - Addy Osmani (HTML)
 * [Let's Learn ES6](https://bubblin.io/book/let-s-learn-es6-by-ryan-christiani#frontmatter) - Ryan Christiani (Superbook format)
@@ -1248,7 +1248,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 #### D3.js
 
-* [D3 Tips and Tricks](https://leanpub.com/D3-Tips-and-Tricks/read) - Malcolm Maclean *(Leanpub account or valid email requested)*
+* [D3 Tips and Tricks](https://leanpub.com/D3-Tips-and-Tricks/read) - Malcolm Maclean (HTML)
 * [Dashing D3.js Tutorial](https://www.dashingd3js.com/d3-tutorial)
 * [Interactive Data Visualization with D3](http://alignedleft.com/tutorials/d3)
 
@@ -1954,7 +1954,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 ### PureScript
 
-* [PureScript By Example](https://leanpub.com/purescript/read) - Phil Freeman *(Leanpub account or valid email requested)*
+* [PureScript By Example](https://leanpub.com/purescript/read) - Phil Freeman (HTML)
 
 
 ### Python


### PR DESCRIPTION
## What does this PR do?
Remove resource(s) | Add info | Improve repo

## For resources

### Description
This PR removes **3 incorrectly added Leanpub access notes** from D3.js, Leaflet, and PureScript books. Following maintainer @eshellman's guidance: "Do NOT add the access notes if the html version is free without login."

### Why is this valuable?
All 3 books provide **complete free HTML versions** on Leanpub without requiring login. The access notes were added incorrectly and violate repository guidelines.

**Books verified with complete free HTML:**
1. **D3 Tips and Tricks v3.x** ✅ - Complete D3.js data visualization guide by Malcolm Maclean, freely accessible on Leanpub with extensive examples
2. **Leaflet Tips and Tricks** ✅ - Complete Leaflet.js interactive mapping guide by Malcolm Maclean, freely accessible with map examples
3. **PureScript By Example** ✅ - Complete PureScript functional programming guide by Phil Freeman, freely accessible with comprehensive tutorials

### How do we know it's really free?
Verified by accessing each book's Leanpub `/read` URL. All three books return complete HTML content without requiring login or account creation.

### For book lists, is it a book?
Yes, all three are complete technical programming books.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up
✅ All changes committed and pushed successfully