### PR TITLE
Repair broken Herod 'Linear Algebra, Infinite Dimensions, and Maple' link via Wayback

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -599,7 +599,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [Linear Algebra](http://joshua.smcvt.edu/linearalgebra/) - Jim Hefferon
 * [Linear Algebra Done Right](https://linear.axler.net) - Sheldon Axler
 * [Linear Algebra Done Wrong](https://www.math.brown.edu/streil/papers/LADW/LADW.html) - Sergei Treil
-* [Linear Algebra, Infinite Dimensions, and Maple](https://people.math.gatech.edu/~herod/Hspace/Hspace.html) - James Herod
+* [Linear Algebra, Infinite Dimensions, and Maple](https://web.archive.org/web/20240313042212/https://herod.math.gatech.edu/Hspace/Hspace.html) - James Herod (HTML) *( :card_file_box: archived)*
 * [ORCCA: Open Resources for Community College Algebra](https://spaces.pcc.edu/pages/viewpage.action?pageId=52729944) - Portland Community College
 * [Paul's Online Notes: Algebra, Calculus I-III and Differential Equations](https://tutorial.math.lamar.edu) - Paul Dawkins @ Lamar University
 * [Second Course in Algebra](http://djm.cc/library/Second_Algebra_Hawkes_Luby_Touton_edited.pdf) - Herbert E. Hawkes, William A. Luby, Frank C. Touton (PDF)


### PR DESCRIPTION
## What does this PR do?
Improve repo — repair a broken book link.

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] This is not a revision of a previously submitted PR.

## For resources
### Description

The entry for *Linear Algebra, Infinite Dimensions, and Maple* by James Herod (line 602 of `books/free-programming-books-subjects.md`, under Mathematics → Algebra) currently points to `https://people.math.gatech.edu/~herod/Hspace/Hspace.html`, which 301-redirects to `https://herod.math.gatech.edu/Hspace/Hspace.html`. The redirect target no longer resolves (DNS NXDOMAIN), so the link is unreachable.

This PR replaces the broken URL with the most recent Internet Archive snapshot (2024-03-13) and adds the `(HTML)` format note and `*( :card_file_box: archived)*` notation, exactly as documented in `docs/CONTRIBUTING.md`.

Closes #13239 — the issue requested adding this book; it was already listed but unreachable, so the right fix is to restore access to the existing entry rather than add a duplicate.

### Why is this valuable (or not)?

A dead link in a curated list is worse than no link — readers click through and hit a server error with no recourse. Restoring via Wayback Machine recovers the resource and matches the project's documented playbook for unreachable URLs.

### How do we know it's really free?

The book is hosted on the author's Georgia Tech math department personal page (`herod.math.gatech.edu` / `people.math.gatech.edu/~herod/`), which is the standard pattern for freely-published academic course notes. The original entry in this repo treated it as free; this PR does not change that judgment, only the URL used to retrieve it.

### For book lists, is it a book? For course lists, is it a course? etc.

It is a book (course-notes book on linear algebra in infinite-dimensional spaces, with Maple worksheets), already classified correctly under Mathematics → Algebra in `books/free-programming-books-subjects.md`.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates. — confirmed the existing entry is the same book; this PR replaces its URL rather than adding a new line.
- [x] Include author(s) and platform where appropriate. — author "James Herod" preserved; format "(HTML)" added.
- [x] Put lists in alphabetical order, correct spacing. — entry's position is unchanged; only the URL and trailing notation are modified.
- [x] Add needed indications (PDF, access notes, under construction). — added `(HTML)` and `*( :card_file_box: archived)*`.
- [x] Used an informative name for this pull request.