### PR TITLE
Add official Python tutorial (Spanish) to books list

### DIFF
--- a/books/free-programming-books-es.md
+++ b/books/free-programming-books-es.md
@@ -344,6 +344,7 @@
 * [Aprende Python](https://aprendepython.es) - Sergio Delgado Quintero (HTML, PDF) (CC BY)
 * [Aprendiendo a Programar en Python con mi Computador](https://openlibra.com/en/book/download/aprendiendo-a-programar-en-python-con-mi-computador) (PDF)
 * [Doma de Serpientes para Niños: Aprendiendo a Programar con Python](http://code.google.com/p/swfk-es/) (HTML)
+* [El tutorial de Python](https://docs.python.org/es/3/tutorial/) - Python Software Foundation (HTML)
 * [Inmersión en Python](https://code.google.com/archive/p/inmersionenpython3/) (HTML)
 * [Inmersión en Python 3](https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/inmersionenpython3/inmersionEnPython3.0.11.pdf) - Mark Pilgrim, `trl.:` José Miguel González Aguilera (PDF) (descarga directa)
 * [Introducción a la programación con Python](http://repositori.uji.es/xmlui/bitstream/handle/10234/24305/s23.pdf) - Andrés Marzal, Isabel Gracia (PDF)


### PR DESCRIPTION
## Summary
- Add the official Python tutorial in Spanish ([docs.python.org/es/3/tutorial/](https://docs.python.org/es/3/tutorial/)) to `free-programming-books-es.md` under the Python section.
- This is the official tutorial maintained by the Python Software Foundation, translated to Spanish by the [python-docs-es](https://github.com/python/python-docs-es) community.
- The resource is free, publicly accessible, and hosted on the most authoritative source (python.org).

## Details
- **Resource**: El tutorial de Python
- **URL**: https://docs.python.org/es/3/tutorial/
- **Author**: Python Software Foundation
- **Format**: HTML
- **Placement**: Alphabetically ordered in the Python section

## Checklist
- [x] Resource is free and publicly accessible
- [x] Link uses HTTPS
- [x] Uses the most authoritative source (official python.org docs)
- [x] Entry is in alphabetical order
- [x] Follows the formatting guidelines (`* [Title](URL) - Author (Format)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)