### PR TITLE
Add Formacao Java Completa to pt_BR courses

### DIFF
--- a/courses/free-courses-pt_BR.md
+++ b/courses/free-courses-pt_BR.md
@@ -231,6 +231,7 @@
 * [Desenvolvimento Ágil com Padrões de Projeto](https://www.coursera.org/learn/desenvolvimento-agil-com-padroes-de-projeto) - Eduardo Guerra e Clovis Fernandes - ITA (Coursera)
 * [Estrutura de Dados com Java](https://loiane.training/curso/estrutura-de-dados) - Loiane Groner
 * [Estrutura de Dados com Java](https://www.youtube.com/playlist?list=PLCUSYmPGwekcXnzf6_UtgRM0OsOEGoiG_) - Matheus Leandro Ferreira
+* [Formação Java Completa - Do Zero à Arquitetura](https://formacao-java.vercel.app) - Thiago Jorge Pacheco
 * [Fundamentos do Java para Iniciantes](https://www.youtube.com/playlist?list=PLiFLtuN04BS2GSi8Q-haYkRy8KEv6Grvf) - Giuliana Bezerra
 * [Introdução à Interfaces Gráficas em Java com o NetBeans](https://www.udemy.com/introducao-a-interface-grafica-em-java-com-o-netbeans/) - Cezar Augusto Crummenauer (Udemy)
 * [Introdução a Programação Linguagem Java](https://www.youtube.com/playlist?list=PLCUSYmPGwekfDhQHllAkUZ30vOsxhVfhM) - Matheus Leandro Ferreira


### PR DESCRIPTION
Resolves #13367

### Changes proposed in this pull request
- Adds the free course **Formação Java Completa - Do Zero à Arquitetura** by Thiago Jorge Pacheco to `courses/free-courses-pt_BR.md` under `### Java`.
- Inserted in alphabetical order per repository guidelines.
- Content verified: 100% free, no mandatory email or paywall, active URL.

### Checklist
- [x] You have searched the existing issues and pull requests to ensure this is not a duplicate.
- [x] The resource is free and accessible without a required subscription/paywall.
- [x] Entries are kept in alphabetical order.
- [x] Lint checks pass locally.