### PR TITLE
Add Robotics, from scratch (Robotics)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1742,6 +1742,7 @@
 * [Introduction to RTOS](https://www.youtube.com/playlist?list=PLEBQazB0HUyQ4hAPU1cJED6t3DU0h34bz) - Shawn Hymel, Digi-Key
 * [Leveraging ROS 2 and Hardware-in-the-Loop (HIL) in Isaac Sim](https://learn.nvidia.com/courses/course-detail?course_id=course-v1:DLI+S-OV-32+V1) - NVIDIA Deep Learning Institute
 * [Robotics 1](https://www.youtube.com/playlist?list=PLAQopGWlIcyaqDBW1zSKx7lHfVcOmWSWt) - A. De Luca
+* [Robotics, from scratch](https://robotics.biblio.guru) - Kiran Pachhai
 * [Software-in-the-Loop Testing for Robots With OpenUSD, Isaac Sim, and ROS](https://learn.nvidia.com/courses/course-detail?course_id=course-v1:DLI+S-OV-39+V1) - NVIDIA Deep Learning Institute
 * [Synthetic Data Generation for Perception Model Training in Isaac Sim](https://learn.nvidia.com/courses/course-detail?course_id=course-v1:DLI+S-OV-30+V1) - NVIDIA Deep Learning Institute
 * [Train Your First Robot in Isaac Lab](https://learn.nvidia.com/courses/course-detail?course_id=course-v1:DLI+S-OV-46+V1) - NVIDIA Deep Learning Institute


### PR DESCRIPTION
Adds one course to `courses/free-courses-en.md` under **Robotics**.

`* [Robotics, from scratch](https://robotics.biblio.guru) - Kiran Pachhai`

**Disclosure: I wrote this course.**

**Why it is free:** it is published as a static site with no paywall, no account, no email capture and no ads. Every lesson is readable directly at the link. The content is licensed CC BY-SA 4.0 and the code Apache 2.0, both stated in the site footer, and the runnable code is mirrored in a public repository at https://github.com/kpachhai/robotics-course-companion

**What it is:** 127 lessons taking a working software engineer with no robotics background from coordinate frames, rotations, transforms, kinematics and feedback control, through simulation and robot learning, to current foundation models. Every idea is implemented in plain Python by the reader. Each lesson carries exercises and self-check questions, so it fits the guide's definition of a course rather than a book.

**On placement:** the link is the author's own site, which the guidelines prefer over a third-party host, and the root domain carries no trailing slash. Inserted alphabetically between `Robotics 1` and `Software-in-the-Loop Testing for Robots...`. I ran `free-programming-books-lint` against `courses/` locally and it passes.

Happy to adjust the entry, the wording or the placement if you would prefer it differently.
