### PR TITLE
Updated rtl_ltr_linter.py

### DIFF
--- a/scripts/rtl_ltr_linter.py
+++ b/scripts/rtl_ltr_linter.py
@@ -175,14 +175,13 @@ def split_by_span(text, base_ctx):
 
         # If so, push the new context onto the stack
         if m:
-            stack.append(m.group(1).lower()); #continue
-        
+            stack.append(m.group(1).lower()); 
         # If the token is a closing </span> tag
         if tok.lower() == '</span>':
 
             # Pop the last context from the stack
             if len(stack) > 1: stack.pop()
-            #continue
+            
 
         # Otherwise, if the token is not a span tag, it's a text segment.
         # So, we need to append the tuple (segment, current context) to segments[]


### PR DESCRIPTION
This commit removes premature continue statements in the tag-processing loop within split_by_span. This fixes a bug where lines with multiple <span> tags were not fully processed, ensuring both opening and closing tags are handled correctly and the direction context stack remains accurate. Change done for Hacktoberfest 2025 to help improve linting reliability.

What does this PR do?
Improve repo | Bug fix in linting script

IMPORTANT
 Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).

 Is this a revision of a previously submitted PR? No.

For resources
Description
Fixes tag parsing in split_by_span by allowing full line processing of multiple <span> tags. Prevents false context stack updates during linting.

Why is this valuable (or not)?
Improves accuracy/reliability of the linter for mixed RTL/LTR markdowns, avoids missed errors.

How do we know it's really free?
Not a resource addition, just a code improvement.

For book lists, is it a book? For course lists, is it a course? etc.
Not applicable.

Checklist:
 [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.

 Used an informative name for this pull request.

 Addresses source code, not content.

Follow-up
Will monitor GitHub Actions for errors and address any as needed.