### PR TITLE
Add four cheatsheets from dev-cheatsheets (Git, Docker, SQL, Bash)

### DIFF
--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -606,6 +606,7 @@
 
 * [Bash Cheatsheet - CheatSheet.Wtf](https://www.cheatsheet.wtf/bash) - smokingcuke (HTML)
 * [Bash Scripting cheatsheet](https://devhints.io/bash) Devhints (HTML)
+* [Bash Scripting Cheatsheet](https://github.com/mixseomin/dev-cheatsheets/blob/main/13-bash.md) - mixseomin (Markdown)
 * [Cron Cheatsheet](https://devhints.io/cron) - DevHints, Rico Santa Cruz (HTML)
 * [Fish Shell cheatsheet](https://devhints.io/fish-shell) - DevHints, Rico Santa Cruz (HTML)
 

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -206,6 +206,7 @@
 * [Docker Cheat Sheet : Complete Guide (2024)](https://www.geeksforgeeks.org/docker-cheat-sheet) - Geeksforgeeks (HTML)
 * [Docker Cheat Sheet (v1)](https://dockerlux.github.io/pdf/cheat-sheet.pdf) - Gildas Cuisinier, Docker Meetup Luxembourg (PDF)
 * [Docker Cheat Sheet (v2)](https://dockerlux.github.io/pdf/cheat-sheet-v2.pdf) - Gildas Cuisinier, Docker Meetup Luxembourg (PDF)
+* [Docker Cheatsheet](https://github.com/mixseomin/dev-cheatsheets/blob/main/02-docker.md) - mixseomin (Markdown)
 * [Docker Cheatsheet: Docker commands that developers should know](https://vishnuch.tech/docker-cheatsheet) - Vishnu Chilamakuru (HTML)
 * [Docker CLI \& Dockerfile Cheat Sheet](https://web.archive.org/web/20210909015922/https://design.jboss.org/redhatdeveloper/marketing/docker_cheatsheet/cheatsheet/images/docker_cheatsheet_r3v2.pdf) - Bachir Chihani, Rafael Benevides, Red Hat Developers (PDF) *( :card_file_box: archived)*
 * [Docker CLI cheatsheet](https://devhints.io/docker) - DevHints, Rico Santa Cruz (HTML)

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -632,6 +632,7 @@
 * [SQL Cheat Sheet](https://zerotomastery.io/cheatsheets/sql-cheat-sheet/) - ZeroToMastery (HTML)
 * [SQL Cheat Sheet](https://www.cheatgrid.com/databases/0293-sql-cheat-sheet) - CheatGrid (HTML)
 * [SQL Cheat Sheet by Tomi Mester](https://data36.com/wp-content/uploads/2018/12/sql-cheat-sheet-for-data-scientists-by-tomi-mester.pdf) - Tomi Mester (PDF)
+* [SQL Cheatsheet](https://github.com/mixseomin/dev-cheatsheets/blob/main/04-sql.md) - mixseomin (Markdown)
 
 
 ### TensorFlow

--- a/more/free-programming-cheatsheets.md
+++ b/more/free-programming-cheatsheets.md
@@ -255,6 +255,7 @@
 * [Git Cheat Sheet](https://web.archive.org/web/20230816231123/https://programmingwithmosh.com/wp-content/uploads/2020/09/Git-Cheat-Sheet.pdf) - Moshfegh Hamedani (PDF) *( :card_file_box: archived)*
 * [Git Cheat Sheet](https://www.geeksforgeeks.org/git/git-cheat-sheet) - Geeksforgeeks
 * [Git Cheat Sheet (id)](https://reyhanhamidi.medium.com/buku-saku-git-cheatsheet-git-bahasa-indonesia-3af42e42156e) - Reyhan Alhafizal (HTML)
+* [Git Cheatsheet](https://github.com/mixseomin/dev-cheatsheets/blob/main/01-git.md) - mixseomin (Markdown)
 * [Git ściąga (pl)](https://training.github.com/downloads/pl/github-git-cheat-sheet/) - GitHub (HTML)
 * [GitHub Actions Security Best Practices \[cheat sheet included\]](https://blog.gitguardian.com/github-actions-security-cheat-sheet/) - Thomas Segura, GitGuardian, C.J. May (HTML, PDF)
 * [GitHub Cheat Sheet](https://github.com/tiimgreen/github-cheat-sheet) - Tim Green (Markdown)


### PR DESCRIPTION
Adds four single-page reference sheets to the sections they belong to:

- Git → `01-git.md`
- Docker → `02-docker.md`
- SQL → `04-sql.md`
- Shell Scripting → `13-bash.md`

**Why these are free:** they are plain Markdown files in a public repo ([mixseomin/dev-cheatsheets](https://github.com/mixseomin/dev-cheatsheets)), readable directly on GitHub. No account, no email, no paywall, nothing gated.

**Disclosure:** I wrote them. The repo also offers an optional typeset PDF bundle for sale, but the Markdown linked here is the complete content, not a teaser or a sample - every command in the PDF is in the Markdown. If listing a resource whose author sells a typeset edition is outside what you want here, say so and I will close this.

Four atomic commits, one per addition. Sorted per the formatting guidelines and `free-programming-books-lint` passes on `more/`.