### PR TITLE
Remove broken link: ProgrammeringMedDelphi (Delphi)

### DIFF
--- a/books/free-programming-books-da.md
+++ b/books/free-programming-books-da.md
@@ -25,11 +25,6 @@
 * [Notes about C++](http://people.cs.aau.dk/~normark/ap/index.html) - Kurt Nørmark (HTML)
 
 
-### Delphi
-
-* [Programmering Med Delphi 7](http://olewitthansen.dk/Datalogi/ProgrammeringMedDelphi.pdf) - Ole Witt-Hansen (PDF)
-
-
 ### Java
 
 * [Objektorienteret programmering i Java](http://javabog.dk) - Jacob Nordfalk


### PR DESCRIPTION
## What this changes
Removes a broken link for "ProgrammeringMedDelphi" under Delphi section.

The URL http://olewitthansen.dk/Datalogi/ProgrammeringMedDelphi.pdf 
loads the site but the PDF does not render/load.

No working archive found on the Wayback Machine.

## Checklist
- [x] Verified the link is broken
- [x] Checked Wayback Machine - no working archive available
- [x] Only removed the broken entry, no other changes