### PR TITLE
Add AI Agent Evaluation (Artificial Intelligence)

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -144,6 +144,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 
 ### Artificial Intelligence
 
+* [AI Agent Evaluation](https://hallieren.github.io/ai-agent-evaluation/) - Hallie Ren (HTML) *( :construction: in process)* (CC BY-NC-SA)
 * [AI Safety for Fleshy Humans](https://aisafety.dance) - Nicky Case and Hack Club *( :construction: in process)* (CC BY-NC)
 * [Artificial Intelligence, 3rd Edition (1993)](https://courses.csail.mit.edu/6.034f/ai3/rest.pdf) - Patrick Henry Winston (PDF)
 * [Artificial Intelligence and the Future for Teaching and Learning](https://www2.ed.gov/documents/ai-report/ai-report.pdf) - Office of Educational Technology (PDF)


### PR DESCRIPTION
Adds **AI Agent Evaluation** to `books/free-programming-books-subjects.md`, section *Artificial Intelligence*.

- Free, open-source book on evaluating LLM agents (16 chapters; 1-8 published, remaining chapters landing roughly weekly), with per-chapter template packs and zero-dependency labs. Marked *( :construction: in process)* accordingly.
- Read online (HTML): https://hallieren.github.io/ai-agent-evaluation/
- Source repository: https://github.com/hallieren/ai-agent-evaluation
- License: CC BY-NC-SA 4.0 (prose), MIT (code)

Disclosure: I am the author. Entry follows the list's format (alphabetical order, `- Author (Format)`, license note) and I searched the list for duplicates; none found.