### PR TITLE
Add Java Standard (Wikibooks) to German list

### DIFF
--- a/books/free-programming-books-de.md
+++ b/books/free-programming-books-de.md
@@ -140,6 +140,7 @@
 * [Java 7 Mehr als eine Insel](http://openbook.rheinwerk-verlag.de/java7) - Christian Ullenboom (Online)
 * [Java ist auch eine Insel](http://openbook.rheinwerk-verlag.de/javainsel) - Christian Ullenboom (Online)
 * [Java SE 8 Standard-Bibliothek](http://openbook.rheinwerk-verlag.de/java8) - Christian Ullenboom (Online)
+* [Java Standard](https://de.wikibooks.org/wiki/Java_Standard) - Wikibooks (HTML)
 * [Java Tutorial - Java lernen leicht gemacht](https://web.archive.org/web/20230805211306/https://java-tutorial.org/index.php) - Björn und Britta Petri *( :card_file_box: archived)*
 * [Nebenläufige Programmierung mit Java](https://www.assets.dpunkt.de/openbooks/Hettel_Nebenlaeufige%20Programmierung%20mit%20Java_Broschuere.pdf) - Jörg Hettel und Manh Tien Tran (PDF)
 * [Programmieren Java: Aufbau](http://www.highscore.de/java/aufbau) - Boris Schäling (HTML)


### PR DESCRIPTION

## What does this PR do?
Add resource(s) 

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
Adds *Java Standard*, a free German-language programming book hosted on Wikibooks, to the Java section of `books/free-programming-books-de.md`.

### Why is this valuable (or not)?
It is a complete, community-maintained German Java book covering fundamentals through advanced topics (OOP, java.lang/util, threads, GUI, networking, databases). It fills a gap, as the Java section had no Wikibooks entry yet, and parallels the existing Wikibooks entries for C and VHDL.

### How do we know it's really free?
It is hosted on Wikibooks and licensed under Creative Commons (CC BY-SA). It is freely readable online without registration or payment and even offers a print/collection version.

### For book lists, is it a book? For course lists, is it a course? etc.
Yes — it is a structured book in the Wikibooks "Regal Programmierung" (programming shelf), with chapters, a print version, and a collection.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!

#HSFDPMUW