### PR TITLE
Add game design AI book (Chinese list, Simplified & Traditional editions)

### DIFF
--- a/books/free-programming-books-zh.md
+++ b/books/free-programming-books-zh.md
@@ -198,6 +198,8 @@
 * [南瓜书PumpkinBook](https://datawhalechina.github.io/pumpkin-book) - Datawhale
 * [深度学习500问](https://github.com/scutan90/DeepLearning-500-questions) - scutan90
 * [神经网络与深度学习](https://nndl.github.io) - 邱锡鹏
+* [游戏策划实务即用的 AI · Claude Code 活用法](https://github.com/eremes81/game-design-ai-practice-zh-hans) - 李旼洙
+* [遊戲策劃實務即用的 AI · Claude Code 活用法](https://github.com/eremes81/game-design-ai-practice-zh-hant) - 李旼洙
 
 
 ### 软件开发方法


### PR DESCRIPTION
Adds a free, CC BY-NC-SA 4.0 book to the 人工智能 (AI) section — a practitioner's field manual on using AI (Claude Code) in game design production. Both the Simplified and Traditional Chinese editions are AI-assisted translations from the Korean original (disclosed in each repo's README), reviewed by the author.

The English/Korean/Japanese/Thai/Indonesian editions of the same book are already merged (#13339–#13343). Placed under 人工智能 because this list has no Game Development section.

* [游戏策划实务即用的 AI · Claude Code 活用法](https://github.com/eremes81/game-design-ai-practice-zh-hans) - 李旼洙
* [遊戲策劃實務即用的 AI · Claude Code 活用法](https://github.com/eremes81/game-design-ai-practice-zh-hant) - 李旼洙