### PR TITLE
fix: correct OSTEP authors and add Korean translators

### DIFF
--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -156,7 +156,7 @@
 
 ### Operation System
 
-* [운영체제: 아주 쉬운 세 가지 이야기](https://github.com/remzi-arpacidusseau/ostep-translations/tree/master/korean) - Remzi Arpacidusseau (PDF)
+* [운영체제: 아주 쉬운 세 가지 이야기](https://github.com/remzi-arpacidusseau/ostep-translations/tree/master/korean) - Remzi H. Arpaci-Dusseau, Andrea C. Arpaci-Dusseau, `trl.:` Youjip Won, `trl.:` Minkyu Park, `trl.:` Sungjin Lee (PDF)
 
 
 ### Perl


### PR DESCRIPTION
Corrects the author entry for OSTEP in the Korean books list:

- Added co-author Andrea C. Arpaci-Dusseau (book is co-authored by Remzi H. and Andrea C.)
- Added missing hyphen and middle initial: Arpacidusseau → Remzi H. Arpaci-Dusseau
- Added Korean translators (Youjip Won, Minkyu Park, Sungjin Lee) as credited in the linked ostep-translations repo

References: https://pages.cs.wisc.edu/~remzi/OSTEP/
