### PR TITLE
docs: remove unavailable Rust book from Turkish section

### DIFF
--- a/books/free-programming-books-tr.md
+++ b/books/free-programming-books-tr.md
@@ -30,6 +30,7 @@
 
 <!-- Note: 'Rust'a Giriş - Mahmut Bulut (PDF)' is no longer available. -->
 
+
 ### Algoritma ve Veri Yapıları
 
 * [Algoritma ve Programlama Soru Bankası](https://ia601404.us.archive.org/34/items/algoritma-ve-programlama-soru-bankasi/algoritma-ve-programlama-soru-bankas%C4%B1.pdf) (PDF)


### PR DESCRIPTION
### Summary
This PR removes the link to the Turkish Rust book "Rust'a Giriş - Mahmut Bulut (PDF)" because it is no longer available. The corresponding section in `free-programming-books-tr.md` has been updated to reflect this.

### Changes
- Modified `books/free-programming-books-tr.md`
- Removed the unavailable Rust book link
- Added a comment noting that the book is no longer available

### Context
The Turkish Rust book previously listed is no longer accessible. This update ensures that the repository only contains valid resources for readers.


## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## IMPORTANT
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
