### PR TITLE
Add aiOlaOla free AI coding & AI agents courses (en, zh, ja, ko, es)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -289,6 +289,7 @@
 #### Generative AI
 
 * [AI Agents for Beginners](https://www.youtube.com/playlist?list=PLlrxD0HtieHgKcRjd5-8DT9TbwdlDO-OC) - Microsoft Developer
+* [Build AI Agents, from zero](https://aiolaola.com/en/course/agents) - aiOlaOla
 * [CS236: Deep Generative Models](https://www.youtube.com/playlist?list=PLoROMvodv4rPOWA-omMM6STXaWW4FvJT8) - Stefano Ermon (Stanford Online)
 * [Deep Generative Models](https://www.youtube.com/playlist?list=PL2UML_KCiC0UPzjW9BjO-IW6dqliu9O4B) - Volodymyr Kuleshov
 * [Foundation Models and Generative AI](https://ocw.mit.edu/courses/6-s087-foundation-models-and-generative-ai-january-iap-2024) - Rickard Gabrielsson (MIT OpenCourseWare)
@@ -300,6 +301,7 @@
 * [Getting Started with NVIDIA Tools for Generative AI in Digital Health](https://learn.nvidia.com/courses/course-detail?course_id=course-v1:DLI+S-HX-03+V1) - NVIDIA Deep Learning Institute
 * [Intro to Generative AI](https://www.codecademy.com/learn/intro-to-generative-ai) - Codecademy
 * [LangChain & Vector Databases in Production](https://learn.activeloop.ai/courses/langchain) - Activeloop *(account required)*
+* [Learn AI Coding, from zero](https://aiolaola.com/en/course) - aiOlaOla
 * [LangChain for LLM Application Development](https://www.deeplearning.ai/short-courses/langchain-for-llm-application-development) - Harrison Chase, Andrew Ng (DeepLearning.AI)
 * [Retrieval Augmented Generation for Production with LangChain & LlamaIndex](https://learn.activeloop.ai/courses/rag) - Activeloop *(account required)*
 * [Training & Fine-Tuning LLMs for Production](https://learn.activeloop.ai/courses/llms) - Activeloop *(account required)*

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -116,6 +116,8 @@
 
 ### Inteligencia Artificial
 
+* [Aprende a programar con IA, desde cero (180 lecciones)](https://aiolaola.com/es/course) - aiOlaOla
+* [Construye agentes de IA, desde cero (40 lecciones)](https://aiolaola.com/es/course/agents) - aiOlaOla
 * [Generative AI para Principiantes .NET - Un Curso](https://github.com/microsoft/Generative-AI-for-beginners-dotnet/tree/main/translations/es) - Microsoft (GitHub)
 
 

--- a/courses/free-courses-ja.md
+++ b/courses/free-courses-ja.md
@@ -17,4 +17,6 @@
 
 ### 人工知能
 
+* [AIエージェントをゼロから作る(全40レッスン)](https://aiolaola.com/ja/course/agents) - aiOlaOla
+* [AIプログラミングをゼロから学ぶ(全180レッスン)](https://aiolaola.com/ja/course) - aiOlaOla
 * [初心者向け 生成 AI .NET コース](https://github.com/microsoft/Generative-AI-for-beginners-dotnet/tree/main/translations/ja) - Microsoft (GitHub)

--- a/courses/free-courses-ko.md
+++ b/courses/free-courses-ko.md
@@ -104,6 +104,8 @@
 
 ### Generative AI
 
+* [AI 에이전트 만들기 (전체 40강)](https://aiolaola.com/ko/course/agents) - aiOlaOla
+* [AI 코딩 배우기 (전체 180강)](https://aiolaola.com/ko/course) - aiOlaOla
 * [초보자를 위한 Generative AI .NET - 강좌](https://github.com/microsoft/Generative-AI-for-beginners-dotnet/tree/main/translations/ko) - Microsoft (GitHub)
 
 

--- a/courses/free-courses-zh.md
+++ b/courses/free-courses-zh.md
@@ -15,6 +15,8 @@
 
 ### AI
 
+* [从零学会 AI 编程](https://aiolaola.com/course) - aiOlaOla
+* [从零构建 AI 智能体](https://aiolaola.com/course/ai-agent) - aiOlaOla
 * [初学者的生成式 AI .NET - 一门课程](https://github.com/microsoft/Generative-AI-for-beginners-dotnet/tree/main/translations/zh) - Microsoft (GitHub)
 * [动手学深度学习](https://zh.d2l.ai/index.html) - d2lzh
 * [机器学习速成课程](https://developers.google.com/machine-learning/crash-course/prereqs-and-prework?hl=zh-cn) - 谷歌出品


### PR DESCRIPTION
Adds two free, hands-on courses to the AI/Generative AI course sections in five language lists:

- **Learn AI Coding, from zero** — 180 lessons taking complete beginners from "what is a file" to shipping real projects with AI pair programmers.
- **Build AI Agents, from zero** — 40 lessons: ReAct, tool calling, memory & RAG, MCP, multi-agent, evaluation, shipping.

Both are originally written in Chinese (the team also maintains agency-agents-zh / superpowers-zh on GitHub) and fully translated into English, 日本語, Español and 한국어 — each list links its own language version.

All lessons are free of charge. The first chapter of each course is open without any account; later chapters ask for a free sign-in. Entries follow the existing format and alphabetical order; no tracking parameters.