### PR TITLE
Add The Last Mile (Artificial Intelligence)

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -169,6 +169,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [The Agentic AI Hub](https://daily.dev/agentic-ai-hub/) - daily.dev (HTML) (CC BY)
 * [The Claude Code Book](https://github.com/bartek-890/the-claude-code-book) - Bartłomiej Krupa (Markdown) (CC BY-NC-ND)
 * [The History of Artificial Intelligence](https://courses.cs.washington.edu/courses/csep590/06au/projects/history-ai.pdf) - Chris Smith, Brian McGuire, Ting Huang, Gary Yang (PDF)
+* [The Last Mile](https://hallieren.github.io/the-last-mile/) - Hallie Ren (HTML, EPUB) (CC BY-NC-SA)
 * [The Math Behind Artificial Intelligence: A Guide to AI Foundations](https://www.freecodecamp.org/news/the-math-behind-artificial-intelligence-book) - Tiago Monteiro (HTML)
 * [The Quest for Artificial Intelligence: A History of Ideas and Achievements](https://ai.stanford.edu/~nilsson/QAI/qai.pdf) - Nils J. Nilsson (PDF)
 


### PR DESCRIPTION
Adds **The Last Mile** to `books/free-programming-books-subjects.md`, section *Artificial Intelligence*.

### Description
A free, open-source field guide to taking enterprise AI systems from demo to daily use: 27 chapters, 24 field templates, and 22 zero-dependency scripts, following one delivery cycle end to end.

### Why is this valuable
Most AI books cover models and prompts; this one covers the delivery side (data access, workflow, trust, ownership, adoption) that decides whether a system is used. Every chapter has a template and a paste-to-agent block.

### How do we know it's really free
Published by the author under CC BY-NC-SA 4.0 (prose) and MIT (code) at https://github.com/hallieren/the-last-mile, read online at https://hallieren.github.io/the-last-mile/, EPUB at https://hallieren.github.io/the-last-mile/the-last-mile.epub.

### Is it a book
Yes, a complete book with chapters, appendices, and an EPUB.

Disclosure: I am the author. Entry follows the list's format (alphabetical order under T, `- Author (Format)`, license note); I searched the list for duplicates and found none.


Replaces #13441, which was closed by mistake when the fork was deleted; the branch content is identical and the linter passed there.
