### PR TITLE
Add AIMarket Courses (10 free AI agent-economy academies)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -125,6 +125,7 @@
 ### 0 - MOOC
 
 * [AI School](https://lillytechsystems.com/ai-school/)
+* [AIMarket Courses](https://alexar76.github.io/aimarket-courses/) - Aleksandr Artamokhov (HTML) (MIT)
 * [CheatGrid](https://www.cheatgrid.com/roadmaps)
 * [class central](https://www.classcentral.com)
 * [Codecademy](https://www.codecademy.com)


### PR DESCRIPTION
## What

Adds **[AIMarket Courses](https://alexar76.github.io/aimarket-courses/)** under **Artificial Intelligence** in `courses/free-courses-en.md`.

## Why free / why a course

- Always free portal — 10 structured Python academies (labs, Colab, docs, certificates), not a single blog post
- MIT-licensed monorepo: https://github.com/alexar76/aimarket-courses
- Live ecosystem labs (oracles, Hub/SDK, MCP security, agent economy, AI-Factory, …)
- Locales EN / RU / ES on the course sites (EN catalog entry)

## Notes for reviewers

- Companion listing to open PR #13393 ([AIMarket School](https://edu.modelmarket.dev) — shorter clip on-ramp); this entry is the full academy track
- Title = product name on the portal
- Author: Aleksandr Artamokhov (alexar76)
- Format: `(HTML) (MIT)`
- Alphabetized after *AI Python for Beginners*, before *Aml-2018 Ambient Intelligence* (and before *AIMarket School* if both land)