### PR TITLE
Fix: Update broken Agda Tutorial link

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -254,7 +254,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 ### Agda
 
-* [Agda Tutorial](https://people.inf.elte.hu/divip/AgdaTutorial/Index.html)
+* [Agda Tutorial](https://people.inf.elte.hu/pgj/agda/tutorial/Index.html)
 * [Programming Language Foundations in Agda](https://plfa.github.io) - Philip Wadler, Wen Kokke
 
 


### PR DESCRIPTION
The previous link http://www.inf.elte.hu/divip/AgdaTutorial/Index.html  returns 404. Updated to the working mirror at 
https://people.inf.elte.hu/pgj/agda/tutorial/Index.html

## What does this PR do?
Remove resource(s)

## IMPORTANT
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
Fix broken Agda Tutorial link. The old URL returns 404.
Updated to working mirror.

### Why is this valuable (or not)?
Fixes a dead link so users can access the Agda Tutorial.

### How do we know it's really free?
The tutorial is freely accessible at the new URL.

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
