### PR TITLE
fix(scripts): load rtl_ltr_linter config from correct filename

### DIFF
--- a/scripts/rtl_ltr_linter.py
+++ b/scripts/rtl_ltr_linter.py
@@ -4,7 +4,7 @@ RTL/LTR Markdown Linter.
 
 This script analyzes Markdown files to identify potential issues
 in the display of mixed Right-To-Left (RTL) and Left-To-Right (LTR) text.
-It reads configuration from a `rtl_linter_config.yml` file located in the same
+It reads configuration from a `rtl_ltr_linter_config.yml` file located in the same
 directory as the script.
 
 Key Features:
@@ -491,8 +491,8 @@ def main():
     # Determine the directory where the script is located to find the config file
     script_dir = os.path.dirname(os.path.abspath(__file__))
 
-    # Load the configuration from 'rtl_linter_config.yml'
-    cfg = load_config(os.path.join(script_dir, 'rtl_linter_config.yml'))
+    # Load the configuration from 'rtl_ltr_linter_config.yml'
+    cfg = load_config(os.path.join(script_dir, 'rtl_ltr_linter_config.yml'))
 
     # Initialize counters for total files processed and errors/warnings found
     total = errs = 0


### PR DESCRIPTION

**Repo:** EbookFoundation/free-programming-books (⭐ 385770)
**Type:** bugfix
**Files changed:** 1
**Lines:** +3/-3

## What
`scripts/rtl_ltr_linter.py` called `load_config(...'rtl_linter_config.yml')`, but the
actual configuration file in the same directory is `rtl_ltr_linter_config.yml`.
Since `load_config` silently falls back to built-in defaults when the path does
not exist, the repo's tuned `ltr_keywords`, `ltr_symbols`, and `severity` settings
were never being applied. This patch corrects the filename (and the two stale
references to it in the docstring/comment).

## Why
The RTL/LTR linter is wired into CI to annotate PRs touching the RTL language
markdown files. Loading the wrong config means the curated keyword/symbol lists
maintained in `rtl_ltr_linter_config.yml` were inert — every run used the
hard-coded defaults (empty `ltr_keywords` and `ltr_symbols`), so most keyword and
symbol checks never fired. Restoring the correct path makes the linter actually
behave as configured.

## Testing
- Verified by inspection: `os.path.exists` check on the old path returns False,
  on the new path returns True (the file is at `scripts/rtl_ltr_linter_config.yml`).
- `grep` confirms no other references to the old `rtl_linter_config.yml` name remain.
- Change is local-only; no test suite execution required for a one-character
  filename correction.

## Risk
Low — a one-line filename correction in a CI lint script. Worst case is the
linter starts emitting more warnings on changed RTL lines (which is the intent).
