### PR TITLE
Add Korean Linux command line book

### DIFF
--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -138,6 +138,7 @@
 
 ### Linux
 
+* [리눅스 커맨드라인 (제5판 인터넷 에디션)](https://wikidocs.net/book/11259) - William Shotts, `trl.:` 브리티쉬 (HTML) (CC BY-NC-ND)
 * [리눅스 서버를 다루는 기술](https://web.archive.org/web/20220107111504/https://thebook.io/006718/) *( :card_file_box: archived)*
 * [GNOME 배우기](https://sites.google.com/site/gnomekr/home/learning_gnome)
 

--- a/books/free-programming-books-ko.md
+++ b/books/free-programming-books-ko.md
@@ -138,8 +138,8 @@
 
 ### Linux
 
-* [리눅스 커맨드라인 (제5판 인터넷 에디션)](https://wikidocs.net/book/11259) - William Shotts, `trl.:` 브리티쉬 (HTML) (CC BY-NC-ND)
 * [리눅스 서버를 다루는 기술](https://web.archive.org/web/20220107111504/https://thebook.io/006718/) *( :card_file_box: archived)*
+* [리눅스 커맨드라인 (제5판 인터넷 에디션)](https://wikidocs.net/book/11259) - William Shotts, `trl.:` 브리티쉬 (HTML) (CC BY-NC-ND)
 * [GNOME 배우기](https://sites.google.com/site/gnomekr/home/learning_gnome)
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a Korean HTML resource for Linux command-line learning to books/free-programming-books-ko.md.

## Resource checks

- Free to read at WikiDocs: https://wikidocs.net/book/11259
- Author/translator shown on the resource page: William Shotts, translator: 브리티쉬
- License shown on the resource page: CC BY-NC-ND 3.0
- Not already listed in the Korean Linux section
- git diff --check passes locally

## Notes

The resource page states that it covers the same material as LinuxCommand.org in more detail and is available as a WikiDocs HTML book.