### PR TITLE
fix: pin 6 unpinned action(s)

### DIFF
--- a/.github/workflows/check-urls.yml
+++ b/.github/workflows/check-urls.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: ${{ steps.set-params.outputs.fetch-depth }}
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           separator: " "
           json: true
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: ${{ needs.get-changed-files.outputs.fetch-depth }}
       - name: Setup Ruby v2.6
         if: ${{ endsWith(matrix.file, '.yml') || endsWith(matrix.file, '.md') }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@eab2afb99481ca09a4e91171a8e0aee0e89bfedd # v1
         with:
           ruby-version: 2.6
       - name: Install awesome_bot

--- a/.github/workflows/detect-conflicting-prs.yml
+++ b/.github/workflows/detect-conflicting-prs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Label conflicting PRs that are open
         id: pr-labeler
-        uses: eps1lon/actions-label-merge-conflict@v3.0.3
+        uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
         with:
           repoToken:  ${{ secrets.GITHUB_TOKEN }}
           retryAfter: 30 # seconds

--- a/.github/workflows/issues-pinner.yml
+++ b/.github/workflows/issues-pinner.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Add pushpin label on pinning an issue
         id: if-pinned
         if: github.event.action == 'pinned'
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
         with:
           repo:   ${{ github.repository }}
           number: ${{ github.event.issue.number }}
@@ -45,7 +45,7 @@ jobs:
       - name: Remove pushpin label on unpinning an issue
         id: if-unpinned
         if: github.event.action == 'unpinned'
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1
         with:
           repo:   ${{ github.repository }}
           number: ${{ github.event.issue.number }}

--- a/.github/workflows/rtl-ltr-linter.yml
+++ b/.github/workflows/rtl-ltr-linter.yml
@@ -40,7 +40,7 @@ jobs:
     # Identify all changed Markdown files in the PR using tj-actions/changed-files
     - name: Get changed Markdown files
       id: changed_md_files
-      uses: tj-actions/changed-files@v46
+      uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
       with:
         files: |
           **/*.md


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/check-urls.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/detect-conflicting-prs.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/issues-pinner.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/rtl-ltr-linter.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/comment-pr.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/comment-pr.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/comment-pr.yml` | Comment-Triggered Workflow Without Author Authorization Check |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.