### PR TITLE
Fix double-word typo in free-programming-books-langs.md

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -2,7 +2,7 @@
 
 Originally, this list included a section called "Language Agnostic" for books about programming subjects not restricted to a specific programming language.
 That section got so big, we decided to split it into its own file, the [BY SUBJECT file](free-programming-books-subjects.md).
-Books on general-purpose programming that don't focus on a specific language are in listed in the subject "Programming". Books on specialized topics are listed in their own sub-sections.
+Books on general-purpose programming that don't focus on a specific language are listed in the subject "Programming". Books on specialized topics are listed in their own sub-sections.
 
 
 ### Index


### PR DESCRIPTION
Removes duplicate word 'in' on line 5: 'are in listed in' -> 'are listed in'.