### PR TITLE
Fix subject link casing for OOP

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -34,7 +34,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
   * [Mathematics For Computer Science](#mathematics-for-computer-science)
 * [Misc](#misc)
 * [Networking](#networking)
-* [Object Oriented Programming](#object-oriented-programming)
+* [Object-Oriented Programming](#object-oriented-programming)
 * [Open Source Ecosystem](#open-source-ecosystem)
 * [Operating Systems](#operating-systems)
 * [Parallel Programming](#parallel-programming)


### PR DESCRIPTION
## What does this PR do?
- [ ] Add resource(s)
- [ ] Remove resource(s)
- [ ] Add info
- [x] **Improve repo**

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted.

## For resources
### Description
N/A. This PR is a minor fix to the subject index structure.

### Why is this valuable (or not)?
This PR improves the guide's consistency by correcting the display text for the 'Object-Oriented Programming' subject entry. Using the hyphenated spelling ensures consistency with industry standards and internal document headings.

### How do we know it's really free?
N/A. This PR modifies only the index.

### For book lists, is it a book? For course lists, is it a course? etc.
N/A. This PR modifies the structure of the subject index (`books/free-programming-books-subjects.md`).

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request. (Title: `docs: Fix subject link casing for Object-Oriented Programming`)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!