### PR TITLE
Add and update Django Courses from freeCodeCamp

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1608,9 +1608,10 @@
 * [Django Tutorials](https://www.youtube.com/playlist?list=PL-osiE80TeTtoQCKZ03TU5fNfx2UY6U4p) - Corey Schafer
 * [Django Tutorials for Beginners](https://www.youtube.com/playlist?list=PLK8cqdr55Tsv-D2HMdrnD32oOVBNvmxjr) - ProgrammingWithHarry
 * [Django Wednesdays](https://www.youtube.com/playlist?list=PLCC34OHNcOtqW9BJmgQPPzUpJ8hl49AGy) - Codemy.com
+* [Learn Django by Building an Online Marketplace - Python Tutorial for Beginners](https://www.youtube.com/watch?v=ZxMB6Njs3ck) - Stein Helset (freeCodeCamp)
 * [Python Django Tutorial 2018 for Beginners](https://www.youtube.com/playlist?list=PL-J2q3Ga50oOpni_xS2PPUe4mf9lM96dD) - Clever Programmer
 * [Python Django Tutorial 2021](https://www.youtube.com/playlist?list=PL-51WBLyFTg1pUMaTJ4WSgnyvWfLGmwDm) - Dennis Ivy
-* [Python Django Web Framework - Full Course for Beginners](https://www.youtube.com/playlist?list=PLBfoYdk-WAlyr3cpOiOI4UXBfVVuF05e6) - freeCodeCamp (Justin Mitchel)
+* [Python Django Web Framework - Full Course for Beginners](https://www.youtube.com/watch?v=F5mRW0jo-U4) - freeCodeCamp (Justin Mitchel)
 * [Try Django 3.2 - Python Web Development Tutorial Series](https://www.youtube.com/playlist?list=PLEsfXFp6DpzRMby_cSoWTFw8zaMdTEXgL) - Justin Mitchel, CodingEntrepreneurs
 
 


### PR DESCRIPTION
Added a Learn Django YouTube course by Stein Helset (CodewithStein) in freeCodeCamp and updated the broken link for the Justin Mitchel Python tutorial on freeCodeCamp's YouTube channel.

## What does this PR do?
Add resource(s), Improve repo

## IMPORTANT
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
This is a free Python Django course on freeCodeCamp's YouTube channel, hosted by Stein Helset (CodewithStein), where you learn to build a simple online e-commerce marketplace. I also updated the broken link for Justin Mitchel's Python tutorial course in the same section.

### Why is this valuable (or not)? 
You can learn the basics of Django with these YouTube tutorials.

### How do we know it's really free?
They are currently free to play on YouTube on freeCodeCamp's channel. 

### For book lists, is it a book? For course lists, is it a course? etc.
These are video courses. 

## Checklist:
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
