### PR TITLE
fix: replace broken link in APL section

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -281,6 +281,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 * [A Programming Language](https://softwarepreservation.computerhistory.org/apl/book/APROGRAMMINGLANGUAGE.pdf) - Kenneth E. Iverson (PDF)
 * [APL2 at a Glance](https://ia801009.us.archive.org/28/items/apl-2-at-a-glance-brown-pakin-polivka/APL2_at_a_Glance_-_Brown_Pakin_Polivka.pdf) - James A. Brown, Sandra Pakin, Raymond P. Polivka - 1988 (PDF)
+* [Introduction to College Mathematics with A Programming Language (1978)](https://softwarepreservation.computerhistory.org/apl/book/CollegeMathematicswithAPL.pdf) - E. J. LeCuyer (PDF)
 * [Learning APL](https://xpqz.github.io/learnapl) - Stefan Kruger (HTML,PDF,IPYNB)
 * [Mastering Dyalog APL](https://www.dyalog.com/mastering-dyalog-apl.htm) (PDF, HTML, IPYNB) *( :construction: in process)*
 * [Reinforcement Learning From The Ground Up](https://romilly.github.io/o-x-o) - Romilly Cocking (PDF, HTML, IPYNB) *( :construction: in process)*


### PR DESCRIPTION
## Description

The issue reported that the link to *Introduction to College Mathematics with A Programming Language (1978)* by E.J. LeCuyer was broken.

**Broken link:** `https://www.softwarepreservation.org/projects/apl/Books/CollegeMathematicswithAPL` (returns 404)

**Replacement:** `https://softwarepreservation.computerhistory.org/apl/book/CollegeMathematicswithAPL.pdf` (confirmed 200 OK, PDF ~15MB)

## What I tried

1. Visited the reported broken URL (`www.softwarepreservation.org/projects/apl/Books/CollegeMathematicswithAPL`) — returns 404.
2. Checked the redirect target of the above URL — it points to `softwarepreservation.computerhistory.org/apl/Books/CollegeMathematicswithAPL`, which also returns 404.
3. Tried `softwarepreservation.computerhistory.org/apl/book/CollegeMathematicswithAPL.pdf` (note `/book/` vs `/Books/`) — this **works** (HTTP 200, 15MB PDF).
4. Also tried `softwarepreservation.computerhistory.org/apl/Books/CollegeMathematicswithAPL/` with trailing slash — returns 404.

## Fix applied

The entry for *Introduction to College Mathematics with A Programming Language* was previously removed (in #12958) because the original link was broken. I found that the working PDF exists at the `/book/` path variant on `softwarepreservation.computerhistory.org` and restored the entry with the correct URL.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof