### PR TITLE
Remove dead links from Estonian and Finnish book lists

### DIFF
--- a/books/free-programming-books-et.md
+++ b/books/free-programming-books-et.md
@@ -17,8 +17,6 @@
 
 ### Algoritmid ja andmestruktuurid
 
-* [Algoritmid ja andmestruktuurid (2003, Kolmas, parandatud ja täiendatud trükk)](https://dspace.ut.ee/bitstream/handle/10062/16872/9985567676.pdf) - Jüri Kiho (PDF)
-
 
 ### C
 
@@ -26,8 +24,6 @@
 
 
 ### <a id="csharp"></a>C\#
-
-* [Microsoft Visual Studio Code ja C#](https://digiarhiiv.ut.ee/Ained/Doc/VFailid/CSharp_ja_VS.pdf) - Kalle Remm (PDF)
 
 
 ### Java
@@ -76,7 +72,6 @@
 
 ### SQL
 
-* [Andmebaaside alused](https://enos.itcollege.ee/~priit/1.%20Andmebaasid/1.%20Loengumaterjalid) - Priit Raspel (HTML)
 * [SQL päringute koostamine, analüüsimine  ja optimeerimine](https://comserv.cs.ut.ee/home/files/Ivanova_Informaatika_2017.pdf?study=ATILoputoo&reference=C408CC06DE4620A985CDF60C2678C97AE45017AB) - Anastassia Ivanova (PDF)
 
 

--- a/books/free-programming-books-et.md
+++ b/books/free-programming-books-et.md
@@ -1,8 +1,6 @@
 ### Index
 
-* [Algoritmid ja andmestruktuurid](#algoritmid-ja-andmestruktuurid)
 * [C](#c)
-* [C#](#csharp)
 * [Java](#java)
 * [JavaScript](#javascript)
     * [AngularJS](#angularjs)
@@ -15,15 +13,9 @@
 * [WebGL](#webgl)
 
 
-### Algoritmid ja andmestruktuurid
-
-
 ### C
 
 * [Programmeerimiskeel C](https://et.wikibooks.org/wiki/Programmeerimiskeel_C) - Wikiõpikud
-
-
-### <a id="csharp"></a>C\#
 
 
 ### Java

--- a/books/free-programming-books-fi.md
+++ b/books/free-programming-books-fi.md
@@ -15,7 +15,6 @@
 ### Kieliagnostinen
 
 * [Kisakoodarin käsikirja](https://www.cs.helsinki.fi/u/ahslaaks/kkkk.pdf) - Antti Laaksonen (PDF)
-* [Ohjelmoinnin peruskurssi Y1 - Opetusmoniste syksy 2017](https://grader.cs.hut.fi/static/y1/) - Kerttu Pollari-Malmi
 * [Ohjelmointi 2](https://jyx.jyu.fi/bitstream/handle/123456789/47415/978-951-39-4624-1.pdf) - Vesa Lappalainen, Santtu Viitanen (PDF)
 * [Olio-ohjelmointi käytännössä käyttäen hyväksi avointa tietoa, graafista käyttöliittymää ja karttaviitekehystä](http://urn.fi/URN:ISBN:978-952-265-756-5) - Antti Herala, Erno Vanhala, Uolevi Nikula (PDF)
 * [Oliosuuntautunut analyysi ja suunnittelu](https://jyx.jyu.fi/bitstream/handle/123456789/49293/oasmoniste.pdf) - Mauri Leppänen, Timo Käkölä, Miika Nurminen (PDF)


### PR DESCRIPTION
## What changed

Removed 4 dead links from the Estonian and Finnish free programming book lists. All URLs were verified with `curl` (HTTP status codes shown below).

### Estonian (`books/free-programming-books-et.md`)

| Entry | URL | HTTP Status |
|---|---|---|
| Algoritmid ja andmestruktuurid - Jüri Kiho (PDF) | https://dspace.ut.ee/bitstream/handle/10062/16872/9985567676.pdf | 000 (server not responding) |
| Microsoft Visual Studio Code ja C# - Kalle Remm (PDF) | https://digiarhiiv.ut.ee/Ained/Doc/VFailid/CSharp_ja_VS.pdf | 000 (server not responding) |
| Andmebaaside alused - Priit Raspel (HTML) | https://enos.itcollege.ee/~priit/1.%20Andmebaasid/1.%20Loengumaterjalid | 404 (not found) |

### Finnish (`books/free-programming-books-fi.md`)

| Entry | URL | HTTP Status |
|---|---|---|
| Ohjelmoinnin peruskurssi Y1 - Kerttu Pollari-Malmi | https://grader.cs.hut.fi/static/y1/ | 000 (server not responding) |

## Checklist

- [x] All links in the modified files were verified
- [x] Only entries with non-200 HTTP status codes were removed
- [x] No other changes were made