### PR TITLE
Add Chinese (zh-CN) and Traditional Chinese (zh-TW) README translations

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,233 @@
+# 多语言免费学习资源列表
+
+<div align="center" markdown="1">
+
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)&#160;
+[![许可证: CC BY 4.0](https://img.shields.io/github/license/EbookFoundation/free-programming-books)](https://creativecommons.org/licenses/by/4.0/)&#160;
+[![Hacktoberfest 2025 统计](https://img.shields.io/github/hacktoberfest/2025/EbookFoundation/free-programming-books?label=Hacktoberfest+2025)](https://github.com/EbookFoundation/free-programming-books/pulls?q=is%3Apr+is%3Amerged+created%3A2025-10-01..2025-10-31)
+
+</div>
+
+在 [https://ebookfoundation.github.io/free-programming-books-search/](https://ebookfoundation.github.io/free-programming-books-search/) 搜索列表 [![https://ebookfoundation.github.io/free-programming-books-search/](https://img.shields.io/website?style=flat&logo=www&logoColor=whitesmoke&label=动态搜索站点&down_color=red&down_message=down&up_color=green&up_message=up&url=https%3A%2F%2Febookfoundation.github.io%2Ffree-programming-books-search%2F)](https://ebookfoundation.github.io/free-programming-books-search/)。
+
+本页面也提供易于阅读的网站版本。点击访问 [![https://ebookfoundation.github.io/free-programming-books/](https://img.shields.io/website?style=flat&logo=www&logoColor=whitesmoke&label=静态站点&down_color=red&down_message=down&up_color=green&up_message=up&url=https%3A%2F%2Febookfoundation.github.io%2Ffree-programming-books%2F)](https://ebookfoundation.github.io/free-programming-books/)。
+
+<div align="center">
+  <form action="https://ebookfoundation.github.io/free-programming-books-search">
+    <input type="text" id="fpbSearch" name="search" required placeholder="搜索书籍或作者"/>
+    <label for="submit"> </label>
+    <input type="submit" id="submit" name="submit" value="搜索" />
+  </form>
+</div>
+
+## 简介
+
+本列表最初克隆自 [StackOverflow - 免费编程书籍列表](https://web.archive.org/web/20140606191453/http://stackoverflow.com/questions/194812/list-of-freely-available-programming-books/392926)，并得到了 Karan Bhangui 和 George Stocker 的贡献。
+
+该列表由 Victor Felder 迁移至 GitHub 以便协作更新和维护。如今已发展为 [GitHub 最受欢迎的仓库之一](https://octoverse.github.com/)。
+
+<div align="center" markdown="1">
+
+[![GitHub 仓库 Forks](https://img.shields.io/github/forks/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=Forks)](https://github.com/EbookFoundation/free-programming-books/network)&#160;
+[![GitHub 仓库 Stars](https://img.shields.io/github/stars/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=Stars)](https://github.com/EbookFoundation/free-programming-books/stargazers)&#160;
+[![GitHub 仓库贡献者](https://img.shields.io/github/contributors-anon/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=贡献者)](https://github.com/EbookFoundation/free-programming-books/graphs/contributors)    
+[![GitHub 组织赞助者](https://img.shields.io/github/sponsors/EbookFoundation?style=flat&logo=github&logoColor=whitesmoke&label=赞助者)](https://github.com/sponsors/EbookFoundation)&#160;
+[![GitHub 仓库 Watchers](https://img.shields.io/github/watchers/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=Watchers)](https://github.com/EbookFoundation/free-programming-books/watchers)&#160;
+[![GitHub 仓库大小](https://img.shields.io/github/repo-size/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=仓库大小)](https://github.com/EbookFoundation/free-programming-books/archive/refs/heads/main.zip)
+
+</div>
+
+[Free Ebook Foundation](https://ebookfoundation.org) 现在管理该仓库，这是一个致力于促进免费电子书的创建、分发、归档和可持续发展的非营利组织。对 Free Ebook Foundation 的[捐赠](https://ebookfoundation.org/contributions.html)在美国可享受税收减免。
+
+## 如何贡献
+
+请阅读 [CONTRIBUTING](docs/CONTRIBUTING.md)。如果你是 GitHub 新手，请[欢迎](docs/HOWTO.md)！请记住遵守我们改编自 ![贡献者公约 1.3](https://img.shields.io/badge/Contributor%20Covenant-1.3-4baaaa.svg) 的[行为准则](docs/CODE_OF_CONDUCT.md)（也提供[翻译版本](#translations)）。
+
+点击以下徽章了解你可以如何提供帮助：
+
+<div align="center" markdown="1">
+
+[![GitHub 仓库 Issues](https://img.shields.io/github/issues/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/EbookFoundation/free-programming-books/issues)&#160;
+[![GitHub 仓库新手友好 Issues](https://img.shields.io/github/issues/EbookFoundation/free-programming-books/good%20first%20issue?style=flat&logo=github&logoColor=green&label=新手友好%20Issues)](https://github.com/EbookFoundation/free-programming-books/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)&#160;
+[![GitHub 需要帮助的 Issues](https://img.shields.io/github/issues/EbookFoundation/free-programming-books/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22需要帮助%22%20Issues)](https://github.com/EbookFoundation/free-programming-books/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)    
+[![GitHub 仓库 PRs](https://img.shields.io/github/issues-pr/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=orange&label=PRs)](https://github.com/EbookFoundation/free-programming-books/pulls)&#160;
+[![GitHub 仓库已合并 PRs](https://img.shields.io/github/issues-search/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=green&label=已合并%20PRs&query=is%3Amerged)](https://github.com/EbookFoundation/free-programming-books/pulls?q=is%3Apr+is%3Amerged)&#160;
+[![GitHub 需要帮助的 PRs](https://img.shields.io/github/issues-pr/EbookFoundation/free-programming-books/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22需要帮助%22%20PRs)](https://github.com/EbookFoundation/free-programming-books/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+
+</div>
+
+## 如何分享
+
+<div align="left" markdown="1">
+<a href="https://www.facebook.com/share.php?u=https%3A%2F%2Fgithub.com%2FEbookFoundation%2Ffree-programming-books&p[images][0]=&p[title]=Free%20Programming%20Books&p[summary]=">在 Facebook 上分享</a><br>
+<a href="https://www.linkedin.com/shareArticle?mini=true&url=https://github.com/EbookFoundation/free-programming-books&title=Free%20Programming%20Books&summary=&source=">在 LinkedIn 上分享</a><br>
+<a href="https://toot.kytta.dev/?text=https://github.com/EbookFoundation/free-programming-books">在 Mastodon/Fediverse 上分享</a><br>    
+<a href="https://t.me/share/url?url=https://github.com/EbookFoundation/free-programming-books">在 Telegram 上分享</a><br>
+<a href="https://twitter.com/intent/tweet?text=https://github.com/EbookFoundation/free-programming-books%0AFree%20Programming%20Books">在 𝕏 (Twitter) 上分享</a><br>
+</div>
+
+## 资源
+
+本项目按类别列出书籍和其他资源：
+
+### 书籍
+
+[英语，按编程语言分类](books/free-programming-books-langs.md)
+
+[英语，按主题分类](books/free-programming-books-subjects.md)
+
+#### 其他语言
+
++ [阿拉伯语 / al arabiya / العربية](books/free-programming-books-ar.md)
++ [亚美尼亚语 / Հայերեն](books/free-programming-books-hy.md)
++ [阿塞拜疆语 / Азәрбајҹан дили / آذربايجانجا ديلي](books/free-programming-books-az.md)
++ [孟加拉语 / বাংলা](books/free-programming-books-bn.md)
++ [保加利亚语 / български](books/free-programming-books-bg.md)
++ [缅甸语 / မြန်မာဘာသာ](books/free-programming-books-my.md)
++ [中文](books/free-programming-books-zh.md)
++ [捷克语 / čeština / český jazyk](books/free-programming-books-cs.md)
++ [加泰罗尼亚语 / catalan / català](books/free-programming-books-ca.md)
++ [丹麦语 / dansk](books/free-programming-books-da.md)
++ [荷兰语 / Nederlands](books/free-programming-books-nl.md)
++ [爱沙尼亚语 / eesti keel](books/free-programming-books-et.md)
++ [芬兰语 / suomi / suomen kieli](books/free-programming-books-fi.md)
++ [法语 / français](books/free-programming-books-fr.md)
++ [德语 / Deutsch](books/free-programming-books-de.md)
++ [希腊语 / ελληνικά](books/free-programming-books-el.md)
++ [希伯来语 / עברית](books/free-programming-books-he.md)
++ [印地语 / हिन्दी](books/free-programming-books-hi.md)
++ [匈牙利语 / magyar / magyar nyelv](books/free-programming-books-hu.md)
++ [印尼语 / Bahasa Indonesia](books/free-programming-books-id.md)
++ [意大利语 / italiano](books/free-programming-books-it.md)
++ [日语 / 日本語](books/free-programming-books-ja.md)
++ [韩语 / 한국어](books/free-programming-books-ko.md)
++ [拉脱维亚语 / Latviešu](books/free-programming-books-lv.md)
++ [马拉雅拉姆语 / മലയാളം](books/free-programming-books-ml.md)
++ [挪威语 / Norsk](books/free-programming-books-no.md)
++ [波斯语 / Farsi (Iran) / فارسى](books/free-programming-books-fa_IR.md)
++ [波兰语 / polski / język polski / polszczyzna](books/free-programming-books-pl.md)
++ [葡萄牙语（巴西）](books/free-programming-books-pt_BR.md)
++ [葡萄牙语（葡萄牙）](books/free-programming-books-pt_PT.md)
++ [罗马尼亚语 / limba română / român](books/free-programming-books-ro.md)
++ [俄语 / Русский язык](books/free-programming-books-ru.md)
++ [塞尔维亚语 / српски језик / srpski jezik](books/free-programming-books-sr.md)
++ [斯洛伐克语 / slovenčina](books/free-programming-books-sk.md)
++ [斯洛文尼亚语 / Slovenščina](books/free-programming-books-sl.md)
++ [西班牙语 / español / castellano](books/free-programming-books-es.md)
++ [瑞典语 / Svenska](books/free-programming-books-sv.md)
++ [泰米尔语 / தமிழ்](books/free-programming-books-ta.md)
++ [泰卢固语 / తెలుగు](books/free-programming-books-te.md)
++ [泰语 / ไทย](books/free-programming-books-th.md)
++ [土耳其语 / Türkçe](books/free-programming-books-tr.md)
++ [乌克兰语 / Українська](books/free-programming-books-uk.md)
++ [乌尔都语 / اردو](books/free-programming-books-ur.md)
++ [越南语 / Tiếng Việt](books/free-programming-books-vi.md)
+
+### 速查表
+
++ [所有语言](more/free-programming-cheatsheets.md)
+
+### 免费在线课程
+
++ [阿拉伯语 / al arabiya / العربية](courses/free-courses-ar.md)
++ [孟加拉语 / বাংলা](courses/free-courses-bn.md)
++ [保加利亚语 / български](courses/free-courses-bg.md)
++ [缅甸语 / မြန်မာဘာသာ](courses/free-courses-my.md)
++ [中文](courses/free-courses-zh.md)
++ [英语](courses/free-courses-en.md)
++ [芬兰语 / suomi / suomen kieli](courses/free-courses-fi.md)
++ [法语 / français](courses/free-courses-fr.md)
++ [德语 / Deutsch](courses/free-courses-de.md)
++ [希腊语 / ελληνικά](courses/free-courses-el.md)
++ [希伯来语 / עברית](courses/free-courses-he.md)
++ [印地语 / हिंदी](courses/free-courses-hi.md)
++ [印尼语 / Bahasa Indonesia](courses/free-courses-id.md)
++ [意大利语 / italiano](courses/free-courses-it.md)
++ [日语 / 日本語](courses/free-courses-ja.md)
++ [卡纳达语 / ಕನ್ನಡ](courses/free-courses-kn.md)
++ [哈萨克语 / қазақша](courses/free-courses-kk.md)
++ [高棉语 / ភាសាខ្មែរ](courses/free-courses-km.md)
++ [韩语 / 한국어](courses/free-courses-ko.md)
++ [马拉雅拉姆语 / മലയാളം](courses/free-courses-ml.md)
++ [马拉地语 / मराठी](courses/free-courses-mr.md)
++ [尼泊尔语 / नेपाली](courses/free-courses-ne.md)
++ [挪威语 / Norsk](courses/free-courses-no.md)
++ [波斯语 / Farsi (Iran) / فارسى](courses/free-courses-fa_IR.md)
++ [波兰语 / polski / język polski / polszczyzna](courses/free-courses-pl.md)
++ [葡萄牙语（巴西）](courses/free-courses-pt_BR.md)
++ [葡萄牙语（葡萄牙）](courses/free-courses-pt_PT.md)
++ [旁遮普语 / ਪੰਜਾਬੀ / پنجابی](courses/free-courses-pa.md)
++ [罗马尼亚语 / limba română / român](courses/free-courses-ro.md)
++ [俄语 / Русский язык](courses/free-courses-ru.md)
++ [僧伽罗语 / සිංහල](courses/free-courses-si.md)
++ [西班牙语 / español / castellano](courses/free-courses-es.md)
++ [瑞典语 / svenska](courses/free-courses-sv.md)
++ [泰米尔语 / தமிழ்](courses/free-courses-ta.md)
++ [泰卢固语 / తెలుగు](courses/free-courses-te.md)
++ [泰语 / ภาษาไทย](courses/free-courses-th.md)
++ [土耳其语 / Türkçe](courses/free-courses-tr.md)
++ [乌克兰语 / Українська](courses/free-courses-uk.md)
++ [乌尔都语 / اردو](courses/free-courses-ur.md)
++ [越南语 / Tiếng Việt](courses/free-courses-vi.md)
+
+### 交互式编程资源
+
++ [中文](more/free-programming-interactive-tutorials-zh.md)
++ [英语](more/free-programming-interactive-tutorials-en.md)
++ [德语 / Deutsch](more/free-programming-interactive-tutorials-de.md)
++ [日语 / 日本語](more/free-programming-interactive-tutorials-ja.md)
++ [俄语 / Русский язык](more/free-programming-interactive-tutorials-ru.md)
+
+### 习题集与竞赛编程
+
++ [习题集](more/problem-sets-competitive-programming.md)
+
+### 播客与视频教程
+
+免费播客和视频教程：
+
++ [阿拉伯语 / al Arabiya / العربية](casts/free-podcasts-screencasts-ar.md)
++ [缅甸语 / မြန်မာဘာသာ](casts/free-podcasts-screencasts-my.md)
++ [中文](casts/free-podcasts-screencasts-zh.md)
++ [捷克语 / čeština / český jazyk](casts/free-podcasts-screencasts-cs.md)
++ [荷兰语 / Nederlands](casts/free-podcasts-screencasts-nl.md)
++ [英语](casts/free-podcasts-screencasts-en.md)
++ [芬兰语 / Suomi](casts/free-podcasts-screencasts-fi.md)
++ [法语 / français](casts/free-podcasts-screencasts-fr.md)
++ [德语 / Deutsch](casts/free-podcasts-screencasts-de.md)
++ [希伯来语 / עברית](casts/free-podcasts-screencasts-he.md)
++ [印尼语 / Bahasa Indonesia](casts/free-podcasts-screencasts-id.md)
++ [波斯语 / Farsi (Iran) / فارسى](casts/free-podcasts-screencasts-fa_IR.md)
++ [波兰语 / polski / język polski / polszczyzna](casts/free-podcasts-screencasts-pl.md)
++ [葡萄牙语（巴西）](casts/free-podcasts-screencasts-pt_BR.md)
++ [葡萄牙语（葡萄牙）](casts/free-podcasts-screencasts-pt_PT.md)
++ [俄语 / Русский язык](casts/free-podcasts-screencasts-ru.md)
++ [僧伽罗语 / සිංහල](casts/free-podcasts-screencasts-si.md)
++ [西班牙语 / español / castellano](casts/free-podcasts-screencasts-es.md)
++ [瑞典语 / Svenska](casts/free-podcasts-screencasts-sv.md)
++ [土耳其语 / Türkçe](casts/free-podcasts-screencasts-tr.md)
++ [乌克兰语 / Українська](casts/free-podcasts-screencasts-uk.md)
+
+### 在线编程练习平台
+
+在浏览器中编写、编译和运行代码。试试看！
+
++ [中文](more/free-programming-playgrounds-zh.md)
++ [英语](more/free-programming-playgrounds.md)
++ [德语 / Deutsch](more/free-programming-playgrounds-de.md)
+
+## 翻译
+
+志愿者已将我们的贡献指南、使用指南和行为准则翻译为列表中涵盖的多种语言。
+
++ 英语
+  + [行为准则](docs/CODE_OF_CONDUCT.md)
+  + [贡献指南](docs/CONTRIBUTING.md)
+  + [使用指南](docs/HOWTO.md)
++ ... *[更多语言](docs/README.md#translations)* ...
+
+你可能会注意到[这里还有一些缺失的翻译](docs/README.md#translations) — 也许你愿意[贡献一份翻译](docs/CONTRIBUTING.md#help-out-by-contributing-a-translation)？
+
+## 许可证
+
+本仓库中的所有文件均基于 [CC BY 许可证](LICENSE) 授权。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,233 @@
+# 多語言免費學習資源列表
+
+<div align="center" markdown="1">
+
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)&#160;
+[![授權條款: CC BY 4.0](https://img.shields.io/github/license/EbookFoundation/free-programming-books)](https://creativecommons.org/licenses/by/4.0/)&#160;
+[![Hacktoberfest 2025 統計](https://img.shields.io/github/hacktoberfest/2025/EbookFoundation/free-programming-books?label=Hacktoberfest+2025)](https://github.com/EbookFoundation/free-programming-books/pulls?q=is%3Apr+is%3Amerged+created%3A2025-10-01..2025-10-31)
+
+</div>
+
+在 [https://ebookfoundation.github.io/free-programming-books-search/](https://ebookfoundation.github.io/free-programming-books-search/) 搜尋列表 [![https://ebookfoundation.github.io/free-programming-books-search/](https://img.shields.io/website?style=flat&logo=www&logoColor=whitesmoke&label=動態搜尋站點&down_color=red&down_message=down&up_color=green&up_message=up&url=https%3A%2F%2Febookfoundation.github.io%2Ffree-programming-books-search%2F)](https://ebookfoundation.github.io/free-programming-books-search/)。
+
+本頁面也提供易於閱讀的網站版本。點擊存取 [![https://ebookfoundation.github.io/free-programming-books/](https://img.shields.io/website?style=flat&logo=www&logoColor=whitesmoke&label=靜態站點&down_color=red&down_message=down&up_color=green&up_message=up&url=https%3A%2F%2Febookfoundation.github.io%2Ffree-programming-books%2F)](https://ebookfoundation.github.io/free-programming-books/)。
+
+<div align="center">
+  <form action="https://ebookfoundation.github.io/free-programming-books-search">
+    <input type="text" id="fpbSearch" name="search" required placeholder="搜尋書籍或作者"/>
+    <label for="submit"> </label>
+    <input type="submit" id="submit" name="submit" value="搜尋" />
+  </form>
+</div>
+
+## 簡介
+
+本列表最初複製自 [StackOverflow - 免費程式設計書籍列表](https://web.archive.org/web/20140606191453/http://stackoverflow.com/questions/194812/list-of-freely-available-programming-books/392926)，並得到了 Karan Bhangui 和 George Stocker 的貢獻。
+
+該列表由 Victor Felder 遷移至 GitHub 以便協作更新和維護。如今已發展為 [GitHub 最受歡迎的倉庫之一](https://octoverse.github.com/)。
+
+<div align="center" markdown="1">
+
+[![GitHub 倉庫 Forks](https://img.shields.io/github/forks/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=Forks)](https://github.com/EbookFoundation/free-programming-books/network)&#160;
+[![GitHub 倉庫 Stars](https://img.shields.io/github/stars/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=Stars)](https://github.com/EbookFoundation/free-programming-books/stargazers)&#160;
+[![GitHub 倉庫貢獻者](https://img.shields.io/github/contributors-anon/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=貢獻者)](https://github.com/EbookFoundation/free-programming-books/graphs/contributors)    
+[![GitHub 組織贊助者](https://img.shields.io/github/sponsors/EbookFoundation?style=flat&logo=github&logoColor=whitesmoke&label=贊助者)](https://github.com/sponsors/EbookFoundation)&#160;
+[![GitHub 倉庫 Watchers](https://img.shields.io/github/watchers/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=Watchers)](https://github.com/EbookFoundation/free-programming-books/watchers)&#160;
+[![GitHub 倉庫大小](https://img.shields.io/github/repo-size/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=whitesmoke&label=倉庫大小)](https://github.com/EbookFoundation/free-programming-books/archive/refs/heads/main.zip)
+
+</div>
+
+[Free Ebook Foundation](https://ebookfoundation.org) 現在管理該倉庫，這是一個致力於促進免費電子書的建立、分發、歸檔和永續發展的非營利組織。對 Free Ebook Foundation 的[捐贈](https://ebookfoundation.org/contributions.html)在美國可享受稅收減免。
+
+## 如何貢獻
+
+請閱讀 [CONTRIBUTING](docs/CONTRIBUTING.md)。如果你是 GitHub 新手，請[歡迎](docs/HOWTO.md)！請記住遵守我們改編自 ![貢獻者公約 1.3](https://img.shields.io/badge/Contributor%20Covenant-1.3-4baaaa.svg) 的[行為準則](docs/CODE_OF_CONDUCT.md)（也提供[翻譯版本](#translations)）。
+
+點擊以下徽章了解你可以如何提供幫助：
+
+<div align="center" markdown="1">
+
+[![GitHub 倉庫 Issues](https://img.shields.io/github/issues/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/EbookFoundation/free-programming-books/issues)&#160;
+[![GitHub 倉庫新手友善 Issues](https://img.shields.io/github/issues/EbookFoundation/free-programming-books/good%20first%20issue?style=flat&logo=github&logoColor=green&label=新手友善%20Issues)](https://github.com/EbookFoundation/free-programming-books/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)&#160;
+[![GitHub 需要幫助的 Issues](https://img.shields.io/github/issues/EbookFoundation/free-programming-books/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22需要幫助%22%20Issues)](https://github.com/EbookFoundation/free-programming-books/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)    
+[![GitHub 倉庫 PRs](https://img.shields.io/github/issues-pr/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=orange&label=PRs)](https://github.com/EbookFoundation/free-programming-books/pulls)&#160;
+[![GitHub 倉庫已合併 PRs](https://img.shields.io/github/issues-search/EbookFoundation/free-programming-books?style=flat&logo=github&logoColor=green&label=已合併%20PRs&query=is%3Amerged)](https://github.com/EbookFoundation/free-programming-books/pulls?q=is%3Apr+is%3Amerged)&#160;
+[![GitHub 需要幫助的 PRs](https://img.shields.io/github/issues-pr/EbookFoundation/free-programming-books/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22需要幫助%22%20PRs)](https://github.com/EbookFoundation/free-programming-books/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+
+</div>
+
+## 如何分享
+
+<div align="left" markdown="1">
+<a href="https://www.facebook.com/share.php?u=https%3A%2F%2Fgithub.com%2FEbookFoundation%2Ffree-programming-books&p[images][0]=&p[title]=Free%20Programming%20Books&p[summary]=">在 Facebook 上分享</a><br>
+<a href="https://www.linkedin.com/shareArticle?mini=true&url=https://github.com/EbookFoundation/free-programming-books&title=Free%20Programming%20Books&summary=&source=">在 LinkedIn 上分享</a><br>
+<a href="https://toot.kytta.dev/?text=https://github.com/EbookFoundation/free-programming-books">在 Mastodon/Fediverse 上分享</a><br>    
+<a href="https://t.me/share/url?url=https://github.com/EbookFoundation/free-programming-books">在 Telegram 上分享</a><br>
+<a href="https://twitter.com/intent/tweet?text=https://github.com/EbookFoundation/free-programming-books%0AFree%20Programming%20Books">在 𝕏 (Twitter) 上分享</a><br>
+</div>
+
+## 資源
+
+本專案按類別列出書籍和其他資源：
+
+### 書籍
+
+[英語，按程式設計語言分類](books/free-programming-books-langs.md)
+
+[英語，按主題分類](books/free-programming-books-subjects.md)
+
+#### 其他語言
+
++ [阿拉伯語 / al arabiya / العربية](books/free-programming-books-ar.md)
++ [亞美尼亞語 / Հայերեն](books/free-programming-books-hy.md)
++ [亞塞拜然語 / Азәрбајҹан дили / آذربايجانجا ديلي](books/free-programming-books-az.md)
++ [孟加拉語 / বাংলা](books/free-programming-books-bn.md)
++ [保加利亞語 / български](books/free-programming-books-bg.md)
++ [緬甸語 / မြန်မာဘာသာ](books/free-programming-books-my.md)
++ [中文](books/free-programming-books-zh.md)
++ [捷克語 / čeština / český jazyk](books/free-programming-books-cs.md)
++ [加泰隆尼亞語 / catalan / català](books/free-programming-books-ca.md)
++ [丹麥語 / dansk](books/free-programming-books-da.md)
++ [荷蘭語 / Nederlands](books/free-programming-books-nl.md)
++ [愛沙尼亞語 / eesti keel](books/free-programming-books-et.md)
++ [芬蘭語 / suomi / suomen kieli](books/free-programming-books-fi.md)
++ [法語 / français](books/free-programming-books-fr.md)
++ [德語 / Deutsch](books/free-programming-books-de.md)
++ [希臘語 / ελληνικά](books/free-programming-books-el.md)
++ [希伯來語 / עברית](books/free-programming-books-he.md)
++ [印地語 / हिन्दी](books/free-programming-books-hi.md)
++ [匈牙利語 / magyar / magyar nyelv](books/free-programming-books-hu.md)
++ [印尼語 / Bahasa Indonesia](books/free-programming-books-id.md)
++ [義大利語 / italiano](books/free-programming-books-it.md)
++ [日語 / 日本語](books/free-programming-books-ja.md)
++ [韓語 / 한국어](books/free-programming-books-ko.md)
++ [拉脫維亞語 / Latviešu](books/free-programming-books-lv.md)
++ [馬拉雅拉姆語 / മലയാളം](books/free-programming-books-ml.md)
++ [挪威語 / Norsk](books/free-programming-books-no.md)
++ [波斯語 / Farsi (Iran) / فارسى](books/free-programming-books-fa_IR.md)
++ [波蘭語 / polski / język polski / polszczyzna](books/free-programming-books-pl.md)
++ [葡萄牙語（巴西）](books/free-programming-books-pt_BR.md)
++ [葡萄牙語（葡萄牙）](books/free-programming-books-pt_PT.md)
++ [羅馬尼亞語 / limba română / român](books/free-programming-books-ro.md)
++ [俄語 / Русский язык](books/free-programming-books-ru.md)
++ [塞爾維亞語 / српски језик / srpski jezik](books/free-programming-books-sr.md)
++ [斯洛伐克語 / slovenčina](books/free-programming-books-sk.md)
++ [斯洛維尼亞語 / Slovenščina](books/free-programming-books-sl.md)
++ [西班牙語 / español / castellano](books/free-programming-books-es.md)
++ [瑞典語 / Svenska](books/free-programming-books-sv.md)
++ [泰米爾語 / தமிழ்](books/free-programming-books-ta.md)
++ [泰盧固語 / తెలుగు](books/free-programming-books-te.md)
++ [泰語 / ไทย](books/free-programming-books-th.md)
++ [土耳其語 / Türkçe](books/free-programming-books-tr.md)
++ [烏克蘭語 / Українська](books/free-programming-books-uk.md)
++ [烏爾都語 / اردو](books/free-programming-books-ur.md)
++ [越南語 / Tiếng Việt](books/free-programming-books-vi.md)
+
+### 速查表
+
++ [所有語言](more/free-programming-cheatsheets.md)
+
+### 免費線上課程
+
++ [阿拉伯語 / al arabiya / العربية](courses/free-courses-ar.md)
++ [孟加拉語 / বাংলা](courses/free-courses-bn.md)
++ [保加利亞語 / български](courses/free-courses-bg.md)
++ [緬甸語 / မြန်မာဘာသာ](courses/free-courses-my.md)
++ [中文](courses/free-courses-zh.md)
++ [英語](courses/free-courses-en.md)
++ [芬蘭語 / suomi / suomen kieli](courses/free-courses-fi.md)
++ [法語 / français](courses/free-courses-fr.md)
++ [德語 / Deutsch](courses/free-courses-de.md)
++ [希臘語 / ελληνικά](courses/free-courses-el.md)
++ [希伯來語 / עברית](courses/free-courses-he.md)
++ [印地語 / हिंदी](courses/free-courses-hi.md)
++ [印尼語 / Bahasa Indonesia](courses/free-courses-id.md)
++ [義大利語 / italiano](courses/free-courses-it.md)
++ [日語 / 日本語](courses/free-courses-ja.md)
++ [卡納達語 / ಕನ್ನಡ](courses/free-courses-kn.md)
++ [哈薩克語 / қазақша](courses/free-courses-kk.md)
++ [高棉語 / ភាសាខ្មែរ](courses/free-courses-km.md)
++ [韓語 / 한국어](courses/free-courses-ko.md)
++ [馬拉雅拉姆語 / മലയാളം](courses/free-courses-ml.md)
++ [馬拉地語 / मराठी](courses/free-courses-mr.md)
++ [尼泊爾語 / नेपाली](courses/free-courses-ne.md)
++ [挪威語 / Norsk](courses/free-courses-no.md)
++ [波斯語 / Farsi (Iran) / فارسى](courses/free-courses-fa_IR.md)
++ [波蘭語 / polski / język polski / polszczyzna](courses/free-courses-pl.md)
++ [葡萄牙語（巴西）](courses/free-courses-pt_BR.md)
++ [葡萄牙語（葡萄牙）](courses/free-courses-pt_PT.md)
++ [旁遮普語 / ਪੰਜਾਬੀ / پنجابی](courses/free-courses-pa.md)
++ [羅馬尼亞語 / limba română / român](courses/free-courses-ro.md)
++ [俄語 / Русский язык](courses/free-courses-ru.md)
++ [僧伽羅語 / සිංහල](courses/free-courses-si.md)
++ [西班牙語 / español / castellano](courses/free-courses-es.md)
++ [瑞典語 / svenska](courses/free-courses-sv.md)
++ [泰米爾語 / தமிழ்](courses/free-courses-ta.md)
++ [泰盧固語 / తెలుగు](courses/free-courses-te.md)
++ [泰語 / ภาษาไทย](courses/free-courses-th.md)
++ [土耳其語 / Türkçe](courses/free-courses-tr.md)
++ [烏克蘭語 / Українська](courses/free-courses-uk.md)
++ [烏爾都語 / اردو](courses/free-courses-ur.md)
++ [越南語 / Tiếng Việt](courses/free-courses-vi.md)
+
+### 互動式程式設計資源
+
++ [中文](more/free-programming-interactive-tutorials-zh.md)
++ [英語](more/free-programming-interactive-tutorials-en.md)
++ [德語 / Deutsch](more/free-programming-interactive-tutorials-de.md)
++ [日語 / 日本語](more/free-programming-interactive-tutorials-ja.md)
++ [俄語 / Русский язык](more/free-programming-interactive-tutorials-ru.md)
+
+### 習題集與競賽程式設計
+
++ [習題集](more/problem-sets-competitive-programming.md)
+
+### 播客與影片教學
+
+免費播客和影片教學：
+
++ [阿拉伯語 / al Arabiya / العربية](casts/free-podcasts-screencasts-ar.md)
++ [緬甸語 / မြန်မာဘာသာ](casts/free-podcasts-screencasts-my.md)
++ [中文](casts/free-podcasts-screencasts-zh.md)
++ [捷克語 / čeština / český jazyk](casts/free-podcasts-screencasts-cs.md)
++ [荷蘭語 / Nederlands](casts/free-podcasts-screencasts-nl.md)
++ [英語](casts/free-podcasts-screencasts-en.md)
++ [芬蘭語 / Suomi](casts/free-podcasts-screencasts-fi.md)
++ [法語 / français](casts/free-podcasts-screencasts-fr.md)
++ [德語 / Deutsch](casts/free-podcasts-screencasts-de.md)
++ [希伯來語 / עברית](casts/free-podcasts-screencasts-he.md)
++ [印尼語 / Bahasa Indonesia](casts/free-podcasts-screencasts-id.md)
++ [波斯語 / Farsi (Iran) / فارسى](casts/free-podcasts-screencasts-fa_IR.md)
++ [波蘭語 / polski / język polski / polszczyzna](casts/free-podcasts-screencasts-pl.md)
++ [葡萄牙語（巴西）](casts/free-podcasts-screencasts-pt_BR.md)
++ [葡萄牙語（葡萄牙）](casts/free-podcasts-screencasts-pt_PT.md)
++ [俄語 / Русский язык](casts/free-podcasts-screencasts-ru.md)
++ [僧伽羅語 / සිංහල](casts/free-podcasts-screencasts-si.md)
++ [西班牙語 / español / castellano](casts/free-podcasts-screencasts-es.md)
++ [瑞典語 / Svenska](casts/free-podcasts-screencasts-sv.md)
++ [土耳其語 / Türkçe](casts/free-podcasts-screencasts-tr.md)
++ [烏克蘭語 / Українська](casts/free-podcasts-screencasts-uk.md)
+
+### 線上程式設計練習平台
+
+在瀏覽器中編寫、編譯和執行程式碼。試試看！
+
++ [中文](more/free-programming-playgrounds-zh.md)
++ [英語](more/free-programming-playgrounds.md)
++ [德語 / Deutsch](more/free-programming-playgrounds-de.md)
+
+## 翻譯
+
+志願者已將我們的貢獻指南、使用指南和行為準則翻譯為列表中涵蓋的多種語言。
+
++ 英語
+  + [行為準則](docs/CODE_OF_CONDUCT.md)
+  + [貢獻指南](docs/CONTRIBUTING.md)
+  + [使用指南](docs/HOWTO.md)
++ ... *[更多語言](docs/README.md#translations)* ...
+
+你可能會注意到[這裡還有一些缺失的翻譯](docs/README.md#translations) — 也許你願意[貢獻一份翻譯](docs/CONTRIBUTING.md#help-out-by-contributing-a-translation)？
+
+## 授權條款
+
+本倉庫中的所有檔案均基於 [CC BY 授權條款](LICENSE) 授權。


### PR DESCRIPTION
## Summary

This PR adds Simplified Chinese (`README.zh-CN.md`) and Traditional Chinese (`README.zh-TW.md`) translations of the README. The project already has extensive Chinese-language content (books, courses, podcasts, playgrounds) but the main README was only available in English.

## Changes

- Added `README.zh-CN.md` — full Simplified Chinese translation
- Added `README.zh-TW.md` — full Traditional Chinese translation (Taiwan locale)

All links, badges, HTML forms, and markdown formatting are preserved. No content changes — only translation of the prose sections.