### PR TITLE
fix: reorder C and C++ in index to match content order

### DIFF
--- a/courses/free-courses-de.md
+++ b/courses/free-courses-de.md
@@ -2,8 +2,8 @@
 
 * [Ansible](#ansible)
 * [Bash](#bash)
-* [C](#c)
 * [C++](#cpp)
+* [C](#c)
 * [Haskell](#haskell)
 * [HTML and CSS](#html-and-css)
     * [Bootstrap](#bootstrap)


### PR DESCRIPTION

#HSFDPMUW

## What does this PR do?
Improve repo

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
Reordered C and C++ in the index to match the actual content order. 
The index listed C before C++, but the content sections had C++ before C.

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
