### PR TITLE
Add free Spanish programming courses (Certmundo)

### DIFF
--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -59,6 +59,7 @@
 * [Fundamentos de las bases de datos (2011)](https://ocw.ua.es/es/ingenieria-y-arquitectura/fundamentos-de-las-bases-de-datos-2011.html)
 * [Manual práctico de SQL](https://www.lawebdelprogramador.com/cursos/archivos/ManualPracticoSQL.pdf) - Álvaro E. García (PDF)
 * [Principios de SQL](https://programadorwebvalencia.com/cursos/sql/introducci%C3%B3n/) - Andros Fenollosa (Programador Web Valencia)
+* [SQL y Bases de Datos: Curso Gratis desde Cero](https://certmundo.com/es-mx/curso/sql-y-bases-de-datos) - Certmundo
 
 
 ### Ciencias de la Computación
@@ -86,6 +87,7 @@
 ### Control de Versiones
 
 * [Curso de Git y Github desde cero para principiantes](https://www.youtube.com/watch?v=3GymExBkKjE) - Brias Moure "MoureDev"
+* [Git y Control de Versiones](https://certmundo.com/es-mx/curso/git-y-control-de-versiones) - Certmundo
 * [Git & GitHub](https://www.pildorasinformaticas.es/course/curso-de-git-github) - Juan Díaz (Píldoras Informáticas)
 * [Git & GitHub](https://www.youtube.com/playlist?list=PLPl81lqbj-4I8i-x2b5_MG58tZfgKmJls) - Ignacio Gutiérrez, BlueWeb
 
@@ -174,6 +176,7 @@
 * [Curso de JavaScript Gratis](https://codigofacilito.com/cursos/javascript) - Código Facilito
 * [Curso de PHP/MySQL](https://www.youtube.com/playlist?list=PLU8oAlHdN5BkinrODGXToK9oPAlnJxmW_) - Juan Díaz (Píldoras informáticas)
 * [Curso de Python](https://www.youtube.com/playlist?list=PLNdFk2_brsRcrVO-C915sjog0WclPgxHb) - Brias Moure "MoureDev"
+* [Curso de Python desde Cero para Principiantes](https://certmundo.com/es-mx/curso/python-basico) - Certmundo
 * [Curso de Python gratis y con certificación](https://edutin.com/curso-de-python-4276) - Edutin
 * [Curso Gratis de Programación Básica](https://platzi.com/clases/programacion-basica/) - Platzi
 * [Curso Gratis de Ruby](https://codigofacilito.com/cursos/ruby-2) - Código Facilito
@@ -227,6 +230,7 @@
 * [FullStack JavaScript Bootcamp \| JavaScript, React.js, GraphQL, Node.js, TypeScript y +](https://www.youtube.com/playlist?list=PLV8x_i1fqBw0Kn_fBIZTa3wS_VZAqddX7) - Miguel Ángel Durán «midudev»
 * [HTML 5](https://www.pildorasinformaticas.es/course/html-5) - Juan Díaz (Píldoras Informáticas)
 * [Introducción a HTML & CSS](https://www.aulaclic.es/html/index.htm) (HTML)
+* [JavaScript para Principiantes](https://certmundo.com/es-mx/curso/javascript-para-principiantes) - Certmundo
 * [PHP MySql Módulo 1](https://www.pildorasinformaticas.es/course/php-mysql) - Juan Díaz (Píldoras Informáticas)
 * [PHP MySql Módulo 2](https://www.pildorasinformaticas.es/course/php-mysql/php-mysql-modulo-2) - Juan Díaz (Píldoras Informáticas)
 * [Tecnologías Web (2010)](https://ocw.ua.es/es/ingenieria-y-arquitectura/tecnologias-web-2010.html)

--- a/courses/free-courses-es.md
+++ b/courses/free-courses-es.md
@@ -87,9 +87,9 @@
 ### Control de Versiones
 
 * [Curso de Git y Github desde cero para principiantes](https://www.youtube.com/watch?v=3GymExBkKjE) - Brias Moure "MoureDev"
-* [Git y Control de Versiones](https://certmundo.com/es-mx/curso/git-y-control-de-versiones) - Certmundo
 * [Git & GitHub](https://www.pildorasinformaticas.es/course/curso-de-git-github) - Juan Díaz (Píldoras Informáticas)
 * [Git & GitHub](https://www.youtube.com/playlist?list=PLPl81lqbj-4I8i-x2b5_MG58tZfgKmJls) - Ignacio Gutiérrez, BlueWeb
+* [Git y Control de Versiones](https://certmundo.com/es-mx/curso/git-y-control-de-versiones) - Certmundo
 
 
 ### Flujos de Trabajo


### PR DESCRIPTION
Adding four free Spanish-language programming courses from Certmundo (Python, JavaScript, SQL, Git) — each free to study with an optional certificate, same format as the existing Edutin/Platzi entries.