### PR TITLE
Clean up C# tutorial links that were in C

### DIFF
--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -76,11 +76,6 @@
 
 * [C Tutorial](https://www.w3schools.com/c/) - W3Schools
 
-
-* [C# Tutorial](https://www.tutlane.com/tutorial/csharp) - tutlane
-* [C# Tutorial](https://www.w3schools.com/cs) - W3Schools
-
-
 ### Artificial Intelligence
 
 * [Generative AI tutorial](https://www.geeksforgeeks.org/artificial-intelligence/generative-ai-tutorial/) - GeeksforGeeks


### PR DESCRIPTION
Removed duplicate C# tutorial links from the list in C

## What does this PR do?
Remove resource(s): The C section contained two C# tutorial links that were duplicates of the links already present in the dedicated C# section. This PR removes those duplicates to keep the list accurate and properly categorize.

## For resources
### Description
The C section contained two C# tutorial links that were duplicates of the links already present in the dedicated C# section. This PR removes those duplicates to keep the list accurate and properly categorized.

### Why is this valuable?
* Fixes categorization errors
* Reduces duplication
* Keeps the resource list clean and easier to navigate

## Checklist:
* [x] Searched for duplicates
* [x] Ensured alphabetical order in the updated list
* [x] Used an informative name for the PR

## Follow-up
- Check the status of GitHub Actions and resolve any reported warnings!
