### PR TITLE
Add The Agentic AI Hub to Artificial Intelligence (books by subject)

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -165,6 +165,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [Paradigms of Artificial Intelligence Programming: Case Studies in Common Lisp](https://github.com/norvig/paip-lisp) - Peter Norvig (Git repo)
 * [Probabilistic Programming & Bayesian Methods for Hackers](https://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/) - Cam Davidson-Pilon (HTML, Jupyter Notebook)
 * [Stanford CS224N: Natural Language Processing with Deep Learning](https://www.youtube.com/playlist?list=PLoROMvodv4rOSH4v6133s9LFPRHjEmbmJ) - Christopher Manning (Stanford Online)
+* [The Agentic AI Hub](https://daily.dev/agentic-ai-hub/) - daily.dev (HTML) (CC BY)
 * [The History of Artificial Intelligence](https://courses.cs.washington.edu/courses/csep590/06au/projects/history-ai.pdf) - Chris Smith, Brian McGuire, Ting Huang, Gary Yang (PDF)
 * [The Math Behind Artificial Intelligence: A Guide to AI Foundations](https://www.freecodecamp.org/news/the-math-behind-artificial-intelligence-book) - Tiago Monteiro (HTML)
 * [The Quest for Artificial Intelligence: A History of Ideas and Achievements](https://ai.stanford.edu/~nilsson/QAI/qai.pdf) - Nils J. Nilsson (PDF)


### PR DESCRIPTION
## What does this PR do?
Add resource(s)

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] Is this a revision of a previously submitted PR? No, this is a first submission.

## For resources
### Description
Adds one entry to `books/free-programming-books-subjects.md` under Artificial Intelligence:

`* [The Agentic AI Hub](https://daily.dev/agentic-ai-hub/) - daily.dev (HTML) (CC BY)`

The Agentic AI Hub is a handbook for software engineers covering LLM foundations through building autonomous agents. It has 45 chapters in 7 sections: Foundations, Models and Labs, Tools and Agents, Engineering Stack, Techniques and Adoption, Ecosystem, and Appendices. It also includes suggested reading orders and a 6-level scale (L0 to L5) for describing how far a team has gone with AI tooling. It is at version 1.1.

Disclosure: I work at daily.dev, which publishes it.

### Why is this valuable (or not)?
The Artificial Intelligence section covers classical AI and machine learning well, but has less on LLM and agent engineering. This fills that gap in one place rather than across scattered articles.

### How do we know it's really free?
The whole handbook reads in the browser with no account, no paywall, and no email gate. The bottom of the landing page states that it is published under CC BY 4.0 and links to the license text.

### For book lists, is it a book? For course lists, is it a course? etc.
A book, for these reasons:

- It calls itself a handbook and a reference, not a course.
- It has a fixed table of contents, is self-contained, and every chapter is hosted on the same site. The URL is not an index pointing to third-party material.
- It has no lectures, exercises, tests, or graded work, which is the Books vs. Courses test in CONTRIBUTING.
- It is prose. Printing it out would not lose anything, so it is not an interactive tutorial.

The format note is `(HTML)`. No PDF or EPUB is offered, so there is only one link.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates. No entry for daily.dev exists anywhere in the repo.
- [x] Include author(s) and platform where appropriate. Credited to daily.dev as publisher; there is no single named author.
- [x] Put lists in alphabetical order, correct spacing. Placed between `Stanford CS224N` and `The History of Artificial Intelligence`. Ran `fpb-lint books` locally with no warnings.
- [x] Add needed indications (PDF, access notes, under construction). `(HTML) (CC BY)`. No access note is needed and it is not under construction.
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
