### PR TITLE
replace outdated pdf course with newer Java course

### DIFF
--- a/books/free-programming-books-pl.md
+++ b/books/free-programming-books-pl.md
@@ -109,7 +109,7 @@
 ### Java
 
 * [Darmowy kurs Java](https://javastart.pl/baza-wiedzy/darmowy-kurs-java) - Sławek Ludwiczak
-* [Kurs Java](https://kursjava.com) - Przemysław Kruglej(2019-2023)
+* [Język Java](http://www.dz5.pl/ti/java/java_skladnia.pdf) - Jacek Rumiński (PDF)
 * [Kurs Java](https://stormit.pl/kurs-java/) - Tomasz Woliński
 * [Kurs programowania Java](http://www.samouczekprogramisty.pl/kurs-programowania-java/) - Marcin Pietraszek
 * [Praktyczny kurs Javy](https://kobietydokodu.pl/kurs-javy/) - Jakub Derda

--- a/books/free-programming-books-pl.md
+++ b/books/free-programming-books-pl.md
@@ -109,7 +109,7 @@
 ### Java
 
 * [Darmowy kurs Java](https://javastart.pl/baza-wiedzy/darmowy-kurs-java) - Sławek Ludwiczak
-* [Kurs Java](https://kursjava.com) - Przemysław Kruglej (2019-2023 Przemysław Kruglej)
+* [Kurs Java](https://kursjava.com) - Przemysław Kruglej(2019-2023)
 * [Kurs Java](https://stormit.pl/kurs-java/) - Tomasz Woliński
 * [Kurs programowania Java](http://www.samouczekprogramisty.pl/kurs-programowania-java/) - Marcin Pietraszek
 * [Praktyczny kurs Javy](https://kobietydokodu.pl/kurs-javy/) - Jakub Derda

--- a/books/free-programming-books-pl.md
+++ b/books/free-programming-books-pl.md
@@ -109,7 +109,7 @@
 ### Java
 
 * [Darmowy kurs Java](https://javastart.pl/baza-wiedzy/darmowy-kurs-java) - Sławek Ludwiczak
-* [Język Java](http://www.dz5.pl/ti/java/java_skladnia.pdf) - Jacek Rumiński (PDF)
+* [Kurs Java](https://kursjava.com) - Przemysław Kruglej (2019-2023 Przemysław Kruglej)
 * [Kurs Java](https://stormit.pl/kurs-java/) - Tomasz Woliński
 * [Kurs programowania Java](http://www.samouczekprogramisty.pl/kurs-programowania-java/) - Marcin Pietraszek
 * [Praktyczny kurs Javy](https://kobietydokodu.pl/kurs-javy/) - Jakub Derda

--- a/courses/free-courses-pl.md
+++ b/courses/free-courses-pl.md
@@ -77,13 +77,12 @@
 * [Darmowe kursy z Javy dla początkujących](https://web.archive.org/web/20220326010054/http://programowaniejava.pl/edukacja/darmowe-szkolenia.html) *( :card_file_box: archived)*
 * [JAVA FX-wprowadzenie](https://www.youtube.com/playlist?list=PL-ikpm9wGd1HkA9PvGTYWZHtO-Xq_i_Mw)
 * [Java GUI: programowanie Graficznego Interfejsu Użytkownika](https://www.youtube.com/playlist?list=PL3298E3EB8CFDE9BA)
+* [Kurs Java](https://kursjava.com) - Przemysław Kruglej (2019-2023)
 * [Kurs Java od podstaw (2023)](https://www.youtube.com/playlist?list=PLj-pbEqbjo6A7edIf1EWfhZ4prfYPJpTq) - Zaprogramuj Życie
 * [Kurs Java od podstaw (2024)](https://www.youtube.com/playlist?list=PLp9WLfHXxbccTjbdEqf79zE5eJ9n6aaPW) - Jak nauczyć się programowania
 * [Kurs JavaFX od podstaw](https://www.youtube.com/playlist?list=PLpzwMkmxJDUwQuQR7Rezut5UE_8UGDxkU)
-* [Kurs Java](https://kursjava.com) - Przemysław Kruglej (2019-2023)
 * [Kurs programowania Java](https://www.youtube.com/playlist?list=PLED70A92187B1406A)
 * [Kurs programowania w Javie od podstaw](https://programovanie.pl) - Michał Łoza (email address *requested*, not required)
-
 
 ### JavaScript
 

--- a/courses/free-courses-pl.md
+++ b/courses/free-courses-pl.md
@@ -84,6 +84,7 @@
 * [Kurs programowania Java](https://www.youtube.com/playlist?list=PLED70A92187B1406A)
 * [Kurs programowania w Javie od podstaw](https://programovanie.pl) - Michał Łoza (email address *requested*, not required)
 
+
 ### JavaScript
 
 * [Kurs Javascript: Moduł 1: Poczatkujacy](https://youtube.com/playlist?list=PLaRAejmsc8gGAs-Ml8aa4eLCkm6ESvdnN) - Kacper Szarkiewicz

--- a/courses/free-courses-pl.md
+++ b/courses/free-courses-pl.md
@@ -77,7 +77,7 @@
 * [Darmowe kursy z Javy dla początkujących](https://web.archive.org/web/20220326010054/http://programowaniejava.pl/edukacja/darmowe-szkolenia.html) *( :card_file_box: archived)*
 * [JAVA FX-wprowadzenie](https://www.youtube.com/playlist?list=PL-ikpm9wGd1HkA9PvGTYWZHtO-Xq_i_Mw)
 * [Java GUI: programowanie Graficznego Interfejsu Użytkownika](https://www.youtube.com/playlist?list=PL3298E3EB8CFDE9BA)
-* [Kurs Java](https://kursjava.com) - Przemysław Kruglej (2019-2023)
+* [Kurs Java](https://kursjava.com) - Przemysław Kruglej
 * [Kurs Java od podstaw (2023)](https://www.youtube.com/playlist?list=PLj-pbEqbjo6A7edIf1EWfhZ4prfYPJpTq) - Zaprogramuj Życie
 * [Kurs Java od podstaw (2024)](https://www.youtube.com/playlist?list=PLp9WLfHXxbccTjbdEqf79zE5eJ9n6aaPW) - Jak nauczyć się programowania
 * [Kurs JavaFX od podstaw](https://www.youtube.com/playlist?list=PLpzwMkmxJDUwQuQR7Rezut5UE_8UGDxkU)

--- a/courses/free-courses-pl.md
+++ b/courses/free-courses-pl.md
@@ -80,6 +80,7 @@
 * [Kurs Java od podstaw (2023)](https://www.youtube.com/playlist?list=PLj-pbEqbjo6A7edIf1EWfhZ4prfYPJpTq) - Zaprogramuj Życie
 * [Kurs Java od podstaw (2024)](https://www.youtube.com/playlist?list=PLp9WLfHXxbccTjbdEqf79zE5eJ9n6aaPW) - Jak nauczyć się programowania
 * [Kurs JavaFX od podstaw](https://www.youtube.com/playlist?list=PLpzwMkmxJDUwQuQR7Rezut5UE_8UGDxkU)
+* [Kurs Java](https://kursjava.com) - Przemysław Kruglej (2019-2023)
 * [Kurs programowania Java](https://www.youtube.com/playlist?list=PLED70A92187B1406A)
 * [Kurs programowania w Javie od podstaw](https://programovanie.pl) - Michał Łoza (email address *requested*, not required)
 


### PR DESCRIPTION
## Summary

This PR replaces an outdated PDF-based Java resource with a newer free Java course.

## Changes

### Removed
- [Język Java](http://www.dz5.pl/ti/java/java_skladnia.pdf) - Jacek Rumiński (PDF)

### Added
- [Kurs Java](https://kursjava.com) - Przemysław Kruglej

## Notes

The previous resource was outdated, and the new one provides a more current free Java learning option.