### PR TITLE
Remove Riptutorials landing page entry

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -82,7 +82,6 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [O'Reilly's Open Books Project](https://www.oreilly.com/openbook/)
 * [Papers we love](https://github.com/papers-we-love/papers-we-love)
 * [Red Gate Books](https://www.red-gate.com/hub/books/)
-* [Rip Tutorials](https://riptutorial.com/ebook)
 * [Stef's Free Online Smalltalk Books](http://stephane.ducasse.free.fr/FreeBooks/)
 * [TechBeamers.com](https://www.techbeamers.com)
 * [TechBooksForFree.com](https://www.techbooksforfree.com)


### PR DESCRIPTION
## What does this PR do?

- [x] Remove resource(s)
- [x] Improve repo

## Summary

Addresses [issue #6153](https://github.com/EbookFoundation/free-programming-books/issues/6153) by removing the remaining Riptutorials HTML landing-page entry from the subject index.

The issue discussion distinguishes the ad-heavy landing page from the direct PDF resources. This change removes only:

- https://riptutorial.com/ebook

All direct https://riptutorial.com/Download/*.pdf entries remain unchanged.

## Validation

- [x] Read the repository contributing guidelines.
- [x] Confirmed no open competing PR for the Riptutorials cleanup.
- [x] Ran npx --yes free-programming-books-lint books.
- [x] Ran git diff --check.
- [x] Confirmed the diff contains one deletion in books/free-programming-books-subjects.md.

No new links were introduced.