### PR TITLE
Add FastAPI official docs and free tutorial (Python resources) — responds to #12043

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2139,6 +2139,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [Social Auth App](https://python-social-auth.readthedocs.io/en/latest/) (HTML)
 * [Test-Driven Development With Python And Django](http://www.obeythetestinggoat.com/pages/book.html) (1.11)
 
+
 #### FastAPI
 
 * [FastAPI – Python Web Framework (Tutorialspoint)](https://tutorialspoint.com/fastapi/fastapi_tutorial.pdf) — Free PDF tutorial covering FastAPI basics and deployment. (PDF)


### PR DESCRIPTION
Issue #12043 requested adding FastAPI learning resources. The requested O'Reilly title "FastAPI: Modern Python Web Development" appears to be a paid book, so instead this PR adds two free, authoritative FastAPI resources:

- FastAPI official docs: https://fastapi.tiangolo.com/ (tutorial + reference)
- Tutorialspoint FastAPI PDF: https://tutorialspoint.com/fastapi/fastapi_tutorial.pdf

Both are free and legal to link to; added them alphabetically to the Python section in books/free-programming-books-langs.md.

I verified both links on 2025-10-30. See #12043 for the original request.
