### PR TITLE
docs: add 2 resources to Web Services section

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -1070,7 +1070,9 @@ Kerridge (PDF) (email address *requested*, not required)
 
 ### Web Services
 
+* [An Introduction to APIs](https://zapier.com/resources/guides/apis) - Brian Cooksey (HTML)
 * [RESTful Web Services](http://restfulwebapis.org/RESTful_Web_Services.pdf) (PDF)
+* [Web API Design: Crafting Interfaces that Developers Love](https://pages.apigee.com/rs/apigee/images/api-design-ebook-2012-03.pdf) - Brian Mulloy (PDF)
 
 
 ### Workflow


### PR DESCRIPTION
]## What does this PR do?
Adds 2 free, high-quality resources to the Web Services section:

- **An Introduction to APIs** by Brian Cooksey (Zapier) - A beginner-friendly 
  HTML guide explaining what APIs are and how they work.
- **Web API Design: Crafting Interfaces that Developers Love** by Brian Mulloy 
  (Apigee) - A practical PDF guide on designing clean, developer-friendly APIs.

## Why these resources?
Both are:
- Completely free with no account required
- From reputable authors and organizations
- Directly relevant to the Web Services topic
- Not currently listed in the repository

## Type of change
- [x] Adding a new free resource