### PR TITLE
Remove unsafe Chinese JavaScript resource

### DIFF
--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -487,7 +487,6 @@
 * [学用 JavaScript 设计模式](http://www.oschina.net/translate/learning-javascript-design-patterns) - 开源中国
 * [Airbnb JavaScript 规范](https://github.com/adamlu/javascript-style-guide)
 * [ECMAScript 6 入门](http://es6.ruanyifeng.com) - 阮一峰
-* [Google JavaScript 代码风格指南](https://web.archive.org/web/20200415002735/bq69.com/blog/articles/script/868/google-javascript-style-guide.html) *( :card_file_box: archived)*
 * [javascript 的 12 个怪癖](https://github.com/justjavac/12-javascript-quirks)
 * [JavaScript 教程 - 廖雪峰的官方网站](https://www.liaoxuefeng.com/wiki/1022910821149312)
 * [《JavaScript 模式》](https://github.com/jayli/javascript-patterns) (《JavaScript patterns》译本)


### PR DESCRIPTION
## What does this PR do?
Remove resource(s)

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please do not make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
Removes the Chinese JavaScript entry for Google JavaScript 代码风格指南 that points to an archived bq69.com page.

### Why is this valuable (or not)?
Issue #13248 reports that this resource appears in Chinese JavaScript search results and leads users toward a domain flagged as unsafe. Removing it prevents readers from following a potentially unsafe resource.

### How do we know it is really free?
Not applicable; this PR removes a resource.

### For book lists, is it a book? For course lists, is it a course? etc.
Not applicable; this PR removes a resource from the Chinese book list.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Validation
- git diff --check
- npx -y free-programming-books-lint books

Closes #13248