### PR TITLE
docs: fix grammar in HOWTO.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,7 +50,7 @@ By contributing, you agree to respect the [Code of Conduct](CODE_OF_CONDUCT.md) 
     3. *remove it* otherwise.
 - if a link exists in multiple formats, add a separate link with a note about each format
 - if a resource exists at different places on the Internet
-    - use the link with the most authoritative source (meaning author's website is better than editor's website is better than third-party website)
+    - use the link with the most authoritative source (meaning the author's website is preferred over the publisher's or a third-party website)
     - if they link to different editions, and you judge these editions are different enough to be worth keeping them, add a separate link with a note about each edition (see [Issue #2353](https://github.com/EbookFoundation/free-programming-books/issues/2353) to contribute to the discussion on formatting).
 - prefer atomic commits (one commit by addition/deletion/modification) over bigger commits. No need to squash your commits before submitting a PR. (We will never enforce this rule as it's just a matter of convenience for the maintainers)
 - if the book is older, include the publication date with the title.

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -29,6 +29,6 @@ Don't hesitate to ask questions; every contributor started with a first PR. So..
 
 </details>
 
-Even if you're an experienced open source contributor, there are things that might trip you up. Once you've submitted your PR, ***GitHub Actions* will run a *linter*, often finding little issues with spacing or alphabetization**. If you get a green button, everything is ready for review; but if not, click "Details" under the check that failed to find out what the linter didn't like, and fix the problem adding a new commit to the branch from which your PR was opened.
+Even if you're an experienced open source contributor, there are things that might trip you up. Once you've submitted your PR, ***GitHub Actions* will run a *linter*, often finding little issues with spacing or alphabetization**. If you get a green button, everything is ready for review; but if not, click "Details" under the check that failed to find out what the linter didn't like, and fix the problem by adding a new commit to the branch from which your PR was opened.
 
 Finally, if you're not sure that the resource you want to add is appropriate for `Free-Programming-Books`, read through the guidelines in [CONTRIBUTING](CONTRIBUTING.md) *([translations](README.md#translations) also available)*.


### PR DESCRIPTION
Changed 'fix the problem adding a new commit' to 'fix the problem by adding a new commit' for better grammar.