### PR TITLE
fix: Operation System to Operating System in Korean list

### DIFF
--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -20,7 +20,7 @@
 * [Linux](#linux)
 * [Machine Learning](#machine-learning)
 * [Mathematics](#mathematics)
-* [Operation System](#operation-system)
+* [Operating System](#operating-system)
 * [Perl](#perl)
 * [PHP](#php)
     * [Laravel](#laravel)
@@ -154,7 +154,7 @@
 * [기초정수론: 계산과 법연산, 그리고 비밀통신을 강조한](https://wstein.org/ent/ent_ko.pdf) - William Stein (PDF)
 
 
-### Operation System
+### Operating System
 
 * [운영체제: 아주 쉬운 세 가지 이야기](https://github.com/remzi-arpacidusseau/ostep-translations/tree/master/korean) - Remzi Arpacidusseau (PDF)
 


### PR DESCRIPTION
Fixes a grammatical error in the Korean books list.
Operation System is grammatically incorrect - the standard term is Operating System(gerund form). All other language files in this repo (e.g., free-programming-books-langs.md) use Operating System.
Updates both the index entry and the section heading in books/free-programming-books-ko.md.