### PR TITLE
Add ML Academy to free-courses-en.md (Machine Learning)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1440,6 +1440,7 @@
 * [Made with ML](https://madewithml.com) - Goku Mohandas (Applied ML · MLOps · Production)
 * [Mathematics for Machine Learning - Linear Algebra](https://www.youtube.com/playlist?list=PLiiljHvN6z1_o1ztXTKWPrShrMrBLo5P3) - Imperial College London, Dr David Dye, Dr Sam Cooper
 * [Mathematics for Machine Learning - Multivariate Calclus](https://www.youtube.com/playlist?list=PLiiljHvN6z193BBzS0Ln8NnqQmzimTW23) - Imperial College London, Dr David Dye, Dr Sam Cooper
+* [ML Academy](https://mltraining.org) - Cagri Temel
 * [Pattern Recognition and Machine Learning](https://www.microsoft.com/en-us/research/people/cmbishop/#!prml-book)
 * [Python Machine Learning and AI Mega Course - Learn 4 Different Areas of ML & AI](https://www.youtube.com/watch?v=WFr2WgN9_xE) - Tech With Tim (Tim Ruscica)
 * [Python Machine Learning Tutorials](https://www.youtube.com/playlist?list=PLzMcBGfZo4-mP7qA9cagf68V06sko5otr) - Tech With Tim (Tim Ruscica)


### PR DESCRIPTION
Adds one entry to `courses/free-courses-en.md` under **Machine Learning**, in alphabetical order between *Mathematics for Machine Learning - Multivariate Calclus* and *Pattern Recognition and Machine Learning*.

```
* [ML Academy](https://mltraining.org) - Cagri Temel
```

Free, no registration required to start, no advertising and nothing is sold on the site. 123 interactive lessons that run entirely in the browser: no videos and no installation. Every algorithm is implemented from scratch in JavaScript, and every numeric claim in the lesson text is recomputed by a test suite before publishing.

Checked against the contribution guidelines: alphabetical order respected, author given after a dash surrounded by single spaces, shortest form of the link used, and the resource is free and freely accessible.