### PR TITLE
fix: Remove broken link for The Python Game Book

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -472,7 +472,6 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [The Little Book of Deep Learning](https://fleuret.org/public/lbdl.pdf) - François Fleuret (PDF) (CC BY-NC-SA)
 * [The Mathematical Engineering of Deep Learning](https://deeplearningmath.org) - Benoit Liquet, Sarat Moka, Yoni Nazarathy
 * [The Mechanics of Machine Learning](https://mlbook.explained.ai) - Terence Parr, Jeremy Howard
-* [The Python Game Book](https://web.archive.org/web/20210308080726/https://thepythongamebook.com/en%3Astart) - Horst Jens *( :card_file_box: archived)*
 * [Top 10 Machine Learning Algorithms Every Engineer Should Know](https://www.dezyre.com/article/top-10-machine-learning-algorithms/202) - Binny Mathews, Omair Aasim
 * [Understanding Machine Learning: From Theory to Algorithms](https://www.cs.huji.ac.il/~shais/UnderstandingMachineLearning) - Shai Shalev-Shwartz, Shai Ben-David
 * [User Guide - scikit-learn](https://scikit-learn.org/stable/user_guide.html) - Scikit-learn developers (HTML) (BSD)


### PR DESCRIPTION
## Description
Removed the entry for 'The Python Game Book' by Horst Jens as the link is no longer accessible.

## Issue
Fixes #12663

## Details
- The archived link (https://web.archive.org/web/20210308080726/https://thepythongamebook.com/en:start) returns 404 errors
- The original site (thepythongamebook.com) shows 403 forbidden errors
- Per CONTRIBUTING.md guidelines: when a link is broken and no alternative is available, it should be removed

## Checklist
- [x] Link verified as broken (404/403 errors)
- [x] No working alternative found
- [x] Entry removed according to contribution guidelines
- [x] File alphabetically ordered
- [x] Commit message follows conventional format