### PR TITLE
Add Libre.academy to Interactive Tutorials (Language Agnostic)

### DIFF
--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -311,6 +311,7 @@
 * [CodeCombat](http://codecombat.com) - Python, JavaScript, CoffeeScript, Clojure, Lua, Io
 * [Codility](https://codility.com/programmers/)
 * [Introduction to the Coding Interview Prep Algorithms](https://www.freecodecamp.org/learn/coding-interview-prep/algorithms) (freeCodeCamp)
+* [Libre.academy](https://libre.academy) - Python, JavaScript, TypeScript, Rust, Go, Java, C, C++, SQL
 * [Python Tutor](http://pythontutor.com) - Python, Java, JavaScript, TypeScript, Ruby, C, C++
 * [The Fullstack Tutorial for GraphQL](https://www.howtographql.com)
 


### PR DESCRIPTION
Adds [Libre.academy](https://libre.academy), a free, open-source (MIT) interactive coding platform: you read prose, write code in an in-browser editor, and hidden tests grade your work — across 90+ courses in 26 languages. No account, no install, and no paywall to start.

Placed alphabetically in the **Language Agnostic** section of the interactive tutorials list, following the existing `* [Name](url) - Languages` format. Source: https://github.com/InfamousVague/Libre.academy