### PR TITLE
Add Research, Rewritten (Artificial Intelligence)

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -165,6 +165,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [On the Path to AI: Law’s prophecies and the conceptual foundations of the machine learning age](https://link.springer.com/book/10.1007/978-3-030-43582-0) - Thomas D. Grant, Damon J. Wischik (PDF, EPUB)
 * [Paradigms of Artificial Intelligence Programming: Case Studies in Common Lisp](https://github.com/norvig/paip-lisp) - Peter Norvig (Git repo)
 * [Probabilistic Programming & Bayesian Methods for Hackers](https://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/) - Cam Davidson-Pilon (HTML, Jupyter Notebook)
+* [Research, Rewritten](https://hallieren.github.io/research-rewritten/) - Hallie Ren (HTML, EPUB) (CC BY-NC-SA)
 * [Stanford CS224N: Natural Language Processing with Deep Learning](https://www.youtube.com/playlist?list=PLoROMvodv4rOSH4v6133s9LFPRHjEmbmJ) - Christopher Manning (Stanford Online)
 * [The Agentic AI Hub](https://daily.dev/agentic-ai-hub/) - daily.dev (HTML) (CC BY)
 * [The Claude Code Book](https://github.com/bartek-890/the-claude-code-book) - Bartłomiej Krupa (Markdown) (CC BY-NC-ND)


### PR DESCRIPTION
Adds **Research, Rewritten** to `books/free-programming-books-subjects.md`, section *Artificial Intelligence*.

### Description
A free, open-source book on using AI to produce knowledge you can trust: sixteen chapters plus a two-hour Start Here, prompts and templates for every chapter, and two rerunnable experiments with preregistrations, cost ledgers, red-team records, and raw results.

### Why is this valuable
It teaches engineers and researchers where to hand research work to AI, where to gate it themselves, and how to verify AI-produced conclusions. The book publishes the full verification record of its own experiments.

### How do we know it's really free
Published by the author under CC BY-NC-SA 4.0 (prose) and MIT (code) at https://github.com/hallieren/research-rewritten, read online at https://hallieren.github.io/research-rewritten/, EPUB at https://hallieren.github.io/research-rewritten/research-rewritten.epub.

### Is it a book
Yes, a complete book with chapters, appendices, and an EPUB.

Disclosure: I am the author. Entry follows the list's format (alphabetical order under R, `- Author (Format)`, license note); I searched the list for duplicates and found none.


Replaces #13442, which was closed by mistake when the fork was deleted; the branch content is identical and the linter passed there.
