### PR TITLE
Fixed grammar and clarity in Indonesian Code of Conduct

### DIFF
--- a/docs/CODE_OF_CONDUCT-id.md
+++ b/docs/CODE_OF_CONDUCT-id.md
@@ -1,48 +1,48 @@
 # Kode Etik Kontributor
 
-Sebagai kontributor dan pemelihara proyek ini, dan demi membangun komunitas yang
+Sebagai kontributor dan pemelihara proyek ini, serta demi membangun komunitas yang
 terbuka dan ramah, kami berjanji untuk menghormati semua orang yang
 berpartisipasi melalui pelaporan masalah, mengirimkan permintaan fitur,
 memperbarui dokumentasi, mengirimkan Pull Request atau patch, dan kegiatan
 lainnya.
 
-Kami bertekad membuat partisipasi dalam proyek ini menjadi pengalaman bebas
-pelecehan bagi semua orang, tanpa memandang tingkat pengalaman, jenis kelamin,
-identitas dan ekspresi gender, orientasi seksual, cacat, penampilan pribadi,
+Kami berkomitmen untuk menjadikan partisipasi dalam proyek ini sebagai pengalaman yang bebas
+dari pelecehan bagi semua orang, tanpa memandang tingkat pengalaman, jenis kelamin,
+identitas atau ekspresi gender, orientasi seksual, disabilitas, penampilan pribadi,
 ukuran tubuh, ras, etnis, usia, agama, atau kewarganegaraan.
 
 Contoh perilaku partisipan yang tidak dapat diterima meliputi:
 
-* Penggunaan bahasa atau citra seksual
+* Penggunaan bahasa atau gambar bernada seksual
 * Serangan pribadi
 * Trolling atau komentar yang bersifat menghina/menghujat
-* Pelecehan publik atau pribadi
+* Pelecehan publik maupun pribadi
 * Memublikasikan informasi pribadi orang lain, seperti alamat fisik atau elektronik, tanpa izin eksplisit
 * Perilaku tidak etis atau tidak profesional lainnya
 
 Pemelihara proyek memiliki hak dan tanggung jawab untuk menghapus, mengedit,
 atau menolak komentar, commit, kode, suntingan wiki, isu, dan kontribusi lainnya
-yang tidak sesuai dengan Kode Etik ini, atau untuk melarang sementara atau
+yang tidak sesuai dengan Kode Etik ini, atau melarang sementara atau
 permanen setiap kontributor atas perilaku lain yang dianggap tidak pantas,
 mengancam, menyinggung, atau merugikan.
 
-Dengan mengadopsi Kode Etik ini, pemelihara proyek berkomitmen untuk
-mengaplikasikan prinsip-prinsip ini secara adil dan konsisten pada setiap aspek
-pengelolaan proyek ini. Pemelihara proyek yang tidak mengikuti atau menegakkan
+Dengan mengadopsi Kode Etik ini, para pemelihara proyek berkomitmen untuk
+menerapkan prinsip-prinsip ini secara adil dan konsisten di seluruh aspek
+pengelolaan proyek. Pemelihara proyek yang tidak mengikuti atau menegakkan
 Kode Etik ini dapat dihapus secara permanen dari tim proyek.
 
 Kode etik ini berlaku baik di dalam ruang proyek maupun di ruang publik
 ketika seseorang mewakili proyek atau komunitasnya.
 
-Kejadian perilaku yang kasar, mengganggu, atau tidak dapat diterima lainnya
+Kejadian perilaku kasar, mengganggu, atau tidak dapat diterima lainnya
 dapat dilaporkan dengan menghubungi pemelihara proyek di victorfelder(at)gmail.com.
-Semua keluhan akan ditinjau dan diselidiki, dan akan menghasilkan tanggapan yang
-dianggap perlu dan sesuai dengan keadaan. Pemelihara proyek berkewajiban untuk
-menjaga kerahasiaan pelapor insiden.
+Semua keluhan akan ditinjau dan diselidiki, serta akan ditanggapi secara
+tepat sesuai keadaan. Pemelihara proyek berkewajiban menjaga kerahasiaan
+pelapor insiden.
 
 Kode Etik ini diadaptasi dari [Contributor Covenant][homepage],
-versi 1.3.0, avaible at https://contributor-covenant.org/version/1/3/0/
+versi 1.3.0, tersedia di https://contributor-covenant.org/version/1/3/0/
 
 [homepage]: https://contributor-covenant.org
 
-[Terjemahan](README.md#nslations)
+[Terjemahan](README.md#translations)


### PR DESCRIPTION
Cleaned up grammar, punctuation, and translation errors in the Indonesian version of the Contributor Code of Conduct. Ensured consistent tone, improved readability, and corrected minor typos (like “avaible” → “tersedia”). No meaning or structure was changed, just clarity and correctness improvements.

## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## IMPORTANT
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
