### PR TITLE
fix: upgrade http links to https in Python section

### DIFF
--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -666,16 +666,16 @@
 * [简明 Python 教程](https://web.archive.org/web/20200822010330/https://bop.mol.uno/) - Swaroop C H、沈洁元(翻译)、漠伦(翻译) *( :card_file_box: archived)*
 * [人生苦短，我用python](https://www.cnblogs.com/derek1184405959/p/8579428.html) - zhang_derek *(内含丰富的笔记以及各类教程)*
 * [深入 Python 3](https://github.com/jiechic/diveintopython3)
-* [Matplotlib 3.0.3 中文文档](http://www.osgeo.cn/matplotlib/) (Online)
-* [Numpy 1.16 中文文档](http://www.osgeo.cn/numpy/) (Online)
-* [Python 3 文档(简体中文) 3.2.2 documentation](http://docspy3zh.readthedocs.org/en/latest/)
-* [Python 3.8.0a3中文文档](http://www.osgeo.cn/cpython/) (Online) *(目前在线最全的中文文档了)*
+* [Matplotlib 3.0.3 中文文档](https://www.osgeo.cn/matplotlib/) (Online)
+* [Numpy 1.16 中文文档](https://www.osgeo.cn/numpy/) (Online)
+* [Python 3 文档(简体中文) 3.2.2 documentation](https://docspy3zh.readthedocs.org/en/latest/)
+* [Python 3.8.0a3中文文档](https://www.osgeo.cn/cpython/) (Online) *(目前在线最全的中文文档了)*
 * [Python 最佳实践指南](https://pythonguidecn.readthedocs.io/zh/latest/)
-* [Python Cookbook第三版](http://python3-cookbook.readthedocs.io/zh_CN/latest/) - David Beazley、Brian K.Jones、熊能(翻译)
+* [Python Cookbook第三版](https://python3-cookbook.readthedocs.io/zh_CN/latest/) - David Beazley、Brian K.Jones、熊能(翻译)
 * [Python教程 - 廖雪峰的官方网站](https://www.liaoxuefeng.com/wiki/1016959663602400)
 * [Python进阶](https://interpy.eastlakeside.com) - eastlakeside
 * [Python之旅](https://web.archive.org/web/20191217091745/http://funhacks.net/explore-python/) - Ethan *( :card_file_box: archived)*
-* [Tornado 6.1 中文文档](http://www.osgeo.cn/tornado/) (Online) *(网络上其他的都是较旧版本的)*
+* [Tornado 6.1 中文文档](https://www.osgeo.cn/tornado/) (Online) *(网络上其他的都是较旧版本的)*
 
 
 #### Django


### PR DESCRIPTION
### What does this PR do?

Improve repository

### Checklist

- [x] Not a duplicate
- [x] Added in alphabetical order
- [x] Used the most authoritative source
- [x] Used https instead of http where available

### Description

Upgraded 6 HTTP links to HTTPS in the Python section of `free-programming-books-zh.md`. All upgraded links have been verified to serve the same content over HTTPS.