### PR TITLE
Fix 2 dead links

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -828,8 +828,8 @@ Kerridge (PDF) (email address *requested*, not required)
 ### Professional Development
 
 * [Clean Code Developer: An initiative for more professionalism in software development](https://www.gitbook.com/book/ccd_school/clean-code-developer-com/details) *( :construction: in process)*
-* [Confessions of an IT Manager](https://www.red-gate.com/library/confessions-of-an-it-manager) - Phil Factor (PDF)
-* [Don't Just Roll the Dice](https://www.red-gate.com/library/dont-just-roll-the-dice) - Neil Davidson (PDF)
+* [Confessions of an IT Manager](https://assets.red-gate.com/community/books/confessions-of-an-it-manager-ebook.pdf) - Phil Factor (PDF)
+* [Don't Just Roll the Dice](https://assets.red-gate.com/community/books/DJRTD_eBook.pdf) - Neil Davidson (PDF)
 * [How to Do What You Love & Earn What You’re Worth as a Programmer](https://leanpub.com/dowhatyoulove/read) - Reginald Braithwaite
 * [How to Learn to Code & Get a Developer Job in 2023](https://www.freecodecamp.org/news/learn-to-code-book) - Quincy Larson
 * [How to Stand Out as a Software Engineer](https://github.com/lvndry/how-to-stand-out-as-a-software-engineer/blob/main/how_to_stand_out_as_a_software_engineer.pdf) - Landry Monga (PDF)


### PR DESCRIPTION
## What does this PR do?
Fixed Link

## IMPORTANT
- [X] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [X] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description

2 small updates:
1. Confessions of an IT Manager: Old link (`https://www.red-gate.com/library/confessions-of-an-it-manager`) was 404. The correct link is: https://assets.red-gate.com/community/books/confessions-of-an-it-manager-ebook.pdf
2. Don't Just Roll the Dice: Same thing, `https://www.red-gate.com/library/dont-just-roll-the-dice` is 404, and have updated it to the working url at `https://assets.red-gate.com/community/books/DJRTD_eBook.pdf`.

I've confirmed with the wayback machine and checksums that both resources are exactly the same since the link fix. 

### Why is this valuable (or not)?
N/A

### How do we know it's really free?
N/A

### For book lists, is it a book? For course lists, is it a course? etc.
N/A

## Checklist:
- [X] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [X] Include author(s) and platform where appropriate.
- [X] Put lists in alphabetical order, correct spacing.
- [X] Add needed indications (PDF, access notes, under construction).
- [X] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
