### PR TITLE
fix: remove broken link for Grails Tutorial for Beginners

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -888,7 +888,7 @@ Books on general-purpose programming that don't focus on a specific language are
 #### Grails
 
 * [Getting Started with Grails](http://www.infoq.com/minibooks/grails-getting-started)
-* [Grails Tutorial for Beginners](https://web.archive.org/web/20210519053040/http://grails.asia/grails-tutorial-for-beginners/) - grails.asia *( :card_file_box: archived)*
+
 * [The Grails Framework - Reference Documentation](http://grails.github.io/grails-doc/latest/) - Graeme Rocher, Peter Ledbrook, Marc Palmer, Jeff Brown, Luke Daley, Burt Beckwith, Lari Hotari ([PDF](http://grails.github.io/grails-doc/latest/guide/single.pdf))
 
 


### PR DESCRIPTION
The link for "Grails Tutorial for Beginners" (grails.asia) 
is returning a 404 / not loading. Removing the broken link.