### PR TITLE
docs: Added license notation for 2 books under Arduino section (Attached relevant Screenshots for proof)

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -293,14 +293,14 @@ Books on general-purpose programming that don't focus on a specific language are
 ### Arduino
 
 * [Arduino-docs : A beginner's guide](https://arduino-doc.readthedocs.io/en/latest/) - Paramesh Chandra (HTML)
-* [Arduino Programming Notebook](https://unglue.it/work/152452) - Brian Evans (PDF) ( :card_file_box: *archived at unglue.it*)
+* [Arduino Programming Notebook](https://unglue.it/work/152452) - Brian Evans (PDF) ( :card_file_box: *archived at unglue.it*) (CC BY-NC-SA)
 * [Arduino Projects Book](https://www.eitkw.com/wp-content/uploads/2020/03/Arduino_Projects_Book.pdf) - Scott Fitzgerald and Michael Shiloh (PDF)
 * [Arduino Tips, Tricks, and Techniques](https://cdn-learn.adafruit.com/downloads/pdf/arduino-tips-tricks-and-techniques.pdf) - lady ada (PDF)
 * [Getting started with Arduino – A Beginner’s Guide](http://manuals.makeuseof.com.s3.amazonaws.com/for-mobile/Arduino_-_MakeUseOf.com.pdf) - Brad Kendall (PDF)
 * [Getting Started with Arduino products](https://www.arduino.cc/en/Guide) - Official Arduino Documentation *( :construction: in process)*
 * [Introduction to Arduino](http://playground.arduino.cc/Main/ManualsAndCurriculum)
 * [Introduction to Arduino : A piece of cake!](http://www.introtoarduino.com) - Alan G. Smith
-* [Learn Arduino](https://riptutorial.com/Download/arduino.pdf) - Compiled from StackOverflow documentation (PDF)
+* [Learn Arduino](https://riptutorial.com/Download/arduino.pdf) - Compiled from StackOverflow documentation (PDF) (CC BY-SA)
 * [Open softwear - Fashionable prototyping and wearable computing using the Arduino](https://softwear.cc/book/files/Open_Softwear-beta090712.pdf) - Tony Olsson, David Gaetano, Jonas Odhner, Samson Wiklund (PDF) (CC BY-NC-ND)
 * [Science, Programming, Art and Radioelectronics Club (SPARC)](https://github.com/artyom-poptsov/SPARC) - Artyom V. Poptsov (PDF) (CC BY-SA)
 


### PR DESCRIPTION
## What does this PR do?
Adds license notations to 2 books under Arduino Section as part of resolving #11355 

### Why is this valuable (or not)?
I have added licensing notations (`CC BY-NC-SA`) to the book _`"Arduino Programming Notebook"`_ by _Brian Evans_ and (`CC BY-SA`) to the book _`"Learn Arduino"`_ (Compiled from StackOverflow documentation).

### How do we know it's legitimate?

The licenses added by me can be confirmed by visiting the linked books. Once the book has been downloaded, scroll to the copyright page where the license version under which the book has been distributed is clearly specified.

I am also adding below the screenshots of the pages where the license notations have been specified for each book

1.   _`"Arduino Programming Notebook"`_ by _Brian Evans_ (`CC BY-NC-SA`)
<img width="393" height="589" alt="image" src="https://github.com/user-attachments/assets/09fef07b-615f-4818-a553-6ce660ecd934" />

2. _`"Learn Arduino"`_ (Compiled from StackOverflow documentation) (`CC BY-SA`)

<img width="724" height="395" alt="image" src="https://github.com/user-attachments/assets/ee0e3d96-9982-4bc1-9166-7ee75b3d4754" />

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.