### PR TITLE
Fix Japanese Ruby source-code guide URL

### DIFF
--- a/books/free-programming-books-ja.md
+++ b/books/free-programming-books-ja.md
@@ -622,7 +622,7 @@
 
 * [Ruby on Rails ガイド](https://railsguides.jp) - Rails community, `trl:` 八田 昌三, `trl:` 安川 要平
 * [Ruby on Rails チュートリアル](https://railstutorial.jp) - Michael Hartl, `trl:` 八田 昌三, `trl:` 安川 要平
-* [Ruby ソースコード完全解説](https://i.loveruby.net/ja/rhg/book) - 青木峰郎
+* [Ruby ソースコード完全解説](https://i.loveruby.net/ja/rhg/book/) - 青木峰郎
 * [Ruby リファレンスマニュアル](https://www.ruby-lang.org/ja/documentation) - まつもとゆきひろ
 * [Ruby 基礎文法最速マスター](https://route477.net/d/?date=20100125) - yhara
 * [TremaでOpenFlowプログラミング](https://yasuhito.github.io/trema-book) - 高宮安仁, 鈴木一哉, 松井暢之, 村木暢哉, 山崎泰宏


### PR DESCRIPTION
## What does this PR do?
Improve repo

## IMPORTANT
- [x] Read the contributing guidelines.
- [x] This is not a revision of a previously submitted PR; it addresses the unassigned issue #13451.

## For resources
Not applicable. This keeps the existing resource and its metadata unchanged.

## Checklist:
- [x] This repairs an existing entry; no resource was added.
- [x] Author and platform details are unchanged.
- [x] Existing ordering and spacing are unchanged.
- [x] No resource indications need changing.
- [x] Used an informative name for this pull request.

## Validation
- Confirmed the original URL returns HTTP 404 and the corrected URL returns HTTP 200.
- Ran free-programming-books-lint against books, casts, courses, and more.

Closes #13451

## Follow-up
- I will monitor GitHub Actions and address any reported warnings.