### PR TITLE
Added 4 CP sheets to the ladder section

### DIFF
--- a/.github/PR_BODY_add-competitive-ladders.md
+++ b/.github/PR_BODY_add-competitive-ladders.md
@@ -1,0 +1,43 @@
+## What does this PR do?
+Add resource(s)
+
+## IMPORTANT
+- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
+- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.
+
+## For resources
+### Description
+Added four competitive-programming / interview-prep problem-sheet ladders to the `Ladders` section of `more/problem-sets-competitive-programming.md`:
+
+- 450 DSA Sheet — Love Babbar: a comprehensive DSA problem list covering arrays, strings, linked lists, trees, graphs, DP, etc.
+- Apna College DSA Sheet: curated problems suitable for beginners to advanced learners, tied to Apna College playlists and walkthroughs.
+- Blind 75: the commonly referenced top 75 LeetCode problems for interview preparation.
+- NeetCode 150: NeetCode’s collection of ~150 essential coding interview problems organized by topic.
+
+Additionally, the `Ladders` section was alphabetized to comply with repository style guidelines.
+
+### Why is this valuable (or not)?
+These curated lists provide structured, progressive practice paths for learners preparing for competitive programming and technical interviews. They consolidate commonly recommended, high-value problems across topics and difficulty levels, which helps learners plan study and revision effectively.
+
+### How do we know it's really free?
+All referenced resources are publicly accessible without paywalls:
+
+- Love Babbar and Apna College maintain public YouTube playlists or pages.
+- Blind 75 is publicly shared via a LeetCode discussion / public mirrors.
+- NeetCode practice pages are publicly accessible.
+
+Links in the file point to public pages/collections.
+
+### For book lists, is it a book? For course lists, is it a course? etc.
+These entries are curated problem sheets / lists (not books or paid courses). Each entry includes the platform/author where appropriate.
+
+## Checklist:
+- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
+- [ ] Include author(s) and platform where appropriate.
+- [ ] Put lists in alphabetical order, correct spacing.
+- [ ] Add needed indications (PDF, access notes, under construction).
+- [ ] Used an informative name for this pull request.
+
+## Follow-up
+- Check the status of GitHub Actions and resolve any reported warnings.
+- If maintainers prefer canonical links (GitHub repo/gist or playlist) for any sheet, I can update the URLs accordingly.

--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -94,17 +94,16 @@
 
 ### Ladders
 
+* [450 DSA Sheet — Love Babbar](https://www.youtube.com/c/LoveBabbarOfficial) - A widely-used 450-question DSA sheet curated by Love Babbar for comprehensive practice across arrays, trees, graphs, DP and more.
 * [A2 Online Judge](https://a2oj.netlify.app)
+* [Apna College DSA Sheet](https://www.youtube.com/c/ApnaCollege) - Curated problems and guided walkthroughs from Apna College; suitable for beginners to advanced competitive programmers.
 * [Atcoder Problems](https://kenkoooo.com/atcoder/#/table)
+* [Blind 75 (Top 75 problems)](https://leetcode.com/discuss/general-discussion/460599/blind-75-leetcode-questions) - The popular "Blind 75" list of essential LeetCode problems recommended for interview prep and algorithmic fundamentals.
 * [C2 Ladders](https://c2-ladders-juol.onrender.com)
+* [NeetCode 150](https://neetcode.io/practice) - A curated set of 150 essential coding interview problems organized for progressive practice and mastery.
 * [Striver's A2Z DSA Course/sheet](https://takeuforward.org/strivers-a2z-dsa-course/strivers-a2z-dsa-course-sheet-2)
 * [Striver’s CP Sheet](https://takeuforward.org/interview-experience/strivers-cp-sheet/)
 * [System Design Roadmap with Videos for SDEs](https://takeuforward.org/system-design/complete-system-design-roadmap-with-videos-for-sdes/) - take U forward(takeuforward)
-
-* [450 DSA Sheet — Love Babbar](https://www.youtube.com/c/LoveBabbarOfficial) - A widely-used 450-question DSA sheet curated by Love Babbar for comprehensive practice across arrays, trees, graphs, DP and more.
-* [Apna College DSA Sheet](https://www.youtube.com/c/ApnaCollege) - Curated problems and guided walkthroughs from Apna College; suitable for beginners to advanced competitive programmers.
-* [Blind 75 (Top 75 problems)](https://leetcode.com/discuss/general-discussion/460599/blind-75-leetcode-questions) - The popular "Blind 75" list of essential LeetCode problems recommended for interview prep and algorithmic fundamentals.
-* [NeetCode 150](https://neetcode.io/practice) - A curated set of 150 essential coding interview problems organized for progressive practice and mastery.
 
 
 ### Problem Sets


### PR DESCRIPTION
What does this PR do?
Add resource(s)

Description
Added four popular competitive-programming / interview-prep problem-sheet ladders to the "Ladders" section of more/problem-sets-competitive-programming.md:

450 DSA Sheet — Love Babbar: a comprehensive DSA problem list covering arrays, strings, linked lists, trees, graphs, DP, etc.
Apna College DSA Sheet: curated problems suitable for beginners to advanced learners, tied to Apna College curriculum and playlists.
Blind 75: the commonly referenced top 75 LeetCode problems for interview preparation.
NeetCode 150: NeetCode’s collection of ~150 essential coding interview problems organized by topic.

Why is this valuable (or not)?
These sheets provide structured, progressive practice paths for learners preparing for competitive programming and technical interviews. They consolidate high-value problems across topics and difficulty levels, making study planning and revision easier for contributors and learners.

How do we know it's really free?
All referenced resources are publicly available online without paywalls:

Love Babbar and Apna College maintain public playlists and problem lists.
Blind 75 and NeetCode resources are shared via public GitHub/Gist/LeetCode discussion pages or public blog posts. (Links added in-file point to public pages/collections.)

For book lists, is it a book? For course lists, is it a course? etc.

These are curated problem sheets / lists (not books or formal paid courses). Where applicable, the entry indicates the platform/author and the type (problem-sheet / playlist / curated list).