### PR TITLE
docs: fix Emmet PDF link formatting

### DIFF
--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -300,7 +300,7 @@
 * [CSS Grid Cheatsheet](https://css-tricks.com/snippets/css/complete-guide-grid/) - Chris House (HTML)
 * [FLEX: A simple visual cheatsheet for flexbox](https://flexbox.malven.co) - Chris Malven (HTML)
 * [GRID: A simple visual cheatsheet for CSS Grid Layout](https://grid.malven.co) - Chris Malven (HTML)
-* [HTML & CSS Emmet Cheat Sheet](https://docs.emmet.io/cheat-sheet/) - Emmet Documentation (HTML, [PDF]( https://docs.emmet.io/cheatsheet-a5.pdf))
+* [HTML & CSS Emmet Cheat Sheet](https://docs.emmet.io/cheat-sheet/) - Emmet Documentation (HTML, [PDF](https://docs.emmet.io/cheatsheet-a5.pdf))
 * [HTML 5 - The Mega CheatSheet](https://makeawebsitehub.com/wp-content/uploads/2015/06/HTML5-Mega-Cheat-Sheet-A4-Print-ready.pdf) - Jamie Spencer (PDF)
 * [HTML CheatSheet](https://htmlcheatsheet.com) - htmlcheatsheet.com (HTML, [PDF](https://htmlcheatsheet.com/HTML-Cheat-Sheet.pdf))
 * [HTML Cheatsheet](https://www.codewithharry.com/blogpost/html-cheatsheet/) - CodeWithHarry (HTML)


### PR DESCRIPTION
## What does this PR do?
Improve repo

## IMPORTANT
- [x] Read our contributing guidelines.
- [x] This is not a revision of a previously submitted PR.

## Description
Fixes a Markdown formatting issue in the HTML & CSS Emmet Cheat Sheet entry by removing the stray space before the PDF URL.

## Checklist:
- [x] Put lists in alphabetical order, correct spacing.
- [x] Used an informative name for this pull request.

## Verification
- Verified the PDF URL resolves successfully with `curl -I -L`.
- Ran `git diff --check`.