### PR TITLE
Fix Probability and Statistics EBook link

### DIFF
--- a/books/free-programming-books-subjects.md
+++ b/books/free-programming-books-subjects.md
@@ -571,7 +571,7 @@ Books that cover a specific programming language can be found in the [BY PROGRAM
 * [Plane Geometry (1913)](http://djm.cc/library/Plane_Geometry_Wentworth_Smith_edited.pdf) - George Wentworth, David Eugene Smith (PDF)
 * [Planes and Spherical Trigonometry (1915)](http://djm.cc/library/Plane_Spherical_Trigonometry_Wentworth_Smith_edited_2.pdf) - George Wentworth, David Eugene Smith (PDF)
 * [Probability and Statistics Cookbook](http://statistics.zone)
-* [Probability and Statistics EBook](http://wiki.stat.ucla.edu/socr/index.php/Probability_and_statistics_EBook)
+* [Probability and Statistics EBook](https://wiki.socr.umich.edu/index.php/Probability_and_statistics_EBook)
 * [Probability: Lectures and Labs](https://www.markhuberdatascience.org/probability-textbook) - Mark Huber
 * [Proofs and Types](https://www.paultaylor.eu/stable/Proofs+Types) - Jean-Yves Girard, Yves Lafont, Paul Taylor
 * [Recreations in Math](http://djm.cc/library/Recreations_in_Mathematics_Licks_edited.pdf) - H. E. Licks (PDF)


### PR DESCRIPTION
## What does this PR do?

Improve repo

Fixes the broken `Probability and Statistics EBook` link by updating the old UCLA SOCR URL to the current University of Michigan SOCR wiki location.

Closes #13454

## IMPORTANT

- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) to the branch you previously submitted.

## For resources

### Description

This does not add a new resource. It preserves the existing `Probability and Statistics EBook` entry and updates only its URL.

### Why is this valuable (or not)?

The existing UCLA URL is no longer valid. The replacement points to the current SOCR-hosted version of the same Probability and Statistics EBook.

### How do we know it's really free?

This is an existing resource already accepted by the repository. The current SOCR EBook remains freely and openly accessible, and its copyright page states that it is distributed under the Creative Commons Attribution license.

### For book lists, is it a book? For course lists, is it a course? etc.

It is the same existing electronic book; only its URL has changed.

## Checklist:

- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
