### PR TITLE
Update redirected interactive tutorial links

### DIFF
--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -182,7 +182,7 @@
 * [Learn Go Full Course](https://www.boot.dev/courses/learn-golang) - Boot.dev
 * [Start using Go](https://docs.microsoft.com/en-us/learn/paths/go-first-steps/) - Microsoft
 * [TCP Servers in Go](https://app.codecrafters.io/concepts/go-tcp-server) - CodeCrafters
-* [The Go Tutorial](http://tour.golang.org)
+* [The Go Tutorial](https://go.dev/tour/)
 
 
 ### GraphQL
@@ -250,7 +250,7 @@
 * [JavaScript Tutorial](https://www.w3schools.com/js) - W3Schools
 * [JavaScript Tutorial](https://www.scaler.com/topics/javascript/) - Scaler Topics
 * [JavaScript Tutorial and Overview](https://www.afterhoursprogramming.com/tutorial/javascript/) - After Hours Programming
-* [Javascripting](https://github.com/sethvincent/javascripting)
+* [Javascripting](https://github.com/workshopper/javascripting)
 * [JSchallenger](https://www.jschallenger.com)
 * [Learn JavaScript](http://www.learn-js.org)
 * [Learn JavaScript](https://learnjavascript.online)
@@ -295,7 +295,7 @@
 
 #### Svelte
 
-* [Interactive Svelte Tutorial](https://learn.svelte.dev/tutorial/welcome-to-svelte) - svelte.dev
+* [Interactive Svelte Tutorial](https://svelte.dev/tutorial/svelte/welcome-to-svelte) - svelte.dev
 
 
 ### Kotlin


### PR DESCRIPTION
## Summary
- Update The Go Tutorial to the current `go.dev/tour/` URL
- Update Javascripting to the canonical `workshopper/javascripting` repository
- Update the Svelte tutorial to the current `svelte.dev` tutorial URL

## Verification
- `git diff --check`
- `npx -y free-programming-books-lint more`
- Confirmed the three updated URLs return `200` directly
- Confirmed the previous URLs redirect to the updated destinations