### PR TITLE
Add IBM Cloud Training Catalog link

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -476,6 +476,7 @@
 
 * [Getting started with IBM Cloud](https://cognitiveclass.ai/courses/ibm-cloud-essentials) - Horea Porutiu, Steve Martinelli
 * [IBM Cloud Essentials V3](https://cognitiveclass.ai/courses/ibm-cloud-essentials) - CognitiveClass.ai
+* [IBM Cloud Training Catalog](https://www.ibm.com/training/cloud) - Free Cloud and AI Learning Paths
 
 
 ### Compilers


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR?  
No

## For resources
### Description
Adds the IBM Cloud Training Catalog — a free collection of cloud, AI, and data learning paths provided directly by IBM.

### Why is this valuable (or not)?
It offers high-quality, up-to-date courses on cloud computing and AI directly from IBM, making it a great free educational resource for developers and students.

### How do we know it's really free?
The entire IBM Cloud Training Catalog is publicly accessible without payment; users can register for free and access all listed learning paths and modules.

### For book lists, is it a book? For course lists, is it a course?
It’s a **course/resource list** under IBM’s official training platform.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (none needed).
- [x] Used an informative name for this pull request.  
**PR Title:** Add IBM Cloud Training Catalog - Free Cloud and AI Learning Paths

## Follow-up
- Will check GitHub Actions for any warnings after submission.
