### PR TITLE
Fix broken markdown link for bookdown format list

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -1608,7 +1608,7 @@ Books on general-purpose programming that don't focus on a specific language are
 
 ### Markdown
 
-* [bookdown: Authoring Books and Technical Documents with R Markdown](https://bookdown.org) - Yihui Xie (HTML) [(PDF, EPUB, MOBI)] (https://bookdown.org/yihui/bookdown/)
+* [bookdown: Authoring Books and Technical Documents with R Markdown](https://bookdown.org) - Yihui Xie (HTML) [(PDF, EPUB, MOBI)](https://bookdown.org/yihui/bookdown/)
 * [Learn Markdown](https://www.gitbook.com/book/gitbookio/markdown/details) - Sammy P., Aaron O. (PDF) (EPUB) (MOBI)
 
 


### PR DESCRIPTION
## Summary
- Fixes a broken markdown link in `books/free-programming-books-langs.md` for "bookdown: Authoring Books and Technical Documents with R Markdown"
- A space between `]` and `(` (`[(PDF, EPUB, MOBI)] (https://bookdown.org/yihui/bookdown/)`) prevented the link from rendering as a clickable link — it displayed as plain text instead
- Removed the stray space so it renders correctly as `[(PDF, EPUB, MOBI)](https://bookdown.org/yihui/bookdown/)`

## Test plan
- [x] Verified the target URL (https://bookdown.org/yihui/bookdown/) is reachable
- [x] Confirmed this is the only occurrence of this line in the file
- [x] Change is a single-line markdown syntax fix with no content changes