### PR TITLE
Correct capitalization of 'Meteor' in programming languages list

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -106,7 +106,7 @@ Books on general-purpose programming that don't focus on a specific language are
     * [Hydrogen](#hydrogen)
     * [Ionic](#ionic)
     * [jQuery](#jquery)
-    * [meteor](#meteor)
+    * [Meteor](#meteor)
     * [Next.js](#nextjs)
     * [Node.js](#nodejs)
     * [Nuxt.js](#nuxtjs)


### PR DESCRIPTION

Fixes a minor capitalization inconsistency while following contribution guidelines.
