### PR TITLE
Add MIT's The Missing Semester of Your CS Education (Computer Science courses)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -532,6 +532,7 @@
 * [MIT's Introduction to Computer Science and Programming](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-00sc-introduction-to-computer-science-and-programming-spring-2011/) - John Guttag (MIT OpenCourseWare)
 * [MIT's Introduction to Computer Science and Programming in Python](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016/) - Ana Bell, Eric Grimson, John Guttag (MIT OpenCourseWare)
 * [MIT's Mathematics for Computer Science](https://ocw.mit.edu/courses/6-042j-mathematics-for-computer-science-fall-2010/)
+* [The Missing Semester of Your CS Education](https://missing.csail.mit.edu) - Anish Athalye, Jon Gjengset, Jose Javier Gonzalez Ortiz (MIT)
 
 
 ### Cryptography


### PR DESCRIPTION
Adds one course to `courses/free-courses-en.md` under **Computer Science**.

```
* [The Missing Semester of Your CS Education](https://missing.csail.mit.edu) - Anish Athalye, Jon Gjengset, Jose Javier Gonzalez Ortiz (MIT)
```

MIT CSAIL course covering the tooling a CS degree usually skips - shell, scripting, editors, version control, debugging, and profiling. Full video lectures and written notes are on the public site with no signup or paywall.

**Checks done before submitting**

- Not already listed - searched all of `books/`, `courses/`, and `more/` for the title
- URL returns HTTP 200
- Licensed **CC BY-NC-SA**, stated in the site footer, so it is free in the sense this list requires - not a trial or a time-limited enrollment
- Creator names taken from the linked personal sites the course credits, not guessed
- Alphabetical placement: sorted literally under **T**, so it follows "MIT's Mathematics for Computer Science", consistent with how existing entries like "The Odin Project" and "The Python Tutorial" are placed
- `fpb-lint courses` passes locally. I also confirmed the linter is actually exercising this file by moving the entry to a wrong slot and watching it fail with an `alphabetize-lists` warning, then restoring it

One line added, nothing else changed.