### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-urls.yml
+++ b/.github/workflows/check-urls.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: ${{ steps.set-params.outputs.fetch-depth }}
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           separator: " "
           json: true
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: ${{ needs.get-changed-files.outputs.fetch-depth }}
       - name: Setup Ruby v2.6
         if: ${{ endsWith(matrix.file, '.yml') || endsWith(matrix.file, '.md') }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@eab2afb99481ca09a4e91171a8e0aee0e89bfedd # v1
         with:
           ruby-version: 2.6
       - name: Install awesome_bot

--- a/.github/workflows/detect-conflicting-prs.yml
+++ b/.github/workflows/detect-conflicting-prs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Label conflicting PRs that are open
         id: pr-labeler
-        uses: eps1lon/actions-label-merge-conflict@v3.0.3
+        uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
         with:
           repoToken:  ${{ secrets.GITHUB_TOKEN }}
           retryAfter: 30 # seconds

--- a/.github/workflows/issues-pinner.yml
+++ b/.github/workflows/issues-pinner.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Add pushpin label on pinning an issue
         id: if-pinned
         if: github.event.action == 'pinned'
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
         with:
           repo:   ${{ github.repository }}
           number: ${{ github.event.issue.number }}
@@ -45,7 +45,7 @@ jobs:
       - name: Remove pushpin label on unpinning an issue
         id: if-unpinned
         if: github.event.action == 'unpinned'
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1
         with:
           repo:   ${{ github.repository }}
           number: ${{ github.event.issue.number }}

--- a/.github/workflows/rtl-ltr-linter.yml
+++ b/.github/workflows/rtl-ltr-linter.yml
@@ -40,7 +40,7 @@ jobs:
     # Identify all changed Markdown files in the PR using tj-actions/changed-files
     - name: Get changed Markdown files
       id: changed_md_files
-      uses: tj-actions/changed-files@v46
+      uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
       with:
         files: |
           **/*.md


### PR DESCRIPTION
Re-submission of #13155. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts any unsafe expressions from run blocks into env mappings.

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)