### PR TITLE
Add The Claude Code Book to Artificial Intelligence

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -166,6 +166,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [Probabilistic Programming & Bayesian Methods for Hackers](https://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/) - Cam Davidson-Pilon (HTML, Jupyter Notebook)
 * [Stanford CS224N: Natural Language Processing with Deep Learning](https://www.youtube.com/playlist?list=PLoROMvodv4rOSH4v6133s9LFPRHjEmbmJ) - Christopher Manning (Stanford Online)
 * [The Agentic AI Hub](https://daily.dev/agentic-ai-hub/) - daily.dev (HTML) (CC BY)
+* [The Claude Code Book](https://github.com/bartek-890/the-claude-code-book) - Bartłomiej Krupa (Markdown) (CC BY-NC-ND)
 * [The History of Artificial Intelligence](https://courses.cs.washington.edu/courses/csep590/06au/projects/history-ai.pdf) - Chris Smith, Brian McGuire, Ting Huang, Gary Yang (PDF)
 * [The Math Behind Artificial Intelligence: A Guide to AI Foundations](https://www.freecodecamp.org/news/the-math-behind-artificial-intelligence-book) - Tiago Monteiro (HTML)
 * [The Quest for Artificial Intelligence: A History of Ideas and Achievements](https://ai.stanford.edu/~nilsson/QAI/qai.pdf) - Nils J. Nilsson (PDF)


### PR DESCRIPTION
Adds *The Claude Code Book* to **Artificial Intelligence** in `books/free-programming-books-subjects.md`.

```
* [The Claude Code Book](https://github.com/bartek-890/the-claude-code-book) - Bartłomiej Krupa (Markdown) (CC BY-NC-ND)
```

**Why it is free:** the linked repository *is* the book — 31 chapters and 6 appendices, one Markdown file each, readable in full on GitHub with no sign-up, no paywall, and no download gate. It is published under [CC BY-NC-ND 4.0](https://github.com/bartek-890/the-claude-code-book/blob/main/LICENSE) (LICENSE file in the repo root; GitHub's detector does not recognise the NC-ND variant, so the repo badge reads "NOASSERTION" — the licence text itself is the standard Creative Commons one). A typeset PDF of the same text is sold separately, which is why I linked the free Markdown edition rather than the author's book page — the repo is the version that meets this list's "free" bar.

**Subject fit:** it covers Claude Code as an agent harness — what enters a model's context window, how permissions and hooks gate an autonomous run, and what token cost responds to. Nearest neighbours already in the section are *The Agentic AI Hub* and *How to Build Optimal AI Agents That Actually Work*.

**Formatting:**
- Alphabetical position: between *The Agentic AI Hub* and *The History of Artificial Intelligence*.
- Format note `(Markdown)`, licence note `(CC BY-NC-ND)` after the format, normalised without a version number.
- Precedent for a GitHub-hosted book on this exact licence in the same file: *Introduction to Autonomous Robots* and *Mastering Bitcoin*.
- `free-programming-books-lint` run locally against `books/` — exits 0.

Disclosure: I am the author, and this PR was prepared with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)