### PR TITLE
Add Sourcemap to Software Engineering courses

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1836,6 +1836,7 @@
 * [Selenium WebDriver Tutorial](https://www.youtube.com/playlist?list=PLL34mf651faPB-LyEP0-a7Avp_RHO0Lsm) - Software Testing Mentor
 * [Software Engineering](https://www.youtube.com/playlist?list=PLWPirh4EWFpG2b1L3CL-OAPYcM25jLjXH) - Tutorialspoint
 * [Software Engineering — The Easy Way](https://thetpmguy.github.io/software-engineering-the-easy-way/) - thetpmguy
+* [Sourcemap: Ninety Days to Read Any System](https://sourcemap.co) - Mihirsinh Chavda
 
 
 ### Solidity


### PR DESCRIPTION
Adds one entry to the Software Engineering section of `courses/free-courses-en.md`.

```
* [Sourcemap: Ninety Days to Read Any System](https://sourcemap.co) - Mihirsinh Chavda
```

**What it is:** a free 90-day curriculum covering software engineering, system design and AI engineering. Each day gives one objective, a prompt written for that day to use with an AI assistant, 3 to 6 hand-checked external resources, a small exercise, and active-recall questions.

**Against the guidelines:**

- **Free:** all 90 days are readable in full without an account and nothing is paywalled. An optional sign-in exists only to save progress across devices.
- **No email required:** no address is needed to read any of it.
- **Not a book:** it is a course, so it belongs under `courses/` rather than the book lists.
- **Formatting:** `* [Title](URL) - Author`, placed alphabetically after "Software Engineering — The Easy Way".
- **Language:** English, so `free-courses-en.md`.

**Disclosure:** I am the author. Happy to move it to a different section or drop it if it is not a fit.