### PR TITLE
ci: add names to changed-files output steps for readability

### DIFF
--- a/.github/workflows/check-urls.yml
+++ b/.github/workflows/check-urls.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       fetch-depth: ${{ steps.set-params.outputs.fetch-depth }}
       files:       ${{ steps.set-files.outputs.files }}
-      files-len:   ${{ steps.set-files-len.outputs.files-len }}
+      files-len:   ${{ steps.set-files.outputs.files-len }}
       matrix:      ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Determine workflow params
@@ -46,16 +46,14 @@ jobs:
         with:
           separator: " "
           json: true
-      - name: Join changed files for output
+      # Keep a single step id so job outputs (files / files-len) stay unchanged.
+      - name: Set changed-files outputs
         id: set-files
         run: |
           echo "${{ steps.changed-files.outputs.all_changed_files }}"  \
             | jq --raw-output '. | join(" ")'  \
             | sed -e 's/^/files=/'  \
             >> $GITHUB_OUTPUT
-      - name: Count changed files
-        id: set-files-len
-        run: |
           echo "${{ steps.changed-files.outputs.all_changed_files }}"  \
             | jq --raw-output '. | length'  \
             | sed -e 's/^/files-len=/'  \

--- a/.github/workflows/check-urls.yml
+++ b/.github/workflows/check-urls.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       fetch-depth: ${{ steps.set-params.outputs.fetch-depth }}
       files:       ${{ steps.set-files.outputs.files }}
-      files-len:   ${{ steps.set-files.outputs.files-len }}
+      files-len:   ${{ steps.set-files-len.outputs.files-len }}
       matrix:      ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Determine workflow params
@@ -46,17 +46,22 @@ jobs:
         with:
           separator: " "
           json: true
-      - id: set-files
+      - name: Join changed files for output
+        id: set-files
         run: |
           echo "${{ steps.changed-files.outputs.all_changed_files }}"  \
             | jq --raw-output '. | join(" ")'  \
             | sed -e 's/^/files=/'  \
             >> $GITHUB_OUTPUT
+      - name: Count changed files
+        id: set-files-len
+        run: |
           echo "${{ steps.changed-files.outputs.all_changed_files }}"  \
             | jq --raw-output '. | length'  \
             | sed -e 's/^/files-len=/'  \
             >> $GITHUB_OUTPUT
-      - id: set-matrix
+      - name: Build check-urls matrix
+        id: set-matrix
         run: |
           echo "{\"file\":${{ steps.changed-files.outputs.all_changed_files }}}"  \
             | sed -e 's/^/matrix=/'  \


### PR DESCRIPTION
## Problem

In `.github/workflows/check-urls.yml`, the `set-files` step had no `name:`, so a long `run` block shows up as a generic label in the Actions UI.

## Changes

Semantics are unchanged: same `id: set-files`, same `GITHUB_OUTPUT` keys (`files`, `files-len`), and the same job-level output wiring.

- Add `name: Set changed-files outputs` to the existing `set-files` step
- Add `name: Build check-urls matrix` to the existing `set-matrix` step

## Test plan
- [ ] Confirm job outputs still resolve `steps.set-files.outputs.files` and `steps.set-files.outputs.files-len`
- [ ] Open a PR that touches a `.md` / `.yml` file and confirm `check-urls` still runs
