### PR TITLE
Add KubeLearn to Kubernetes section (free-courses-en.md)

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1370,6 +1370,7 @@
 ### Kubernetes
 
 * [Fundamentals of Containers, Kubernetes, and Red Hat OpenShift](https://www.edx.org/course/fundamentals-of-containers-kubernetes-and-red-hat) - Zach Gutterman, Richard Allred (edX)
+* [KubeLearn](https://kube.alftech.space) - Aleksandr Fedorov
 * [Kubernetes 101 workshop - complete hands-on](https://www.youtube.com/live/PN3VqbZqmD8?feature=shared) - Kubesimplify
 * [Kubernetes Core Concepts](https://kube.academy/paths/kubernetes-core-concepts) - KubeAcademy (VMware)
 * [Kubernetes Course](https://www.youtube.com/watch?v=d6WC5n9G_sM) - Bogdan Stashchuk (FreeCoodeCamp)


### PR DESCRIPTION
## What does this PR do?
Add resource(s) — one link.

## IMPORTANT
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? No — first submission, nothing hidden or reopened.

## For resources
### Description
Adds one line to `courses/free-courses-en.md`, section `### Kubernetes`:

`* [KubeLearn](https://kube.alftech.space) - Aleksandr Fedorov`

Disclosure first: this is my own project. I built it and I maintain it.

KubeLearn is a browser-based Kubernetes course: short lessons, each followed by scored questions with explanations. 14 units, 81 lessons, 143 questions (82 multiple choice, 25 fill-in-the-blank, 22 true/false, 14 template completion).

Two limits stated plainly, because they change what this is:

- It is closer to a question bank than to a textbook. Lessons are short; there is no long-form teaching prose inside.
- There is no live cluster behind it. `kubectl` and manifest answers are graded by comparing the submitted answer to the expected one, not by executing anything.

### Why is this valuable (or not)?
All seven current entries in the Kubernetes section are video courses or vendor learning platforms. None of them lets a reader check whether anything stuck. That is the gap.

If you consider a question bank out of scope for a *courses* list, `more/free-programming-interactive-tutorials-en.md` may be the better home — happy to move it, just say which.

### How do we know it's really free?
No paid tier, no trial, no upgrade path, and no payment details are collected anywhere on the site. There is nothing to buy.

An account is required, but only so progress survives closing the tab — no content is behind it and there is no email confirmation step. Per CONTRIBUTING: "We do not accept links to pages that *require* working email addresses to obtain books, but we welcome listings that request them." And for course lists specifically, CONTRIBUTING notes that course platforms often need some sort of account.

### For book lists, is it a book? For course lists, is it a course? etc.
A course: units → lessons → questions, taken in order, in a courses file.

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates. No existing entry for KubeLearn or kube.alftech.space anywhere in the repo.
- [x] Include author(s) and platform where appropriate. Author: Aleksandr Fedorov. No platform — it is self-hosted, not on Coursera/edX/Udemy/etc.
- [x] Put lists in alphabetical order, correct spacing. Inserted between "Fundamentals of Containers, Kubernetes, and Red Hat OpenShift" and "Kubernetes 101 workshop - complete hands-on".
- [x] Add needed indications (PDF, access notes, under construction). None apply — not a PDF, not under construction.
- [x] Used an informative name for this pull request.

## Follow-up

- Will watch GitHub Actions on this PR and fix any reported warnings.
