### PR TITLE
Add FASTAPI info in python section

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -44,7 +44,6 @@ Books on general-purpose programming that don't focus on a specific language are
 * [CUDA](#cuda)
 * [D](#d)
 * [Dart](#dart)
-* [Data Structures and Algorithms](#data-structures-and-algorithms)
 * [DB2](#db2)
 * [DBMS](#dbms)
 * [Delphi / Pascal](#delphi--pascal)
@@ -671,13 +670,6 @@ Books on general-purpose programming that don't focus on a specific language are
 
 * [Essential Dart](https://www.programming-books.io/essential/dart/) - Krzysztof Kowalczyk, StackOverflow Contributors
 * [Learning Dart](https://riptutorial.com/Download/dart.pdf) - Compiled from StackOverflow documentation (PDF)
-
-
-### Data Structures and Algorithms
-
-* [A Common-Sense Guide to Data Structures & Algorithms](https://github.com/GauravWalia19/Free-Algorithms-Books/blob/main/Library/src/JAVASCRIPT/A-Common-Sense-Guide-to-Data-Structures-and-Algorithms-Level-Up-Your-Core-Programming-Skills.pdf) - Jay Wengrow (PDF)
-* [Algorithms and Data Structures](https://textbookequity.org/Textbooks/Nievergelt_Algorithms%20and%20Data%20Structures08.pdf) - Jürg Nievergelt, Klaus Hinrichs (PDF)
-* [An Open Guide to Data Structures and Algorithms](https://open.umn.edu/opentextbooks/textbooks/an-open-guide-to-data-structures-and-algorithms) - Paul W. Bible, Lucas Moser (PDF)
 
 
 ### DB2


### PR DESCRIPTION
Fixes #12192

## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] This is not a revision of a previous PR.

## For resources
### Description
Adds a new subsection for **FastAPI** under the Python section with four free and verified learning resources.

### Why is this valuable (or not)?
FastAPI is one of the fastest-growing Python frameworks for APIs and backend development. These resources help developers learn and build modern, type-safe Python web applications.

### How do we know it's really free?
All included links are to **official documentation**, **GitHub repositories**, or **free online books/tutorials**.

### For book lists, is it a book? For course lists, is it a course? etc.
It’s a **documentation and tutorial** list (not paid or third-party gated content).

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up
GitHub Actions should pass without warnings.