### PR TITLE
Add TheCodeForge to DevOps courses

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -706,7 +706,7 @@
 * [DevOps Full Course](https://www.youtube.com/watch?v=lpk7VpGqkKw) - Simplilearn
 * [DevOps Tutorial for Beginners](https://www.youtube.com/playlist?list=PLVHgQku8Z934suC9LSE6vaAKjOH_MfRbE) - Intellipaat
 * [DevOps Tutorial for Beginners \| Learn DevOps in 7 Hours - Full Course \| DevOps Training \| Edureka](https://www.youtube.com/watch?v=hQcFE0RD0cQ) - Edureka
-* [TheCodeForge DevOps Tutorials](https://thecodeforge.io/category/devops/) - 300+ free production-grade DevOps tutorials covering Docker, Kubernetes, CI/CD, Jenkins, Terraform, Ansible, and more with real incident stories.
+* [TheCodeForge DevOps Tutorials](https://thecodeforge.io/devops/) - 300+ free production-grade DevOps tutorials covering Docker, Kubernetes, CI/CD, Jenkins, Terraform, Ansible, and more with real incident stories.
 
 
 #### Ansible

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -702,11 +702,11 @@
 * [Complete DevOps Zero to Hero Course](https://www.youtube.com/playlist?list=PLdpzxOOAlwvIKMhk8WhzN1pYoJ1YU8Csa) - Abhishek Veeramalla
 * [DevOps Bootcamp](https://www.youtube.com/playlist?list=PL9gnSGHSqcnoqBXdMwUTRod4Gi3eac2Ak) - Kunal Kushwaha
 * [DevOps Courses](https://www.youtube.com/playlist?list=PLWKjhJtqVAbkFiqHnNaxpOPhh9tSWMXIF) - FreeCodeCamp
-* [TheCodeForge DevOps Tutorials](https://thecodeforge.io/category/devops/) - 300+ free production-grade DevOps tutorials covering Docker, Kubernetes, CI/CD, Jenkins, Terraform, Ansible, and more with real incident stories.
 * [DevOps from Zero to Hero: Build and Deploy a Production API](https://www.youtube.com/watch?v=H5FAxTBuNM8) - Adrian Hajdin (JavaScript Mastery)
 * [DevOps Full Course](https://www.youtube.com/watch?v=lpk7VpGqkKw) - Simplilearn
 * [DevOps Tutorial for Beginners](https://www.youtube.com/playlist?list=PLVHgQku8Z934suC9LSE6vaAKjOH_MfRbE) - Intellipaat
 * [DevOps Tutorial for Beginners \| Learn DevOps in 7 Hours - Full Course \| DevOps Training \| Edureka](https://www.youtube.com/watch?v=hQcFE0RD0cQ) - Edureka
+* [TheCodeForge DevOps Tutorials](https://thecodeforge.io/category/devops/) - 300+ free production-grade DevOps tutorials covering Docker, Kubernetes, CI/CD, Jenkins, Terraform, Ansible, and more with real incident stories.
 
 
 #### Ansible

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -706,7 +706,7 @@
 * [DevOps Full Course](https://www.youtube.com/watch?v=lpk7VpGqkKw) - Simplilearn
 * [DevOps Tutorial for Beginners](https://www.youtube.com/playlist?list=PLVHgQku8Z934suC9LSE6vaAKjOH_MfRbE) - Intellipaat
 * [DevOps Tutorial for Beginners \| Learn DevOps in 7 Hours - Full Course \| DevOps Training \| Edureka](https://www.youtube.com/watch?v=hQcFE0RD0cQ) - Edureka
-* [TheCodeForge DevOps Tutorials](https://thecodeforge.io/devops/) - 300+ free production-grade DevOps tutorials covering Docker, Kubernetes, CI/CD, Jenkins, Terraform, Ansible, and more with real incident stories.
+* [TheCodeForge DevOps Tutorials](https://thecodeforge.io/devops/) - TheCodeForge
 
 
 #### Ansible

--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -702,6 +702,7 @@
 * [Complete DevOps Zero to Hero Course](https://www.youtube.com/playlist?list=PLdpzxOOAlwvIKMhk8WhzN1pYoJ1YU8Csa) - Abhishek Veeramalla
 * [DevOps Bootcamp](https://www.youtube.com/playlist?list=PL9gnSGHSqcnoqBXdMwUTRod4Gi3eac2Ak) - Kunal Kushwaha
 * [DevOps Courses](https://www.youtube.com/playlist?list=PLWKjhJtqVAbkFiqHnNaxpOPhh9tSWMXIF) - FreeCodeCamp
+* [TheCodeForge DevOps Tutorials](https://thecodeforge.io/category/devops/) - 300+ free production-grade DevOps tutorials covering Docker, Kubernetes, CI/CD, Jenkins, Terraform, Ansible, and more with real incident stories.
 * [DevOps from Zero to Hero: Build and Deploy a Production API](https://www.youtube.com/watch?v=H5FAxTBuNM8) - Adrian Hajdin (JavaScript Mastery)
 * [DevOps Full Course](https://www.youtube.com/watch?v=lpk7VpGqkKw) - Simplilearn
 * [DevOps Tutorial for Beginners](https://www.youtube.com/playlist?list=PLVHgQku8Z934suC9LSE6vaAKjOH_MfRbE) - Intellipaat


### PR DESCRIPTION
Add [TheCodeForge DevOps Tutorials](https://thecodeforge.io/devops/) — 300+ free DevOps tutorials covering Docker, Kubernetes, CI/CD, Jenkins, Terraform, Ansible, and more with real-world incident stories.