### PR TITLE
Remove dead Armenian Python resource link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ This project lists books and other resources grouped by genres:
 #### Other Languages
 
 + [Arabic / al arabiya / العربية](books/free-programming-books-ar.md)
-+ [Armenian / Հայերեն](books/free-programming-books-hy.md)
 + [Azerbaijani / Азәрбајҹан дили / آذربايجانجا ديلي](books/free-programming-books-az.md)
 + [Bengali / বাংলা](books/free-programming-books-bn.md)
 + [Bulgarian / български](books/free-programming-books-bg.md)

--- a/books/free-programming-books-hy.md
+++ b/books/free-programming-books-hy.md
@@ -1,8 +1,0 @@
-### Index
-
-* [Python](#python)
-
-
-### Python
-
-* [Python Ուղեցույց](https://armath.am/uploads/E-learning/Robotics/RaspberryPi/python.pdf) - Վարդուհի Անդրեասյան (PDF)


### PR DESCRIPTION
## Summary

- remove the only entry from `books/free-programming-books-hy.md` because its PDF URL redirects to the publisher homepage instead of a downloadable resource
- remove the now-empty index and section so the list remains valid for the repository linter

Fixes #13336.

## Validation

- `npx --yes free-programming-books-lint books casts courses more`
- `git diff --check`
- `curl -IL` confirmed the listed URL redirects to `https://armath.am/`

## AI disclosure

AI assistance was used to investigate the issue, implement the patch, and run validation. The contributor is responsible for understanding and reviewing every changed line.