### PR TITLE
Add DevRoadmaps to interactive tutorials (Language Agnostic)

### DIFF
--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -313,6 +313,7 @@
 * [Introduction to the Coding Interview Prep Algorithms](https://www.freecodecamp.org/learn/coding-interview-prep/algorithms) (freeCodeCamp)
 * [Python Tutor](http://pythontutor.com) - Python, Java, JavaScript, TypeScript, Ruby, C, C++
 * [The Fullstack Tutorial for GraphQL](https://www.howtographql.com)
+* [DevRoadmaps](https://rudra496.github.io/devroadmaps) - Rudra Sarker (HTML, PWA)
 
 
 #### Operating systems

--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -310,10 +310,10 @@
 
 * [CodeCombat](http://codecombat.com) - Python, JavaScript, CoffeeScript, Clojure, Lua, Io
 * [Codility](https://codility.com/programmers/)
+* [DevRoadmaps](https://rudra496.github.io/devroadmaps) - Rudra Sarker (HTML, PWA)
 * [Introduction to the Coding Interview Prep Algorithms](https://www.freecodecamp.org/learn/coding-interview-prep/algorithms) (freeCodeCamp)
 * [Python Tutor](http://pythontutor.com) - Python, Java, JavaScript, TypeScript, Ruby, C, C++
 * [The Fullstack Tutorial for GraphQL](https://www.howtographql.com)
-* [DevRoadmaps](https://rudra496.github.io/devroadmaps) - Rudra Sarker (HTML, PWA)
 
 
 #### Operating systems


### PR DESCRIPTION
Added DevRoadmaps — a free interactive developer roadmap platform with 20 career paths, 870+ topics, and 1,880+ free resources.

- **URL:** https://rudra496.github.io/devroadmaps
- **Format:** Interactive HTML, PWA (works offline)
- **License:** MIT
- **Source:** https://github.com/rudra496/devroadmaps
- **No signup required**

Covers frontend, backend, fullstack, DevOps, AI/ML, cybersecurity, blockchain, game dev, mobile, and 11 more career paths.