### PR TITLE
Fix broken link for Learn Python With Jupyter (Fixes #13083)

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2037,7 +2037,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [Learn Python Programming, Second Edition](https://www.packtpub.com/free-ebooks/learn-python-programming-second-edition) - Fabrizio Romano (Packt account *required*)
 * [Learn Python the Right Way](https://learnpythontherightway.com)
 * [Learn Python Visually](https://archive.org/details/learn-python-visually_compress/mode/2up) - Ivelin Demirov *( :card_file_box: archived)*
-*[Learn Python With Jupyter](https://www.learnpythonwithjupyter.com) - Serena Bonaretti (PDF)
+* [Learn Python With Jupyter](https://www.learnpythonwithjupyter.com) - Serena Bonaretti (PDF)
 * [Learn to Program Using Python](https://web.archive.org/web/20201224032210/https://www.ida.liu.se/~732A47/literature/PythonBook.pdf) - Cody Jackson (PDF) *( :card_file_box: archived)*
 * [Learning to Program](http://www.alan-g.me.uk)
 * [Lectures on scientific computing with python](https://github.com/jrjohansson/scientific-python-lectures) - J.R. Johansson (2.7)


### PR DESCRIPTION
## What does this PR do?
Improve repo

## IMPORTANT
- [x] Read our contributing guidelines.
- [ ] Is this a revision of a previously submitted PR? If so, STOP!

## For resources
### Description
Replaced the broken PDF link for **"Learn Python With Jupyter – Serena Bonaretti (PDF)"** with the correct website URL, as the previous link was returning a 404 error.

### Why is this valuable (or not)?
This ensures users can access the resource without encountering broken links.

### How do we know it's really free?
The official website provides free access to the resource.

### For book lists, is it a book? For course lists, is it a course? etc.
It is a book (PDF resource).

## Checklist:
- [x] Search for duplicates.
- [x] Include author(s) where appropriate.
- [x] Put lists in alphabetical order and maintained correct spacing.
- [x] Add needed indications (PDF, access notes, etc.).
- [x] Used an informative name for this pull request.

## Follow-up
Fixes #13083