### PR TITLE
Add Build Your Own Physics to free courses (en + zh)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1593,6 +1593,7 @@
 * [Automate with Python - Full course for Beginners](https://www.youtube.com/watch?v=PXMJ6FS7llk) - FreeCodeCamp
 * [Bento Python Learning Track](https://bento.io/topic/python) (Bento)
 * [Berkeley's Structure and Interpretation of Computer Programs](https://cs61a.org)
+* [Build Your Own Physics](https://github.com/Zensoro/build-your-own-physics) - Learn physics by recreating 12 simulations from scratch (projectile motion to a solar system), bilingual
 * [Codesdope](https://www.codesdope.com/python-introduction)
 * [Complete Python Playlist](https://www.youtube.com/playlist?list=PLZoTAELRMXVNUL99R4bDlVYsncUNvwUBB) - Krish Naik
 * [CS50's Introduction to Programming Using Python](https://cs50.harvard.edu/python/) - David J. Malan (Harvard OpenCourseWare and edX)

--- a/courses/free-courses-zh.md
+++ b/courses/free-courses-zh.md
@@ -39,6 +39,6 @@
 
 ### Python
 
-* [Build Your Own Physics](https://github.com/Zensoro/build-your-own-physics) - 从零重建物理：12 个 Python 模拟项目，双语（中文/English）
-
 * [最新Python编程教程19天从入门到精通](https://www.youtube.com/playlist?list=PLVyDH2ns1F75k1hvD2apA0DwI3XMiSDqp) - 知知识改变命运
+
+* [Build Your Own Physics](https://github.com/Zensoro/build-your-own-physics) - 从零重建物理：12 个 Python 模拟项目，双语（中文/English）

--- a/courses/free-courses-zh.md
+++ b/courses/free-courses-zh.md
@@ -39,4 +39,6 @@
 
 ### Python
 
+* [Build Your Own Physics](https://github.com/Zensoro/build-your-own-physics) - 从零重建物理：12 个 Python 模拟项目，双语（中文/English）
+
 * [最新Python编程教程19天从入门到精通](https://www.youtube.com/playlist?list=PLVyDH2ns1F75k1hvD2apA0DwI3XMiSDqp) - 知知识改变命运


### PR DESCRIPTION
Adds Build Your Own Physics to the free courses lists (English and Chinese Python sections).

[Build Your Own Physics](https://github.com/Zensoro/build-your-own-physics) is a free, MIT-licensed, bilingual (中文/English) curriculum of 12 Python projects where learners recreate physics simulations from scratch: projectile motion, pendulum, orbital mechanics, N-body gravity, waves, a Carnot heat engine, a chaotic double pendulum, fluid dynamics (lattice Boltzmann), electromagnetism (FDTD), special relativity, quantum tunneling, and a full solar system. Each project ships a SPEC, a starter scaffold with TODOs, a verified reference solution, and CI auto-grading for all 12 challenges.

It is completely free with no signup or email gate, so it qualifies for the courses list. Both entries are placed in alphabetical order within the existing "Python" sections.