### PR TITLE
docs: fix incorrect anchor link for Markdown in langs index

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -131,7 +131,7 @@ Books on general-purpose programming that don't focus on a specific language are
 * [Livecode](#livecode)
 * [Lua](#lua)
 * [Make](#make)
-* [Markdown](#markdown)
+* [Markdown](#markdown-1)
 * [Mathematica](#mathematica)
 * [MATLAB](#matlab)
 * [Maven](#maven)


### PR DESCRIPTION
Fixed the anchor link for 'Markdown' in the index to correctly point to '#markdown-1' (the actual ID for the Markdown section header in this file).