### PR TITLE
Add Libre Academy to Language Agnostic interactive tutorials

### DIFF
--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -311,6 +311,7 @@
 * [CodeCombat](http://codecombat.com) - Python, JavaScript, CoffeeScript, Clojure, Lua, Io
 * [Codility](https://codility.com/programmers/)
 * [Introduction to the Coding Interview Prep Algorithms](https://www.freecodecamp.org/learn/coding-interview-prep/algorithms) (freeCodeCamp)
+* [Libre Academy](https://libre.academy) - Rust, Python, JavaScript, TypeScript, Go, Zig, and 20+ more
 * [Python Tutor](http://pythontutor.com) - Python, Java, JavaScript, TypeScript, Ruby, C, C++
 * [The Fullstack Tutorial for GraphQL](https://www.howtographql.com)
 


### PR DESCRIPTION
Adds [Libre Academy](https://libre.academy) to **More → Free Interactive Programming Resources → Language Agnostic**, placed alphabetically.

Libre Academy is a free, open, interactive learn-to-code platform: learners write real code in the browser (or a free desktop app) across 90+ courses spanning 26 languages, graded instantly by hidden test suites rather than multiple-choice quizzes. No paywall, and no account is required to start — the same niche as the existing CodeCombat / Python Tutor entries already in this section.

- **Free:** yes — no paywall, no sign-up required to begin.
- **Interactive:** yes — executes the learner's own code with immediate feedback.
- **Languages:** Rust, Python, JavaScript, TypeScript, Go, Zig, and 20+ more.
- Placed in alphabetical order within the Language Agnostic section.