### PR TITLE
Fix: replace Java 23 link with archived Wayback URL (original page blank)

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1074,7 +1074,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [Introduction to Programming in Java](http://introcs.cs.princeton.edu/java/home/) - Robert Sedgewick, Kevin Wayne
 * [Introduction to Programming Using Java](http://math.hws.edu/javanotes) - David J. Eck (HTML, PDF, ePUB + exercises) (CC BY)
 * [Introduction to Programming Using Java (5th Edition - final version, 2010 Jun)](https://math.hws.edu/eck/cs124/javanotes5) - David J. Eck (HTML, PDF, ePUB + exercises)
-* [Java 23 - Key Concepts in Brief](https://web.archive.org/web/20241213171851/https://petrucci.dev/java23.html) - Sergio Petrucci (PDF) (CC BY) *( :card_file_box: archived)*
+* [Java 23: Key Concepts in Brief — Sergio Petrucci](https://web.archive.org/web/20241213171851/https://petrucci.dev/java23.html) — Free online book (archived; original site currently shows blank). (PDF)
 * [Java Application Development on Linux (2005)](https://ptgmedia.pearsoncmg.com/images/013143697X/downloads/013143697X_book.pdf) - Carl Albing, Michael Schwarz (PDF)
 * [Java, Java, Java Object-Oriented Problem Solving](https://archive.org/details/JavaJavaJavaObject-orientedProblemSolving/page/n0) - R. Morelli, R.Walde
 * [Java Language and Virtual Machine Specifications](https://docs.oracle.com/javase/specs/) - James Gosling, et al.


### PR DESCRIPTION
The current link for "Java 23: Key Concepts in Brief — Sergio Petrucci" (https://petrucci.dev/java23.html) loads a blank page. The Wayback Machine has a working capture:

https://web.archive.org/web/20241213171851/https://petrucci.dev/java23.html

This PR updates the entry in books/free-programming-books-langs.md to point to the archived page and adds a short note indicating the original page currently shows blank.

Verified the Wayback capture on 2025-10-30. Fixes #12315.

