### PR TITLE
docs: update course links to HTTPS

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -138,7 +138,7 @@
 * [LabEx](https://labex.io)
 * [Learning SAP](https://learning.sap.com)
 * [LearnWeb3 DAO \| Become a Web3 Developer for Free](https://learnweb3.io)
-* [MIT OCW](http://ocw.mit.edu)
+* [MIT OCW](https://ocw.mit.edu)
 * [MOOC.fi](https://www.mooc.fi/en/)
 * [NPTEL](https://onlinecourses.nptel.ac.in)
 * [openHPI](https://open.hpi.de)
@@ -684,7 +684,7 @@
 * [NYU Deep Learning SP21](https://www.youtube.com/playlist?list=PLLHTzKZzVU9e6xUfG10TkTWApKSZCzuBI) - Alfredo Canziani
 * [NYU Deep Learning SP22](https://www.youtube.com/playlist?list=PLLHTzKZzVU9f3kmEta5dlkMXgtD1LxHzT) - Alfredo Canziani
 * [OpenCV Bootcamp](https://opencv.org/university/free-opencv-course/) - OpenCV University
-* [Practical Deep Learning For Coders taught](http://www.fast.ai) - Jeremy Howard
+* [Practical Deep Learning For Coders taught](https://www.fast.ai) - Jeremy Howard
 * [Practical Deep Learning for Coders, v3 (using fastai library)](https://course.fast.ai)
 * [PyTorch Bootcamp](https://opencv.org/university/free-pytorch-course/) - OpenCV University
 * [Recurrent Neural Network](https://www.youtube.com/playlist?list=PLuhqtP7jdD8ARBnzj8SZwNFhwWT89fAFr) - Coding Lane
@@ -1938,7 +1938,7 @@
 * [Python Web Scraping & Crawling using Scrapy](https://www.youtube.com/playlist?list=PLhTjy8cBISEqkN-5Ku_kXG4QW33sxQo0t)
 * [React Fundamentals - The Complete Guide For Beginners](https://www.udemy.com/course/react-fundamentals-the-complete-guide-for-beginners/) - Kerim Abdelmouiz (Udemy)
 * [The GraphQL Apollo (with ReactJS, NodeJS and MongoDB)](https://www.udemy.com/course/the-new-graphql-apollo-course-2020) - Mohd. Raqif Warsi (Udemy)
-* [The Odin Project - Learn Web Development for Free](http://www.theodinproject.com)
+* [The Odin Project - Learn Web Development for Free](https://www.theodinproject.com)
 * [Web Accessibility – What It Is and How to Design for It?](https://www.hostinger.in/tutorials/web-accessibility) - Hostinger Tutorials
 * [Web Basics](https://open.cs.uwaterloo.ca/web-basics/) - Centre for Education in Math and Computing (University of Waterloo)
 * [Web Development Course](https://syllabus.migracode.org/courses/introduction-3) - MigraCode Barcelona
@@ -1985,4 +1985,3 @@
 ### YAML
 
 * [Complete YAML Course - Beginner to Advanced for DevOps and more!](https://www.youtube.com/watch?v=IA90BTozdow) - Kunal Kushwaha
-


### PR DESCRIPTION
## What does this PR do?
Improve repo

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] This is not a revision of a previously submitted PR.

## Description
Updates three course links in the English courses list from HTTP to HTTPS:
- MIT OCW
- Practical Deep Learning For Coders taught
- The Odin Project - Learn Web Development for Free

This follows the contributing guideline to prefer HTTPS links when the same domain serves the same content.

## Verification
- curl -I -L confirmed the HTTPS URLs are reachable
- git diff --check