### PR TITLE
docs: fix translations anchor links

### DIFF
--- a/docs/CODE_OF_CONDUCT-fil.md
+++ b/docs/CODE_OF_CONDUCT-fil.md
@@ -47,4 +47,4 @@ version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/
 
 [homepage]: https://contributor-covenant.org
 
-[Translations](README.md#nslations)
+[Translations](README.md#translations)

--- a/docs/CODE_OF_CONDUCT-id.md
+++ b/docs/CODE_OF_CONDUCT-id.md
@@ -45,4 +45,4 @@ versi 1.3.0, avaible at https://contributor-covenant.org/version/1/3/0/
 
 [homepage]: https://contributor-covenant.org
 
-[Terjemahan](README.md#nslations)
+[Terjemahan](README.md#translations)

--- a/docs/CODE_OF_CONDUCT-uk.md
+++ b/docs/CODE_OF_CONDUCT-uk.md
@@ -41,4 +41,4 @@ version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/
 
 [homepage]: https://contributor-covenant.org
 
-[Translations](README.md#nslations)
+[Translations](README.md#translations)

--- a/docs/CONTRIBUTING-zh.md
+++ b/docs/CONTRIBUTING-zh.md
@@ -1,4 +1,4 @@
-*[阅读本文的其他语言版本](README.md#nslations)*
+*[阅读本文的其他语言版本](README.md#translations)*
 
 
 ## 贡献者许可协议
@@ -8,7 +8,7 @@
 
 ## 贡献者行为准则
 
-请同意并遵循此[行为准则](CODE_OF_CONDUCT.md)参与贡献。([translations](README.md#nslations))
+请同意并遵循此[行为准则](CODE_OF_CONDUCT.md)参与贡献。([translations](README.md#translations))
 
 
 ## 概要

--- a/docs/CONTRIBUTING-zh_TW.md
+++ b/docs/CONTRIBUTING-zh_TW.md
@@ -1,4 +1,4 @@
-*[閱讀其他語言版本的文件](README.md#nslations)*
+*[閱讀其他語言版本的文件](README.md#translations)*
 
 
 ## 貢獻者許可協議
@@ -8,7 +8,7 @@
 
 ## 貢獻者行為準則
 
-請同意並遵循此 [行為準則](CODE_OF_CONDUCT.md) 參與貢獻。([translations](README.md#nslations))
+請同意並遵循此 [行為準則](CODE_OF_CONDUCT.md) 參與貢獻。([translations](README.md#translations))
 
 
 ## 概要


### PR DESCRIPTION
## What does this PR do?
Improve repo

Fixes broken `README.md#nslations` anchors in translated docs by pointing them to the existing `README.md#translations` heading.

Fixes #13294.

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] This is not a revision of a previously submitted PR.

## For resources
N/A - this PR does not add, remove, or modify resource listings.

## Why is this valuable?
The affected translated Code of Conduct and contributing docs currently link to a non-existent `#nslations` anchor. This keeps the language-switch links consistent with the existing `## Translations` section in `docs/README.md`.

## Verification
- Searched for `README.md#nslations` after the change and confirmed no matches remain in the updated docs.
- Confirmed `docs/README.md` contains `## Translations`, which maps to `#translations`.