### PR TITLE
Add free AI foundations and RAG books by Addy

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -145,6 +145,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 ### Artificial Intelligence
 
 * [AI Agent Evaluation](https://hallieren.github.io/ai-agent-evaluation/) - Hallie Ren (HTML, EPUB) (CC BY-NC-SA)
+* [AI: From First Principles](https://www.thequery.in/books/ai-from-first-principles) - Addy (HTML, EPUB)
 * [AI Safety for Fleshy Humans](https://aisafety.dance) - Nicky Case and Hack Club *( :construction: in process)* (CC BY-NC)
 * [Artificial Intelligence, 3rd Edition (1993)](https://courses.csail.mit.edu/6.034f/ai3/rest.pdf) - Patrick Henry Winston (PDF)
 * [Artificial Intelligence and the Future for Teaching and Learning](https://www2.ed.gov/documents/ai-report/ai-report.pdf) - Office of Educational Technology (PDF)
@@ -165,6 +166,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [On the Path to AI: Law’s prophecies and the conceptual foundations of the machine learning age](https://link.springer.com/book/10.1007/978-3-030-43582-0) - Thomas D. Grant, Damon J. Wischik (PDF, EPUB)
 * [Paradigms of Artificial Intelligence Programming: Case Studies in Common Lisp](https://github.com/norvig/paip-lisp) - Peter Norvig (Git repo)
 * [Probabilistic Programming & Bayesian Methods for Hackers](https://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/) - Cam Davidson-Pilon (HTML, Jupyter Notebook)
+* [RAG + Knowledge Graph Master Course](https://www.thequery.in/books/rag-kg-master-course) - Addy (HTML, EPUB)
 * [Research, Rewritten](https://hallieren.github.io/research-rewritten/) - Hallie Ren (HTML, EPUB) (CC BY-NC-SA)
 * [Stanford CS224N: Natural Language Processing with Deep Learning](https://www.youtube.com/playlist?list=PLoROMvodv4rOSH4v6133s9LFPRHjEmbmJ) - Christopher Manning (Stanford Online)
 * [The Agentic AI Hub](https://daily.dev/agentic-ai-hub/) - daily.dev (HTML) (CC BY)


### PR DESCRIPTION
## What does this PR do?
Adds two free technical books to the Artificial Intelligence section.

## Disclosure
I maintain TheQuery and am submitting my own resources, published under the byline Addy.

## Description and value
AI: From First Principles is an 11-chapter book covering foundations, data, mathematics, ML, neural networks, transformers, and production systems. RAG + Knowledge Graph Master Course is a 16-chapter text covering retrieval, knowledge graphs, hybrid systems, projects, and assessments. Although the latter title uses “course”, it is a self-contained written book with a table of contents and an EPUB edition.

## How do we know they are free?
Both authoritative landing pages and all chapters are readable without payment, registration, or an email address. EPUB downloads are also available without registration.

## Checklist
- [x] Read the contribution guidelines and code of conduct.
- [x] Checked the book lists for duplicate URLs and titles.
- [x] Included the published author and available formats.
- [x] Added entries in alphabetical order with existing spacing.
- [x] Used an informative PR title.

This is a new submission, not a replacement for a previous PR. The diff adds only two entries. Maintainers retain the editorial decision on inclusion.