### PR TITLE
Update AI Agent Evaluation: book complete, add EPUB

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -144,7 +144,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 
 ### Artificial Intelligence
 
-* [AI Agent Evaluation](https://hallieren.github.io/ai-agent-evaluation/) - Hallie Ren (HTML) *( :construction: in process)* (CC BY-NC-SA)
+* [AI Agent Evaluation](https://hallieren.github.io/ai-agent-evaluation/) - Hallie Ren (HTML, EPUB) (CC BY-NC-SA)
 * [AI Safety for Fleshy Humans](https://aisafety.dance) - Nicky Case and Hack Club *( :construction: in process)* (CC BY-NC)
 * [Artificial Intelligence, 3rd Edition (1993)](https://courses.csail.mit.edu/6.034f/ai3/rest.pdf) - Patrick Henry Winston (PDF)
 * [Artificial Intelligence and the Future for Teaching and Learning](https://www2.ed.gov/documents/ai-report/ai-report.pdf) - Office of Educational Technology (PDF)


### PR DESCRIPTION
Updates the **AI Agent Evaluation** entry in `books/free-programming-books-subjects.md`, section *Artificial Intelligence*.

- The book is now complete (16 chapters and Appendices A to E, tagged v1.0), so the `:construction: in process` marker is removed.
- An EPUB is now served from the same site, so the format marker becomes `(HTML, EPUB)`.
- Read online: https://hallieren.github.io/ai-agent-evaluation/
- EPUB: https://hallieren.github.io/ai-agent-evaluation/ai-agent-evaluation.epub
- License unchanged: CC BY-NC-SA 4.0 (prose), MIT (code)

Disclosure: I am the author. This is a follow-up to #13430.
