### PR TITLE
docs(CONTRIBUTING): add 'last updated' notation for podcasts/screencasts

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,6 +57,7 @@ By contributing, you agree to respect the [Code of Conduct](CODE_OF_CONDUCT.md) 
 - include the author name or names where appropriate. You can shorten author lists with "`et al.`".
 - if the book is not finished, and is still being worked on, add the "`in process`" notation, as described [below](#in_process).
 - if a resource is restored using the [*Internet Archive's Wayback Machine*](https://web.archive.org) (or similar), add the "`archived`" notation, as described [below](#archived). The best versions to use are recent and complete.
+- if a podcast or screencast has not published a new episode in 2 or more years, add the "`last updated`" notation with the most recent publication month and year, as described [below](#last_updated).
 - if an email address or account setup is requested before download is enabled, add language-appropriate notes in parentheses, e.g.: `(email address *requested*, not required)`.
 
 
@@ -139,6 +140,12 @@ Example:
 
     ```text
     GOOD: * [A Way-backed Interesting Book](https://web.archive.org/web/20211016123456/http://example.com/) - John Doe (HTML) *( :card_file_box: archived)*
+    ```
+
+- <a id="last_updated"></a>Last updated podcast or screencast (use when the show has not published a new episode in 2 or more years; record the most recent publication month and year):
+
+    ```text
+    GOOD: * [An Awesome Podcast](https://example.com/podcast) - Jane Roe *( :calendar: last updated: June 2022)*
     ```
     
 - <a id="license"></a>Free Licenses (While we include resources that are "All Rights Reserved" but free to read, we encourage the use of free licenses, such as Creative Commons):


### PR DESCRIPTION
Closes #12348

## Summary

Adds a new optional `last updated` notation that contributors can apply to podcast or screencast entries whose shows have not published a new episode in 2 or more years. This lets readers tell at a glance which shows in the casts lists are still active vs. abandoned, which is the user pain described in #12348.

## What changes

Two additions to `docs/CONTRIBUTING.md`, both modeled exactly on the existing `in process` and `archived` notations:

1. **Guidelines section** — one new bullet describing *when* to apply the notation (parallel to the existing bullets for `in process` and `archived`).
2. **Formatting section** — one new `<a id="last_updated"></a>` block with a worked example, slotted between the existing `archived` and `license` blocks (mirroring those anchors so the Guidelines bullet's `[below](#last_updated)` link resolves).

## Worked example

```text
* [An Awesome Podcast](https://example.com/podcast) - Jane Roe *( :calendar: last updated: June 2022)*
```

`:calendar:` is a GitHub-supported emoji shortcode and is not currently used in `CONTRIBUTING.md`, so it's free to claim as the visual marker for this notation (parallel to `:construction:` for in-process and `:card_file_box:` for archived).

## Why this approach

- **Optional, not mandatory** — Contributors can apply it when they have evidence (the issue suggests a 2–3 year threshold; I picked 2 years to be slightly more aggressive at flagging stale shows). Maintainers are free to bikeshed the threshold in review.
- **Docs-only change** — Does not touch any of the list files. None of the existing podcast/screencast entries are modified by this PR; that follow-up work can happen organically as contributors notice stale entries and apply the new notation.
- **Mirrors existing patterns exactly** — Both edits sit alongside (and use the same indentation, code block, anchor, and emoji style as) the existing `in process` and `archived` notations. There is no new structural concept to learn.

## Checklist

- [x] Atomic commit (single change, single commit)
- [x] No emoji or shortened URLs in titles
- [x] Markdown indentation preserved (code blocks indented 4 spaces, matching the surrounding blocks)
- [x] New anchor (`last_updated`) follows the existing `<a id="..."></a>` pattern used by `in_process`, `archived`, `license`
- [x] No list file content changed → no `fpb-lint` or `awesome_bot` exposure
- [x] No RTL-language file changed → no `rtl-ltr-linter` exposure
