### PR TITLE
fix(bn): remove broken C book link returning 404

### DIFF
--- a/books/free-programming-books-bn.md
+++ b/books/free-programming-books-bn.md
@@ -27,11 +27,6 @@
 * [Computer Programming Part 3](https://archive.org/details/computer-programming-part-3-tamim-shaharier-subin) - Tamim Shahriar Subeen (PDF)
 
 
-### <a id="cpp"></a>C++
-
-* [সিপিপি পরিগণনা Computer Programming](https://www.academia.edu/16658418/c_programming_bangla_book) - Mahmudul Hasan (PDF, HTML)
-
-
 ### Data Science
 
 * [ডাটা সাইন্সের হাতেখড়ি](https://datasinsightsbd.gitbook.io) - Fazle Rabbi Khan (gitbook)


### PR DESCRIPTION
This PR removes a broken link from the Bengali (Bangla) books list.

File: books/free-programming-books-bn.md

Section: C++

Broken link: [](https://www.academia.edu/16658418/c_programming_bangla_book) — returns 404

Fix: The broken academia.edu link has been removed because it no longer resolves and I couldn’t find a verified free copy to replace it with.

Result: The Bengali C/C++ section no longer contains a dead link and will not redirect users to a non-existent page.