### PR TITLE
Add Networking from Scratch to free courses (Networking)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1507,6 +1507,7 @@
 * [Computer Networking Full Course - OSI Model Deep Dive with Real Life Examples](https://www.youtube.com/watch?v=IPvYjXCsTg8) - Kunal Kushwaha
 * [Computer Networks 5e](https://media.pearsoncmg.com/ph/streaming/esm/tanenbaum5e_videonotes/tanenbaum_videoNotes.html) - Andrew Tanenbaum, David Wetherall (Pearson)
 * [Free CCNA 200-301 // Complete Course // NetworkChuck 2023](https://www.youtube.com/playlist?list=PLIhvC56v63IJVXv0GJcl9vO5Z6znCVb1P) - NetworkChuck
+* [Networking from Scratch](https://networkingfromscratch.vercel.app) - Tanay Kumar
 
 
 ### Objective-C


### PR DESCRIPTION
## Description
Adding "Networking from Scratch" — a free, MIT-licensed curriculum with 289 hands-on lessons in C and Python covering the full network stack from raw bytes to eBPF.

## Why is this resource valuable?
- 289 structured lessons covering 15 phases from bits/encoding through eBPF/XDP
- Hands-on implementation in C and Python with tests
- Completely free, MIT-licensed, no signup required
- Website with progress tracking, catalog, and roadmap

## Is it free?
Yes — MIT licensed, hosted freely at networkingfromscratch.vercel.app

## Checklist
- [x] I have searched for duplicates
- [x] The resource is free
- [x] I have followed the formatting guidelines
- [x] Entry is in alphabetical order