### PR TITLE
Update free-courses-ru.md - remove link

### DIFF
--- a/courses/free-courses-ru.md
+++ b/courses/free-courses-ru.md
@@ -186,7 +186,6 @@ ADV - Продвинутый. Тонкости.
 ### Ruby
 
 * [Бесплатный онлайн курс по основам Ruby](https://code-basics.com/ru/languages/ruby) - Code-basics (BEG)
-* [Введение в Ruby](https://ru.hexlet.io/courses/ruby) - Hexlet (BEG)
 * [Путь Rubyrush](https://rubyrush.ru/steps) (BEG)
 * [Ruby - первое знакомство](https://stepik.org/course/87996) - Stepik (BEG)
 


### PR DESCRIPTION

## What does this PR do?
Remove resource(s) 


### Description
This course has been removed from the site. The archived version requires registration, but registration is impossible, rendering the resource useless.

