### PR TITLE
Remove link for casino site from free-programming-playgrounds.md 

### DIFF
--- a/more/free-programming-playgrounds.md
+++ b/more/free-programming-playgrounds.md
@@ -121,7 +121,6 @@
 
 ### ClojureScript
 
-* [Replumb REPL](https://clojurescript.io)
 * [Web REPL](http://clojurescript.net)
 
 


### PR DESCRIPTION
## What does this PR do?
Remove resource(s) 


### Description
The resource has been removed - the link leads to a casino website
