### PR TITLE
Add PracHub to problem sets

### DIFF
--- a/more/problem-sets-competitive-programming.md
+++ b/more/problem-sets-competitive-programming.md
@@ -146,6 +146,7 @@
 * [Pep Coding](https://www.pepcoding.com/resources)
 * [PKU Online Judge](http://poj.org)
 * [Ponder This!](https://www.research.ibm.com/haifa/ponderthis/index.shtml)
+* [PracHub](https://prachub.com/questions)
 * [Practice Python](https://www.practicepython.org)
 * [ProblemBook.NET](https://github.com/AndreyAkinshin/ProblemBook.NET)
 * [Project Euler](https://projecteuler.net)


### PR DESCRIPTION
Adds PracHub to the Problem Sets section as a free, browser-accessible source of candidate-reported coding interview questions that can be filtered by company, role, round, topic, and difficulty.

Founder disclosure: I am the founder of PracHub and am submitting this resource for independent maintainer review. Browsing the question bank does not require an email address. The change is one alphabetized link and does not remove or replace any existing resource.