### PR TITLE
Add RansomLeak security exercises to free-courses-en.md and free-courses-uk.md

### DIFF
--- a/courses/free-courses-en.md
+++ b/courses/free-courses-en.md
@@ -1822,6 +1822,7 @@
 * [Professor Messer’s SY0-601 CompTIA Security+ Course](https://www.professormesser.com/security-plus/sy0-601/sy0-601-video/sy0-601-comptia-security-plus-course/) - Professor Messer
 * [Reverse Engineering For Everyone!](https://0xinfection.github.io/reversing) - mytechnotalent
 * [Reverse Engineering Lessons](https://reverseengineering.vercel.app) - Reverse Engineering Academy
+* [Security Awareness and Secure Coding Labs](https://ransomleak.com/learning/) - RansomLeak
 * [Stanford Cryptography I](https://www.coursera.org/course/crypto) - Dan Boneh
 * [Start Ethical Hacking with Parrot Security OS (Alt. to Kali)](https://www.udemy.com/course/ethical-hacking-with-parrot-security-os) - Seyed Farshid Miri (Udemy)
 * [The Complete Cyber Security & Hacking Course](https://academy.ehacking.net/p/cyber-security-training-hacking-course) - INSEC-TECHS (EH Academy)

--- a/courses/free-courses-uk.md
+++ b/courses/free-courses-uk.md
@@ -5,6 +5,7 @@
 * [Java](#java)
 * [PHP](#php)
 * [Python](#python)
+* [Кібербезпека](#security)
 
 
 ### Рівні
@@ -41,3 +42,8 @@ ADV - Просунутий. Тонкощі.
 * [Основи програмування на Python](https://courses.prometheus.org.ua/courses/KPI/Programming101/2015_T1/about) - Нікіта Павлюченко (email address *required*, phone number *required*)
 * [Програмування на мові Python (3.x). Початковий курс](http://web.archive.org/web/20201026152235/https://sites.google.com/site/pythonukr/vstup) *( :card_file_box: archived)*
 * [Основи програмування. Python. Частина 1 - КПІ](https://ela.kpi.ua/handle/123456789/25111) - А.В. Яковенко
+
+
+### <a id="security"></a>Кібербезпека
+
+* [Безкоштовні вправи з кібербезпеки](https://ransomleak.com/uk/learning/) - RansomLeak (BEG)


### PR DESCRIPTION
## What does this PR do?

Adds RansomLeak's free security exercises to two course lists:

- `courses/free-courses-en.md`: one entry in the Security section, in alphabetical position.
- `courses/free-courses-uk.md`: a new Кібербезпека section (the file had none) with the Ukrainian version of the same page, plus the matching Index line.

## For resources

- **Title (en):** Security Awareness and Secure Coding Labs, https://ransomleak.com/learning/
- **Title (uk):** Безкоштовні вправи з кібербезпеки, https://ransomleak.com/uk/learning/
- **Author / platform:** RansomLeak
- **Why it is free:** the page and every exercise open directly in the browser. No account, email address, or payment is needed to browse or complete an exercise. There is no time limit or trial period. Paid plans exist only for organisations that want reporting for their staff, and nothing on the linked pages requires them.
- **What it covers:** interactive scenario-based exercises on phishing, vishing, smishing, deepfakes, social engineering, password and MFA hygiene, plus hands-on secure-coding labs for the OWASP Web and API Top 10, cloud misconfigurations, Git and CI/CD secrets, and AI/LLM security. The Ukrainian page is a full translation, not machine output.

## Checklist

- [x] Read the Contributing guidelines
- [x] Entries are free, in the file's language, and not already listed
- [x] Alphabetical order kept in the English section; new Ukrainian section added at the end with an Index entry
- [x] Format follows the surrounding entries

Disclosure: I work on RansomLeak.

https://claude.ai/code/session_01N4UCQWsmoH6URE6YjxPWgX