### PR TITLE
Fix Deep Learning URLs and resolve trailing slash issues

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -656,7 +656,7 @@
 * [Self-Paced Courses for Deep Learning](https://developer.nvidia.com/deep-learning-courses)
 * [Stanford CS 224N: Natural Language Processing with Deep Learning](https://www.youtube.com/playlist?list=PLoROMvodv4rOSH4v6133s9LFPRHjEmbmJ) (Stanford Online)
 * [Stanford CS230: Deep Learning](https://www.youtube.com/playlist?list=PLoROMvodv4rOABXSygHTsbvUz4G_YQhOb) (Stanford Online)
-* [Stanford CS234: Reinforcement Learning](https://web.stanford.edu/class/cs234/) - Emma Brunskill
+* [Stanford CS234: Reinforcement Learning](https://web.stanford.edu/class/cs234) - Emma Brunskill
 * [UC Berkeley CS 188: Introduction to Artificial Intelligence](http://ai.berkeley.edu) - Dan Klein
 * [Unsupervised Feature Learning and Deep Learning](http://deeplearning.stanford.edu/tutorial)
 


### PR DESCRIPTION
## What does this PR do?
[x] Add resource(s) | [ ] Remove resource(s) | [ ] Add info | [ ] Improve repo

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) to the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
Adds two foundational, university-level courses to the Deep Learning section:
- Stanford CS234: Reinforcement Learning
- UC Berkeley CS188: Introduction to Artificial Intelligence

### Why is this valuable (or not)?
These are highly-regarded, classic courses from top universities that provide a strong foundation in AI and Reinforcement Learning. Excellent additions to the free learning resources list.

### How do we know it's really free?
Both courses make lecture notes, videos, and materials publicly and freely available on their official university websites.

### For book lists, is it a book? For course lists, is it a course? etc.
These are university courses.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up
- Check the status of GitHub Actions and resolve any reported warnings!
