### PR TITLE
Add Makine Öğrenmesi (Machine Learning) section to free-courses-tr.md

### DIFF
--- a/courses/free-courses-tr.md
+++ b/courses/free-courses-tr.md
@@ -7,6 +7,7 @@
 * [IDE and editors](#ide-and-editors)
 * [Java](#java)
 * [JavaScript](#javascript)
+* [Makine Öğrenmesi](#makine-ogrenmesi)
 * [Python](#python)
 * [React](#react)
 * [SQL](#sql)
@@ -66,6 +67,11 @@
 * [Java Dersleri ve Nesne Yönelimli Programlama](https://www.youtube.com/playlist?list=PLEcJSEQK_cD5KHgg9sXumeg659hAr2j4W) - Kodlama Vakti
 * [Java Programlama](https://www.youtube.com/playlist?list=PLIHume2cwmHctrHFHADb0slNyn95x2M4I) - Mustafa Murat Coşkun
 * [Yazılım Geliştirici Yetiştirme Kampı](https://www.youtube.com/playlist?list=PLqG356ExoxZUuVYKLuiQLnref7Y4ims87) - Engin Demiroğ
+
+
+### <a id='makine-ogrenmesi'></a>Makine Öğrenmesi
+
+* [ML Academy](https://mltraining.org/?lang=tr) - Cagri Temel
 
 
 ### Python


### PR DESCRIPTION
The Turkish course list has no machine learning section yet. This adds one, with a single entry.

```
### <a id='makine-ogrenmesi'></a>Makine Öğrenmesi

* [ML Academy](https://mltraining.org/?lang=tr) - Cagri Temel
```

Also adds `* [Makine Öğrenmesi](#makine-ogrenmesi)` to the Index, in alphabetical order between JavaScript and Python. The explicit anchor follows the pattern already used in this file for headings whose auto-generated anchor is awkward (`c-sharp`, `cpp`), since the heading contains the Turkish characters ğ and Ö.

About the resource: 123 interactive lessons that run entirely in the browser, in Turkish and English, with no videos, no installation, no registration required to start, no advertising and nothing sold on the site. Every algorithm is implemented from scratch in JavaScript and every numeric claim in the lesson text is recomputed by a test suite before publishing.

The `?lang=tr` parameter opens the site in Turkish directly, since the interface defaults to English.

Free machine learning material in Turkish is scarce, which is why I thought the section was worth opening.