### PR TITLE
Add AIMarket School (free AI agent-economy clip lessons)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -261,6 +261,7 @@
 * [AI Courses](https://software.intel.com/content/www/us/en/develop/topics/ai/training/courses.html) - Intel Corporation
 * [AI Fundamentals](https://www.udacity.com/course/ai-fundamentals--ud099) - Microsoft Azure (Udacity)
 * [AI Python for Beginners](https://www.deeplearning.ai/short-courses/ai-python-for-beginners/) - Andrew Ng (DeepLearning.ai)
+* [AIMarket School](https://edu.modelmarket.dev) - Aleksandr Artamokhov (HTML) (MIT)
 * [Aml-2018 Ambient Intelligence](https://www.youtube.com/playlist?list=PLqRTLlwsxDL8fUcY2Y54sITILyJcTySpC) - Fulvio Corno, Luigi De Russis, Alberto Monge Roffarello @ Politecnico di Torino
 * [Artificial Intelligence on Google Cloud Platform](https://www.youtube.com/playlist?list=PL3N9eeOlCrP6Nhv4UFp67IsQ_TVDpXqXK) - Srivatsan Srinivasan @ AIEngineering
 * [Artificial Intelligence Search Methods For Problem Solving](https://www.youtube.com/playlist?list=PLbMVogVj5nJSFZoiF6RDqyz_m6Srjx_MY) - nptelhrd


### PR DESCRIPTION
## What

Adds **[AIMarket School](https://edu.modelmarket.dev)** under **Artificial Intelligence** in `courses/free-courses-en.md`.

## Why free / why a course

- Always free, no signup/email wall for the portal lessons
- 10 structured clip lessons with Try-it demos + Colab notebooks (not a blog post / single video)
- MIT-licensed source: https://github.com/alexar76/aimarket-school
- Locales also available at `/ru/`, `/es/`, `/fr/`, `/zh/` on the same site (listing EN catalog entry first)

## Notes for reviewers

- Title taken from the product name on the portal
- Author: Aleksandr Artamokhov (alexar76)
- Format note: `(HTML) (MIT)`
- Alphabetized after *AI Python for Beginners*, before *Aml-2018 Ambient Intelligence*