### PR TITLE
docs: clarify issue instructions wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The [Free Ebook Foundation](https://ebookfoundation.org) now administers the rep
 
 ## How To Contribute
 
-Please read [CONTRIBUTING](docs/CONTRIBUTING.md). If you're new to GitHub, [welcome](docs/HOWTO.md)! Remember to abide by our adapted from ![Contributor Covenant 1.3](https://img.shields.io/badge/Contributor%20Covenant-1.3-4baaaa.svg) [Code of Conduct](docs/CODE_OF_CONDUCT.md) too ([translations](#translations) also available).
+Please read [CONTRIBUTING](docs/CONTRIBUTING.md). If you're new to GitHub, [welcome](docs/HOWTO.md)! Remember to abide by our [Contributor Covenant 1.3](docs/CODE_OF_CONDUCT.md) Code of Conduct too ([translations](#translations) also available).
 
 Click on these badges to see how you might be able to help:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,7 +15,7 @@ By contributing, you agree to respect the [Code of Conduct](CODE_OF_CONDUCT.md) 
 
 1. "A link to easily download a book" is not always a link to a *free* book. Please only contribute free content. Make sure it's free. We do not accept links to pages that *require* working email addresses to obtain books, but we welcome listings that request them.
 
-2. You don't have to know Git: if you found something of interest which is *not already in this repo*, please open an [Issue](https://github.com/EbookFoundation/free-programming-books/issues) with your links propositions.
+2. You don't have to know Git: if you found something of interest which is *not already in this repo*, please open an [Issue](https://github.com/EbookFoundation/free-programming-books/issues) with your link suggestions.
     - If you know Git, please Fork the repo and send Pull Requests (PR).
 
 3. We have 6 kinds of lists. Choose the right one:


### PR DESCRIPTION
Small docs-only fix in CONTRIBUTING: replaced awkward phrasing 'links propositions' with 'link suggestions' for clarity.